### PR TITLE
fix(test): allow testing of skipped test without IsTransactional panic

### DIFF
--- a/functional_consumer_test.go
+++ b/functional_consumer_test.go
@@ -233,7 +233,8 @@ func TestReadOnlyAndAllCommittedMessages(t *testing.T) {
 	ps := &produceSet{
 		msgs: make(map[string]map[int32]*partitionSet),
 		parent: &asyncProducer{
-			conf: config,
+			conf:   config,
+			txnmgr: &transactionManager{},
 		},
 		producerID:    pidRes.ProducerID,
 		producerEpoch: pidRes.ProducerEpoch,


### PR DESCRIPTION
This test is currently skipped but I was planning to look at flakiness in the functional tests so I thought I'd make this one not panic due to nil txnmgr.
