### PR TITLE
Fix some retry issues

### DIFF
--- a/client.go
+++ b/client.go
@@ -979,9 +979,10 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 			if time.Since(time.Unix(t/1e3, 0)) < backoff {
 				return err
 			}
+			attemptsRemaining--
 			Logger.Printf("client/metadata retrying after %dms... (%d attempts remaining)\n", backoff/time.Millisecond, attemptsRemaining)
 
-			return client.tryRefreshMetadata(topics, attemptsRemaining-1, deadline)
+			return client.tryRefreshMetadata(topics, attemptsRemaining, deadline)
 		}
 		return err
 	}
@@ -1160,9 +1161,10 @@ func (client *client) findCoordinator(coordinatorKey string, coordinatorType Coo
 	retry := func(err error) (*FindCoordinatorResponse, error) {
 		if attemptsRemaining > 0 {
 			backoff := client.computeBackoff(attemptsRemaining)
+			attemptsRemaining--
 			Logger.Printf("client/coordinator retrying after %dms... (%d attempts remaining)\n", backoff/time.Millisecond, attemptsRemaining)
 			time.Sleep(backoff)
-			return client.findCoordinator(coordinatorKey, coordinatorType, attemptsRemaining-1)
+			return client.findCoordinator(coordinatorKey, coordinatorType, attemptsRemaining)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
This fixes #2515.

It also fixed similar off-by-one errors in logging in client.go.

I specifically didn't fix the four off-by-one logging errors in transaction_manager.go since it looks to me like the number of attempts also has off-by-one errors (e.g. [here](https://github.com/IBM/sarama/blob/6ecdb50a30c3f2897be5e863aa7c854781e389be/transaction_manager.go#L299)) so technically until that logic is fixed they are correct.