### PR TITLE
fix: report more unrecoverable errors during SASL authentication

### DIFF
--- a/client.go
+++ b/client.go
@@ -929,11 +929,28 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 				Logger.Println("client is not authorized to access this topic. The topics were: ", topics)
 				return err
 			}
+
+			if errors.Is(err, ErrUnsupportedSASLMechanism) {
+				Logger.Println("requested SASL mechanism is not supported by the broker")
+				return err
+			}
+
 			// else remove that broker and try again
 			Logger.Printf("client/metadata got error from broker %d while fetching metadata: %v\n", broker.ID(), err)
 			_ = broker.Close()
 			client.deregisterBroker(broker)
 		} else {
+			if errors.Is(err, ErrSASLHandshakeReadEOF) ||
+				errors.Is(err, ErrSASLHandshakeSendEOF) ||
+				errors.Is(err, ErrFetchMetadataEOF) ||
+				errors.Is(err, ErrBadTLSHandshake) {
+				// These errors are typically unrecoverable connection /
+				// authentication failures, so we return them
+				// directly here to avoid falling back on the less useful
+				// "client has run out of brokers" error after retrying.
+				return err
+			}
+
 			// some other error, remove that broker and try again
 			Logger.Printf("client/metadata got error from broker %d while fetching metadata: %v\n", broker.ID(), err)
 			brokerErrors = append(brokerErrors, err)

--- a/client.go
+++ b/client.go
@@ -940,17 +940,6 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 			_ = broker.Close()
 			client.deregisterBroker(broker)
 		} else {
-			if errors.Is(err, ErrSASLHandshakeReadEOF) ||
-				errors.Is(err, ErrSASLHandshakeSendEOF) ||
-				errors.Is(err, ErrFetchMetadataEOF) ||
-				errors.Is(err, ErrBadTLSHandshake) {
-				// These errors are typically unrecoverable connection /
-				// authentication failures, so we return them
-				// directly here to avoid falling back on the less useful
-				// "client has run out of brokers" error after retrying.
-				return err
-			}
-
 			// some other error, remove that broker and try again
 			Logger.Printf("client/metadata got error from broker %d while fetching metadata: %v\n", broker.ID(), err)
 			brokerErrors = append(brokerErrors, err)

--- a/errors.go
+++ b/errors.go
@@ -67,6 +67,25 @@ var ErrDeleteRecords = errors.New("kafka server: failed to delete records")
 // ErrCreateACLs is the type of error returned when ACL creation failed
 var ErrCreateACLs = errors.New("kafka server: failed to create one or more ACL rules")
 
+// ErrSASLHandshakeReadEOF is returned when an unexpected EOF arises reading the SASL handshake header,
+// which usually indicates an invalid server certificate.
+var ErrSASLHandshakeReadEOF = errors.New("kafka: couldn't read SASL handshake (bad broker certificate?)")
+
+// ErrSASLHandshakeSendEOF is returned when an EOF arises initiating a SASL handshake with the broker,
+// which usually indicates that the broker is not expecting a SASL handshake.
+var ErrSASLHandshakeSendEOF = errors.New("kafka: couldn't write SASL handshake (make sure SASL is enabled on the target broker port)")
+
+// ErrFetchMetadataEOF is returned when an unexpected EOF arises while fetching broker metadata.
+// When this is not caused by one of the preceding handshake errors, this often means a plaintext
+// client is attempting to connect to a TLS-enabled broker, or a TLS-only client
+// is attempting to connect to a broker that requires SASL authentication.
+var ErrFetchMetadataEOF = errors.New("kafka: couldn't fetch broker metadata (check that your client and broker are using the same encryption and authentication settings)")
+
+// ErrBadTLSHandshake is returned when there is a TLS error while attempting a SASL handshake or
+// metadata refresh. This usually means that the requested TLS version or cipher is unsupported
+// by the broker.
+var ErrBadTLSHandshake = errors.New("kafka: bad TLS handshake connecting to broker (check that your TLS version and cipher are enabled by the broker)")
+
 // MultiErrorFormat specifies the formatter applied to format multierrors. The
 // default implementation is a consensed version of the hashicorp/go-multierror
 // default one


### PR DESCRIPTION
Several types of unrecoverable connection / authentication failure are not recognized as unrecoverable, and result in retrying all brokers and falling back on "client has run out of brokers to talk to" after they all fail. The errors that can cause this include unsupported SASL mechanisms, TLS versions, and ciphers, as well as invalid broker certificates and bad connection protocols. This PR adds additional error types and recognizes them as unrecoverable, so they are reported immediately to the client's error channel instead of only within Sarama's debug output.

This is based on a [similar PR](https://github.com/elastic/sarama/pull/15) in Elastic's vendored Sarama, based on confusion we were seeing with the "run out of brokers to talk to" message.