### PR TITLE
Fix shutdown and race-condition in consumer-group example

### DIFF
--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -54,7 +54,7 @@ func main() {
 
 	version, err := sarama.ParseKafkaVersion(version)
 	if err != nil {
-		panic(err)
+		log.Panicf("Error parsing Kafka version: %v", err)
 	}
 
 	/**
@@ -78,7 +78,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	client, err := sarama.NewConsumerGroup(strings.Split(brokers, ","), group, config)
 	if err != nil {
-		panic(err)
+		log.Panicf("Error creating consumer group client: %v", err)
 	}
 
 	wg := &sync.WaitGroup{}
@@ -86,9 +86,8 @@ func main() {
 		wg.Add(1)
 		defer wg.Done()
 		for {
-			err := client.Consume(ctx, strings.Split(topics, ","), &consumer)
-			if err != nil {
-				panic(err)
+			if err := client.Consume(ctx, strings.Split(topics, ","), &consumer); err != nil {
+				log.Panicf("Error from consumer: %v", err)
 			}
 			// check if context was cancelled, signaling that the consumer should stop
 			if ctx.Err() != nil {
@@ -112,7 +111,7 @@ func main() {
 	cancel()
 	wg.Wait()
 	if err = client.Close(); err != nil {
-		panic(err)
+		log.Panicf("Error closing client: %v", err)
 	}
 }
 

--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/Shopify/sarama"
@@ -70,21 +71,30 @@ func main() {
 	/**
 	 * Setup a new Sarama consumer group
 	 */
-	consumer := Consumer{}
+	consumer := Consumer{
+		ready: make(chan bool, 0),
+	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
 	client, err := sarama.NewConsumerGroup(strings.Split(brokers, ","), group, config)
 	if err != nil {
 		panic(err)
 	}
 
+	wg := &sync.WaitGroup{}
 	go func() {
+		wg.Add(1)
+		defer wg.Done()
 		for {
-			consumer.ready = make(chan bool, 0)
 			err := client.Consume(ctx, strings.Split(topics, ","), &consumer)
 			if err != nil {
 				panic(err)
 			}
+			// check if context was cancelled, signaling that the consumer should stop
+			if ctx.Err() != nil {
+				return
+			}
+			consumer.ready = make(chan bool, 0)
 		}
 	}()
 
@@ -93,11 +103,15 @@ func main() {
 
 	sigterm := make(chan os.Signal, 1)
 	signal.Notify(sigterm, syscall.SIGINT, syscall.SIGTERM)
-
-	<-sigterm // Await a sigterm signal before safely closing the consumer
-
-	err = client.Close()
-	if err != nil {
+	select {
+	case <-ctx.Done():
+		log.Println("terminating: context cancelled")
+	case <-sigterm:
+		log.Println("terminating: via signal")
+	}
+	cancel()
+	wg.Wait()
+	if err = client.Close(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
The Kafka consumer groups example has two issues:
1. A race condition causes the `ready` channel to be reassigned before the consumer starts, leading to the main go-routine reading from a different `ready` channel than the one that is closed in the consumer `Setup` function.
1. The consumer go-routine doesn't exit cleanly when a termination signal is sent. But the termination signal handling wasn't configured because of the aforementioned race condition, so this wouldn't have worked regardless.

This PR fixes both problems by reassigning the `ready` channel variable only after a rebalance, and by using a cancellable context and waitgroup to ensure that the Kafka client is closed cleanly upon receiving a termination signal.