### PR TITLE
fix: avoiding burning cpu if all partitions are paused

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -920,7 +920,7 @@ func (bc *brokerConsumer) subscriptionManager() {
 }
 
 // subscriptionConsumer ensures we will get nil right away if no new subscriptions is available
-// this is a the main loop that fetches Kafka messages
+// this is the main loop that fetches Kafka messages
 func (bc *brokerConsumer) subscriptionConsumer() {
 	for newSubscriptions := range bc.newSubscriptions {
 		bc.updateSubscriptions(newSubscriptions)
@@ -942,6 +942,7 @@ func (bc *brokerConsumer) subscriptionConsumer() {
 		// if there isn't response, it means that not fetch was made
 		// so we don't need to handle any response
 		if response == nil {
+			time.Sleep(partitionConsumersBatchTimeout)
 			continue
 		}
 


### PR DESCRIPTION
Sarama has addressed the issue of submitting empty fetch requests after calling `PauseAll`, as seen in [#2143](https://github.com/IBM/sarama/issues/2143). However, there is still a CPU utilization problem.

The root cause lies in two operations:

1. In [`subscriptionConsumer`](https://github.com/IBM/sarama/blob/v1.40.1/consumer.go#L924-L965), if `response` is nil, it immediately attempts to [fetch](https://github.com/IBM/sarama/blob/v1.40.1/consumer.go#L945) from the `bc.newSubscriptions` channel.

2. In [`subscriptionManager`](https://github.com/IBM/sarama/blob/v1.40.1/consumer.go#L883C27-L920), it continuously sends `nil` to `bc.newSubscriptions`.

These two operations alternate indefinitely until a rebalance or until `ResumeAll/Resume` is called. Consequently, this leads to the CPU burn issue.
