### PR TITLE
Implement resolve_canonical_bootstrap_servers_only

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,6 +50,15 @@ type Config struct {
 		ReadTimeout  time.Duration // How long to wait for a response.
 		WriteTimeout time.Duration // How long to wait for a transmit.
 
+		// ResolveCanonicalBootstrapServers turns each bootstrap broker address
+		// into a set of IPs, then does a reverse lookup on each one to get its
+		// canonical hostname. This list of hostnames then replaces the
+		// original address list. Similar to the `client.dns.lookup` option in
+		// the JVM client, this is especially useful with GSSAPI, where it
+		// allows providing an alias record instead of individual broker
+		// hostnames. Defaults to false.
+		ResolveCanonicalBootstrapServers bool
+
 		TLS struct {
 			// Whether or not to use TLS when connecting to the broker
 			// (defaults to false).


### PR DESCRIPTION
This PR allows specifying the equivalent of `client.dns.lookup=resolve_canonical_bootstrap_servers_only`, described in [KIP-235][]. The motivation is identical to the one in the proposal: the lack of this feature effectively mandates providing individual canonical broker hostnames when using GSSAPI, rather than a single alias which resolves to the same underlying IPs. This increases the likelihood of errors, and commits application owners to checking for new and removed brokers on an ongoing basis.

[KIP-235]: https://cwiki.apache.org/confluence/display/KAFKA/KIP-235%3A+Add+DNS+alias+support+for+secured+connection

The Java client implementation for this can be found [here](https://github.com/apache/kafka/blob/3.1.0/clients/src/main/java/org/apache/kafka/clients/ClientUtils.java#L62-L71).

The config could be designed as a `type DNSLookupStrategy int8` enum, with `UseAllDNSIPs` and `ResolveCanonicalBootstrapServersOnly` values, however I went for the `bool` as there is no precedent for mirroring the Java API, and this seemed much simpler to understand.

I was torn about adding `context.Context` to `resolveCanonicalNames()`'s signature. To be consistent with existing code, I've kept this internal. It is not fully supported anyway due to `Net.Proxy.Dialer` being a `proxy.Dialer` rather than `proxy.ContextDialer`.