### PR TITLE
fix: Adjust the retry count logic

### DIFF
--- a/client.go
+++ b/client.go
@@ -861,7 +861,7 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 		return false
 	}
 	retry := func(err error) error {
-		if attemptsRemaining > 0 {
+		if attemptsRemaining - 1 > 0 {
 			backoff := client.computeBackoff(attemptsRemaining)
 			if pastDeadline(backoff) {
 				Logger.Println("client/metadata skipping last retries as we would go past the metadata timeout")


### PR DESCRIPTION
## Questions：
When the program first tries to connect to kafka, it specifies the number of retries as 3, which should normally be three, but it actually performs four attempts
## Minimum recurrence：
```go
func TestRefreshCount(t *testing.T) {
	seedBroker := NewMockBroker(t, 1)
	leader := NewMockBroker(t, 5)

	metadataResponse1 := new(MetadataResponse)
	metadataResponse1.AddBroker(leader.Addr(), leader.BrokerID())
	metadataResponse1.AddBroker(seedBroker.Addr(), seedBroker.BrokerID())
	seedBroker.Returns(metadataResponse1)
	config := NewTestConfig()
	config.Metadata.Retry.Max = 1
	client, err := NewClient([]string{seedBroker.Addr()}, config)
	if err != nil {
		t.Fatal(err)
	}

	if len(client.Brokers()) != 2 {
		t.Error("Meta broker is not 2")
	}

	metadataResponse2 := new(MetadataResponse)
	metadataResponse2.AddBroker(leader.Addr(), leader.BrokerID())
	seedBroker.Returns(metadataResponse2)

	if err := client.RefreshMetadata(); err != nil {
		t.Error(err)
	}
	if len(client.Brokers()) != 1 {
		t.Error("Meta broker is not 1")
	}
}
```
Also, add a tag to the tryRefreshMetadata in the client.go file
![image](https://user-images.githubusercontent.com/39624029/147230822-db3ed2fe-caf1-48d1-bc22-e2c5814f8975.png)
Results：
![image](https://user-images.githubusercontent.com/39624029/147230990-901f9902-a48c-4aed-a334-97ce4dbc8225.png)

## Description：
The retry used here is defined temporarily and will be executed later. attemptsRemaining will still be executed later with the original attemptsRemaining (it should be minus one to include the current attempt in the retry count)