### PR TITLE
fix: correct unsupported version check

### DIFF
--- a/metadata_request.go
+++ b/metadata_request.go
@@ -24,7 +24,7 @@ func NewMetadataRequest(version KafkaVersion, topics []string) *MetadataRequest 
 }
 
 func (r *MetadataRequest) encode(pe packetEncoder) (err error) {
-	if r.Version < 0 || r.Version > 12 {
+	if r.Version < 0 || r.Version > 7 {
 		return PacketEncodingError{"invalid or unsupported MetadataRequest version field"}
 	}
 	if r.Version == 0 || len(r.Topics) > 0 {


### PR DESCRIPTION
Version 8 is unsupported since the existing code doesn't support the fields IncludeClusterAuthorizedOperations and IncludeTopicAuthorizedOperations required by that version.
