### PR TITLE
remove: redundant backoff timer in heartbeat loop

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -922,9 +922,6 @@ func (s *consumerGroupSession) heartbeatLoop() {
 	pause := time.NewTicker(s.parent.config.Consumer.Group.Heartbeat.Interval)
 	defer pause.Stop()
 
-	retryBackoff := time.NewTimer(s.parent.config.Metadata.Retry.Backoff)
-	defer retryBackoff.Stop()
-
 	retries := s.parent.config.Metadata.Retry.Max
 	for {
 		coordinator, err := s.parent.client.Coordinator(s.parent.groupID)
@@ -933,13 +930,13 @@ func (s *consumerGroupSession) heartbeatLoop() {
 				s.parent.handleError(err, "", -1)
 				return
 			}
-			retryBackoff.Reset(s.parent.config.Metadata.Retry.Backoff)
+
 			select {
 			case <-s.hbDying:
 				return
-			case <-retryBackoff.C:
-				retries--
+			default:
 			}
+			retries--
 			continue
 		}
 


### PR DESCRIPTION
The timer `retryBackoff` here is redundant.

Because in the underlying logic of `func Coordinator(consumerGroup string) (*Broker, error))`, `findCoordinator` has already utilized a retry mechanism with `client.conf.Metadata.Retry.Backoff` or `client.conf.Metadata.Retry.BackoffFunc`.

```
func (client *client) findCoordinator(coordinatorKey string, coordinatorType CoordinatorType, attemptsRemaining int) (*FindCoordinatorResponse, error) {
	retry := func(err error) (*FindCoordinatorResponse, error) {
		if attemptsRemaining > 0 {
**			backoff := client.computeBackoff(attemptsRemaining)
			Logger.Printf("client/coordinator retrying after %dms... (%d attempts remaining)\n", backoff/time.Millisecond, attemptsRemaining)
**			time.Sleep(backoff)
			return client.findCoordinator(coordinatorKey, coordinatorType, attemptsRemaining-1)
		}
		return nil, err
	}
   ...
}

func (client *client) computeBackoff(attemptsRemaining int) time.Duration {
**	if client.conf.Metadata.Retry.BackoffFunc != nil {
		maxRetries := client.conf.Metadata.Retry.Max
		retries := maxRetries - attemptsRemaining
**		return client.conf.Metadata.Retry.BackoffFunc(retries, maxRetries)
	}
**	return client.conf.Metadata.Retry.Backoff
}
```