### PR TITLE
Clean up some typos and docs/help mistakes

### DIFF
--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -3,7 +3,8 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 USER root
 
 RUN microdnf update \
-    && microdnf install curl gzip java-11-openjdk-headless tar \
+    && microdnf install curl gzip java-11-openjdk-headless tar tzdata-java \
+    && microdnf reinstall tzdata \
     && microdnf clean all
 
 ENV JAVA_HOME=/usr/lib/jvm/jre-11

--- a/acl_create_request_test.go
+++ b/acl_create_request_test.go
@@ -16,7 +16,7 @@ var (
 		0, 0, 0, 1,
 		3, // resource type = group
 		0, 5, 'g', 'r', 'o', 'u', 'p',
-		3, // resource pattten type = literal
+		3, // resource pattern type = literal
 		0, 9, 'p', 'r', 'i', 'n', 'c', 'i', 'p', 'a', 'l',
 		0, 4, 'h', 'o', 's', 't',
 		2, // all

--- a/acl_describe_request.go
+++ b/acl_describe_request.go
@@ -1,6 +1,6 @@
 package sarama
 
-// DescribeAclsRequest is a secribe acl request type
+// DescribeAclsRequest is a describe acl request type
 type DescribeAclsRequest struct {
 	Version int
 	AclFilter

--- a/acl_types.go
+++ b/acl_types.go
@@ -60,7 +60,7 @@ func (a *AclOperation) MarshalText() ([]byte, error) {
 	return []byte(a.String()), nil
 }
 
-// UnmarshalText takes a text reprentation of the operation and converts it to an AclOperation
+// UnmarshalText takes a text representation of the operation and converts it to an AclOperation
 func (a *AclOperation) UnmarshalText(text []byte) error {
 	normalized := strings.ToLower(string(text))
 	mapping := map[string]AclOperation{
@@ -114,7 +114,7 @@ func (a *AclPermissionType) MarshalText() ([]byte, error) {
 	return []byte(a.String()), nil
 }
 
-// UnmarshalText takes a text reprentation of the permission type and converts it to an AclPermissionType
+// UnmarshalText takes a text representation of the permission type and converts it to an AclPermissionType
 func (a *AclPermissionType) UnmarshalText(text []byte) error {
 	normalized := strings.ToLower(string(text))
 	mapping := map[string]AclPermissionType{
@@ -166,7 +166,7 @@ func (a *AclResourceType) MarshalText() ([]byte, error) {
 	return []byte(a.String()), nil
 }
 
-// UnmarshalText takes a text reprentation of the resource type and converts it to an AclResourceType
+// UnmarshalText takes a text representation of the resource type and converts it to an AclResourceType
 func (a *AclResourceType) UnmarshalText(text []byte) error {
 	normalized := strings.ToLower(string(text))
 	mapping := map[string]AclResourceType{
@@ -217,7 +217,7 @@ func (a *AclResourcePatternType) MarshalText() ([]byte, error) {
 	return []byte(a.String()), nil
 }
 
-// UnmarshalText takes a text reprentation of the resource pattern type and converts it to an AclResourcePatternType
+// UnmarshalText takes a text representation of the resource pattern type and converts it to an AclResourcePatternType
 func (a *AclResourcePatternType) UnmarshalText(text []byte) error {
 	normalized := strings.ToLower(string(text))
 	mapping := map[string]AclResourcePatternType{

--- a/add_partitions_to_txn_request.go
+++ b/add_partitions_to_txn_request.go
@@ -1,6 +1,6 @@
 package sarama
 
-// AddPartitionsToTxnRequest is a add paartition request
+// AddPartitionsToTxnRequest is a add partition request
 type AddPartitionsToTxnRequest struct {
 	TransactionalID string
 	ProducerID      int64

--- a/async_producer.go
+++ b/async_producer.go
@@ -50,7 +50,7 @@ type AsyncProducer interface {
 	// errors to be returned.
 	Errors() <-chan *ProducerError
 
-	// IsTransactional return true when current producer is is transactional.
+	// IsTransactional return true when current producer is transactional.
 	IsTransactional() bool
 
 	// TxnStatus return current producer transaction status.

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -1115,7 +1115,7 @@ type assignmentPriorityQueue []*consumerGroupMember
 func (pq assignmentPriorityQueue) Len() int { return len(pq) }
 
 func (pq assignmentPriorityQueue) Less(i, j int) bool {
-	// order asssignment priority queue in descending order using assignment-count/member-id
+	// order assignment priority queue in descending order using assignment-count/member-id
 	if len(pq[i].assignments) == len(pq[j].assignments) {
 		return strings.Compare(pq[i].id, pq[j].id) > 0
 	}

--- a/broker.go
+++ b/broker.go
@@ -455,7 +455,7 @@ func (b *Broker) AsyncProduce(request *ProduceRequest, cb ProduceCallback) error
 					return
 				}
 
-				// Wellformed response
+				// Well-formed response
 				b.updateThrottleMetric(res.ThrottleTime)
 				cb(res, nil)
 			},

--- a/client.go
+++ b/client.go
@@ -50,7 +50,7 @@ type Client interface {
 	// topic/partition, as determined by querying the cluster metadata.
 	Leader(topic string, partitionID int32) (*Broker, error)
 
-	// LeaderAndEpoch returns the the leader and its epoch for the current
+	// LeaderAndEpoch returns the leader and its epoch for the current
 	// topic/partition, as determined by querying the cluster metadata.
 	LeaderAndEpoch(topic string, partitionID int32) (*Broker, int32, error)
 

--- a/client_test.go
+++ b/client_test.go
@@ -911,7 +911,7 @@ func TestClientCoordinatorWithConsumerOffsetsTopic(t *testing.T) {
 
 	seedBroker.Returns(coordinatorResponse3)
 
-	// Refresh the locally cahced value because it's stale
+	// Refresh the locally cached value because it's stale
 	if err := client.RefreshCoordinator("my_group"); err != nil {
 		t.Error(err)
 	}

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -406,7 +406,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 		claims = members.Topics
 
 		// in the case of stateful balance strategies, hold on to the returned
-		// assignment metadata, otherwise, reset the statically defined conusmer
+		// assignment metadata, otherwise, reset the statically defined consumer
 		// group metadata
 		if members.UserData != nil {
 			c.userData = members.UserData

--- a/describe_configs_request_test.go
+++ b/describe_configs_request_test.go
@@ -44,7 +44,7 @@ var (
 		2,                   // a topic
 		0, 3, 'f', 'o', 'o', // topic name: foo
 		255, 255, 255, 255, // no configs
-		1, // synoms
+		1, // synonyms
 	}
 )
 

--- a/errors.go
+++ b/errors.go
@@ -79,7 +79,7 @@ var ErrTransactionNotReady = errors.New("transaction manager: transaction is not
 // ErrNonTransactedProducer when calling BeginTxn, CommitTxn or AbortTxn on a non transactional producer.
 var ErrNonTransactedProducer = errors.New("transaction manager: you need to add TransactionalID to producer")
 
-// ErrTransitionNotAllowed when txnmgr state transiion is not valid.
+// ErrTransitionNotAllowed when txnmgr state transition is not valid.
 var ErrTransitionNotAllowed = errors.New("transaction manager: invalid transition attempted")
 
 // ErrCannotTransitionNilError when transition is attempted with an nil error.
@@ -89,7 +89,7 @@ var ErrCannotTransitionNilError = errors.New("transaction manager: cannot transi
 var ErrTxnUnableToParseResponse = errors.New("transaction manager: unable to parse response")
 
 // MultiErrorFormat specifies the formatter applied to format multierrors. The
-// default implementation is a consensed version of the hashicorp/go-multierror
+// default implementation is a condensed version of the hashicorp/go-multierror
 // default one
 var MultiErrorFormat multierror.ErrorFormatFunc = func(es []error) string {
 	if len(es) == 1 {

--- a/heartbeat_request_test.go
+++ b/heartbeat_request_test.go
@@ -8,19 +8,19 @@ import (
 var (
 	basicHeartbeatRequestV0 = []byte{
 		0, 3, 'f', 'o', 'o', // Group ID
-		0x00, 0x01, 0x02, 0x03, // Generatiuon ID
+		0x00, 0x01, 0x02, 0x03, // Generation ID
 		0, 3, 'b', 'a', 'z', // Member ID
 	}
 
 	basicHeartbeatRequestV3_GID = []byte{
 		0, 3, 'f', 'o', 'o', // Group ID
-		0x00, 0x01, 0x02, 0x03, // Generatiuon ID
+		0x00, 0x01, 0x02, 0x03, // Generation ID
 		0, 3, 'b', 'a', 'z', // Member ID
 		0, 3, 'g', 'i', 'd', // Group Instance ID
 	}
 	basicHeartbeatRequestV3_NOGID = []byte{
 		0, 3, 'f', 'o', 'o', // Group ID
-		0x00, 0x01, 0x02, 0x03, // Generatiuon ID
+		0x00, 0x01, 0x02, 0x03, // Generation ID
 		0, 3, 'b', 'a', 'z', // Member ID
 		255, 255, // Group Instance ID
 	}

--- a/join_group_response_test.go
+++ b/join_group_response_test.go
@@ -184,7 +184,7 @@ var (
 		0, 3, 'f', 'o', 'o', // Leader ID
 		0, 3, 'b', 'a', 'r', // Member ID
 		0, 0, 0, 1, // One member info
-		0, 3, 'm', 'i', 'd', // memeberId
+		0, 3, 'm', 'i', 'd', // memberId
 		0, 3, 'g', 'i', 'd', // GroupInstanceId
 		0, 0, 0, 3, 1, 2, 3, // Metadata
 	}

--- a/message_test.go
+++ b/message_test.go
@@ -51,7 +51,7 @@ var (
 		0xFF, 0xFF, 0xFF, 0xFF, // key
 		0x00, 0x00, 0x00, 0x0f, // len
 		0x04, 0x22, 0x4D, 0x18, // LZ4 magic number
-		100,                  // LZ4 flags: version 01, block indepedant, content checksum
+		100,                  // LZ4 flags: version 01, block independent, content checksum
 		112, 185, 0, 0, 0, 0, // LZ4 data
 		5, 93, 204, 2, // LZ4 checksum
 	}

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -359,7 +359,7 @@ func (om *offsetManager) handleResponse(broker *Broker, req *OffsetCommitRequest
 				// nothing wrong but we didn't commit, we'll get it next time round
 			case ErrFencedInstancedId:
 				pom.handleError(err)
-				// TODO close the whole consumer for instacne fenced....
+				// TODO close the whole consumer for instance fenced....
 				om.tryCancelSession()
 			case ErrUnknownTopicOrPartition:
 				// let the user know *and* try redispatching - if topic-auto-create is

--- a/packet_decoder.go
+++ b/packet_decoder.go
@@ -55,7 +55,7 @@ type pushDecoder interface {
 	// Saves the offset into the input buffer as the location to actually read the calculated value when able.
 	saveOffset(in int)
 
-	// Returns the length of data to reserve for the input of this encoder (eg 4 bytes for a CRC32).
+	// Returns the length of data to reserve for the input of this encoder (e.g. 4 bytes for a CRC32).
 	reserveLength() int
 
 	// Indicates that all required data is now available to calculate and check the field.

--- a/sarama.go
+++ b/sarama.go
@@ -91,7 +91,7 @@ import (
 
 var (
 	// Logger is the instance of a StdLogger interface that Sarama writes connection
-	// management events to. By default it is set to discard all log messages via ioutil.Discard,
+	// management events to. By default it is set to discard all log messages via io.Discard,
 	// but you can set it to redirect wherever you want.
 	Logger StdLogger = log.New(io.Discard, "[Sarama] ", log.LstdFlags)
 

--- a/sync_producer.go
+++ b/sync_producer.go
@@ -33,7 +33,7 @@ type SyncProducer interface {
 	// TxnStatus return current producer transaction status.
 	TxnStatus() ProducerTxnStatusFlag
 
-	// IsTransactional return true when current producer is is transactional.
+	// IsTransactional return true when current producer is transactional.
 	IsTransactional() bool
 
 	// BeginTxn mark current transaction as ready.

--- a/tools/kafka-producer-performance/main.go
+++ b/tools/kafka-producer-performance/main.go
@@ -43,7 +43,7 @@ var (
 	securityProtocol = flag.String(
 		"security-protocol",
 		"PLAINTEXT",
-		"The name of the security protocol to talk to Kafka (PLAINTEXT, SSL) (default: PLAINTEXT).",
+		"The name of the security protocol to talk to Kafka (PLAINTEXT, SSL).",
 	)
 	tlsRootCACerts = flag.String(
 		"tls-ca-certs",
@@ -83,7 +83,7 @@ var (
 	maxOpenRequests = flag.Int(
 		"max-open-requests",
 		5,
-		"The maximum number of unacknowledged requests the client will send on a single connection before blocking (default: 5).",
+		"The maximum number of unacknowledged requests the client will send on a single connection before blocking.",
 	)
 	maxMessageBytes = flag.Int(
 		"max-message-bytes",

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -14,7 +14,7 @@ type ProducerTxnStatusFlag int16
 const (
 	// ProducerTxnFlagUninitialized when txnmgr is created
 	ProducerTxnFlagUninitialized ProducerTxnStatusFlag = 1 << iota
-	// ProducerTxnFlagInitializing when txnmgr is initilizing
+	// ProducerTxnFlagInitializing when txnmgr is initializing
 	ProducerTxnFlagInitializing
 	// ProducerTxnFlagReady when is ready to receive transaction
 	ProducerTxnFlagReady
@@ -22,7 +22,7 @@ const (
 	ProducerTxnFlagInTransaction
 	// ProducerTxnFlagEndTransaction when transaction will be committed
 	ProducerTxnFlagEndTransaction
-	// ProducerTxnFlagInError whan having abortable or fatal error
+	// ProducerTxnFlagInError when having abortable or fatal error
 	ProducerTxnFlagInError
 	// ProducerTxnFlagCommittingTransaction when committing txn
 	ProducerTxnFlagCommittingTransaction
@@ -117,13 +117,13 @@ var producerTxnTransitions = map[ProducerTxnStatusFlag][]ProducerTxnStatusFlag{
 		ProducerTxnFlagReady,
 		ProducerTxnFlagInError,
 	},
-	// When we need are initilizing
+	// When we need are initializing
 	ProducerTxnFlagInitializing: {
 		ProducerTxnFlagInitializing,
 		ProducerTxnFlagReady,
 		ProducerTxnFlagInError,
 	},
-	// When we have initilized transactional producer
+	// When we have initialized transactional producer
 	ProducerTxnFlagReady: {
 		ProducerTxnFlagInTransaction,
 	},
@@ -660,7 +660,7 @@ func (t *transactionManager) finishTransaction(commit bool) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
-	// Ensure no error when committing or abording
+	// Ensure no error when committing or aborting
 	if commit && t.currentTxnStatus()&ProducerTxnFlagInError != 0 {
 		return t.lastError
 	} else if !commit && t.currentTxnStatus()&ProducerTxnFlagFatalError != 0 {


### PR DESCRIPTION
Fix obsolete reference to `ioutil.Discard` in docs.
Fix duplication of defaults in `tools/kafka-producer-performance` help output (flag output already includes the defaults without explicitly documenting them).
Fix some typos spotted while reading the code.
