### PR TITLE
chore(ci): add simple apidiff workflow

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -1,0 +1,30 @@
+name: API Compatibility
+on: [push, pull_request]
+jobs:
+  apidiff:
+    runs-on: ubuntu-latest
+    if: github.base_ref
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+      - name: Add GOBIN to PATH
+        run: echo "$(go env GOPATH)/bin" >>$GITHUB_PATH
+      - name: Install apidiff cmd
+        run: go install golang.org/x/exp/cmd/apidiff@latest
+      - name: Checkout base code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+          path: "base"
+      - name: Capture apidiff baseline
+        run: apidiff -m -w ../baseline.bin .
+        working-directory: "base"
+      - name: Checkout updated code
+        uses: actions/checkout@v3
+        with:
+          path: "updated"
+      - name: Run apidiff check
+        run: apidiff -m -incompatible ../baseline.bin .
+        working-directory: "updated"


### PR DESCRIPTION
In order to try and prevent breaking changes to the API going forward, add a simple call to the cmd wrapper of
https://pkg.go.dev/golang.org/x/exp/apidiff