### PR TITLE
chore(ci): bump golangci version, cleanup, depguard config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         GOFLAGS: -tags=functional
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.48.0
+        version: v1.53.3
   test:
     name: Unit Testing with Go ${{ matrix.go-version }}
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,13 @@ linters-settings:
     lines: 300
     statements: 300
 
+  depguard:
+    rules:
+      main:
+        deny:
+          - pkg: "io/ioutil"
+            desc: Use the "io" and "os" packages instead.
+
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters-settings:
   misspell:
     locale: US
   goimports:
-    local-prefixes: github.com/Shopify/sarama
+    local-prefixes: github.com/IBM/sarama
   gocritic:
     enabled-tags:
       - diagnostic
@@ -43,7 +43,7 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
+    # - deadcode
     - depguard
     - exportloopref
     - dogsled
@@ -68,12 +68,12 @@ linters:
     # - paralleltest
     # - scopelint
     - staticcheck
-    - structcheck
+    # - structcheck
     # - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
+    # - varcheck
     - whitespace
 
 issues:


### PR DESCRIPTION
Hi 👋 
Good luck with the project ownership!
In this PR:
* Bumped the `golangci` version to `v1.53.3`
* Changed the `local-prefixes` to IBM
* Commented out [deprecated](https://golangci-lint.run/usage/linters/#disabled-by-default) linters (replaced by `unused `)
* Added some basic `depguard` configs - don't allow `io/ioutil`