### PR TITLE
Remove duplicates from topics

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -188,6 +188,9 @@ func (c *consumerGroup) Consume(ctx context.Context, topics []string, handler Co
 		return fmt.Errorf("no topics provided")
 	}
 
+	// Remove duplicates in topics slice
+	topics = getUniqueKeys(topics)
+
 	// Refresh metadata for requested topics
 	if err := c.client.RefreshMetadata(topics...); err != nil {
 		return err

--- a/utils.go
+++ b/utils.go
@@ -266,3 +266,15 @@ func (v KafkaVersion) String() string {
 
 	return fmt.Sprintf("%d.%d.%d", v.version[0], v.version[1], v.version[2])
 }
+
+func getUniqueKeys(strSlice []string) []string {
+	allKeys := make(map[string]bool)
+	list := []string{}
+	for _, item := range strSlice {
+		if _, value := allKeys[item]; !value {
+			allKeys[item] = true
+			list = append(list, item)
+		}
+	}
+	return list
+}


### PR DESCRIPTION
This PR is intended to fix the issues observed in https://github.com/Shopify/sarama/issues/2264.

Summary of the issue: Passing duplicate topics into the Consume function leads to uneven partition division between different consumers of the consumer group.

References: Java client handles this issue by always discarding duplicates - as it [collapses the collection of topics into a set](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/KafkaConsumer.java#L974).