### PR TITLE
feature: basic support for context

### DIFF
--- a/produce_set.go
+++ b/produce_set.go
@@ -91,6 +91,15 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 	}
 
 	// Past this point we can't return an error, because we've already added the message to the set.
+	if msg.Context != nil {
+		// last chance to check if sender has given up
+		select {
+		case <-msg.Context.Done():
+			return msg.Context.Err()
+		default:
+			// continue sending
+		}
+	}
 	set.msgs = append(set.msgs, msg)
 
 	if ps.parent.conf.Version.IsAtLeast(V0_11_0_0) {


### PR DESCRIPTION
👋 I'm just messing around here to try and find a way to have contexts supported by code that I work with that uses sarama. Is this something that would be of interest? If so, I can look at writing tests and iterating and so on.

The idea being that you can set `Context` on a message and it will be best-effort supported by the producers. In the sync producer case, this makes a lot of mostly obvious sense: _"I'm willing to wait this long to send a message, otherwise give up"_. 

In the async producer case, the use case is a bit less obvious, since the assumption is that a message will be sent _sometime_ in the future. Yet, since the `ProducerMessage.Context` is a field and not a method argument, and therefor opt-in, messages that don't set a context wouldn't see any difference. A user of the async producer would have to set the field to signify that they want to have the message sort-of respect the `ctx.Done()` lifetime. Why would someone do this? Perhaps they're willing to send a message async for up to 5s, after which the message would be untimely and its usefulness gone.