### PR TITLE
fix(consumer): add retry for offset commit

### DIFF
--- a/config.go
+++ b/config.go
@@ -449,7 +449,11 @@ type Config struct {
 			Retry struct {
 				// The total number of times to retry failing commit
 				// requests during OffsetManager shutdown (default 3).
-				Max int
+				Max      int
+				Factor   float64
+				Jitter   bool
+				MinDelay time.Duration
+				MaxDelay time.Duration
 			}
 		}
 
@@ -544,6 +548,10 @@ func NewConfig() *Config {
 	c.Consumer.Offsets.AutoCommit.Interval = 1 * time.Second
 	c.Consumer.Offsets.Initial = OffsetNewest
 	c.Consumer.Offsets.Retry.Max = 3
+	c.Consumer.Offsets.Retry.Jitter = true
+	c.Consumer.Offsets.Retry.Factor = 2
+	c.Consumer.Offsets.Retry.MaxDelay = 2 * time.Second
+	c.Consumer.Offsets.Retry.MinDelay = 200 * time.Millisecond
 
 	c.Consumer.Group.Session.Timeout = 10 * time.Second
 	c.Consumer.Group.Heartbeat.Interval = 3 * time.Second

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -256,23 +256,19 @@ func (om *offsetManager) Commit() {
 }
 
 func (om *offsetManager) flushToBroker() {
-
 	var (
 		attempt int
 	)
-
 	for {
 		req := om.constructRequest()
 		if req == nil {
 			return
 		}
-
 		broker, err := om.coordinator()
 		if err != nil {
 			om.handleError(err)
 			return
 		}
-
 		resp, err := broker.CommitOffset(req)
 		if err != nil {
 			om.handleError(err)
@@ -288,7 +284,6 @@ func (om *offsetManager) flushToBroker() {
 		om.handleResponse(broker, req, resp)
 		return
 	}
-
 }
 
 func (om *offsetManager) shouldRetry(resp *OffsetCommitResponse, attempt int) bool {


### PR DESCRIPTION
Fixes #1562 #1758 
The reason for the timeout when submitting the offset is likely to be the rebalance caused by the server restart or expansion and contraction, and a jittery retry strategy needs to be added.