### PR TITLE
extend throttling metric scope

### DIFF
--- a/acl_create_response.go
+++ b/acl_create_response.go
@@ -63,6 +63,10 @@ func (c *CreateAclsResponse) requiredVersion() KafkaVersion {
 	return V0_11_0_0
 }
 
+func (r *CreateAclsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 // AclCreationResponse is an acl creation response type
 type AclCreationResponse struct {
 	Err    KError

--- a/acl_delete_response.go
+++ b/acl_delete_response.go
@@ -64,6 +64,10 @@ func (d *DeleteAclsResponse) requiredVersion() KafkaVersion {
 	return V0_11_0_0
 }
 
+func (r *DeleteAclsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 // FilterResponse is a filter response type
 type FilterResponse struct {
 	Err          KError

--- a/acl_describe_response.go
+++ b/acl_describe_response.go
@@ -89,3 +89,7 @@ func (d *DescribeAclsResponse) requiredVersion() KafkaVersion {
 		return V0_11_0_0
 	}
 }
+
+func (r *DescribeAclsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/add_offsets_to_txn_response.go
+++ b/add_offsets_to_txn_response.go
@@ -47,3 +47,7 @@ func (a *AddOffsetsToTxnResponse) headerVersion() int16 {
 func (a *AddOffsetsToTxnResponse) requiredVersion() KafkaVersion {
 	return V0_11_0_0
 }
+
+func (r *AddOffsetsToTxnResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/add_partitions_to_txn_response.go
+++ b/add_partitions_to_txn_response.go
@@ -87,6 +87,10 @@ func (a *AddPartitionsToTxnResponse) requiredVersion() KafkaVersion {
 	return V0_11_0_0
 }
 
+func (r *AddPartitionsToTxnResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 // PartitionError is a partition error type
 type PartitionError struct {
 	Partition int32

--- a/alter_client_quotas_response.go
+++ b/alter_client_quotas_response.go
@@ -143,3 +143,7 @@ func (a *AlterClientQuotasResponse) headerVersion() int16 {
 func (a *AlterClientQuotasResponse) requiredVersion() KafkaVersion {
 	return V2_6_0_0
 }
+
+func (r *AlterClientQuotasResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/alter_configs_response.go
+++ b/alter_configs_response.go
@@ -114,3 +114,7 @@ func (a *AlterConfigsResponse) headerVersion() int16 {
 func (a *AlterConfigsResponse) requiredVersion() KafkaVersion {
 	return V0_11_0_0
 }
+
+func (r *AlterConfigsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/alter_partition_reassignments_response.go
+++ b/alter_partition_reassignments_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type alterPartitionReassignmentsErrorBlock struct {
 	errorCode    KError
 	errorMessage *string
@@ -154,4 +156,8 @@ func (r *AlterPartitionReassignmentsResponse) headerVersion() int16 {
 
 func (r *AlterPartitionReassignmentsResponse) requiredVersion() KafkaVersion {
 	return V2_4_0_0
+}
+
+func (r *AlterPartitionReassignmentsResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }

--- a/alter_user_scram_credentials_response.go
+++ b/alter_user_scram_credentials_response.go
@@ -92,3 +92,7 @@ func (r *AlterUserScramCredentialsResponse) headerVersion() int16 {
 func (r *AlterUserScramCredentialsResponse) requiredVersion() KafkaVersion {
 	return V2_7_0_0
 }
+
+func (r *AlterUserScramCredentialsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/api_versions_response.go
+++ b/api_versions_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 // ApiVersionsResponseKey contains the APIs supported by the broker.
 type ApiVersionsResponseKey struct {
 	// Version defines the protocol version to use for encode and decode
@@ -153,4 +155,8 @@ func (r *ApiVersionsResponse) requiredVersion() KafkaVersion {
 	default:
 		return V0_10_0_0
 	}
+}
+
+func (r *ApiVersionsResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }

--- a/broker.go
+++ b/broker.go
@@ -943,7 +943,7 @@ func (b *Broker) write(buf []byte) (n int, err error) {
 	return b.conn.Write(buf)
 }
 
-// b.lock must be haled by caller
+// b.lock must be held by caller
 func (b *Broker) send(rb protocolBody, promiseResponse bool, responseHeaderVersion int16) (*responsePromise, error) {
 	var promise *responsePromise
 	if promiseResponse {

--- a/create_partitions_response.go
+++ b/create_partitions_response.go
@@ -71,6 +71,10 @@ func (r *CreatePartitionsResponse) requiredVersion() KafkaVersion {
 	return V1_0_0_0
 }
 
+func (r *CreatePartitionsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 type TopicPartitionError struct {
 	Err    KError
 	ErrMsg *string

--- a/create_topics_response.go
+++ b/create_topics_response.go
@@ -85,6 +85,10 @@ func (c *CreateTopicsResponse) requiredVersion() KafkaVersion {
 	}
 }
 
+func (r *CreateTopicsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 type TopicError struct {
 	Err    KError
 	ErrMsg *string

--- a/delete_groups_response.go
+++ b/delete_groups_response.go
@@ -72,3 +72,7 @@ func (r *DeleteGroupsResponse) headerVersion() int16 {
 func (r *DeleteGroupsResponse) requiredVersion() KafkaVersion {
 	return V1_1_0_0
 }
+
+func (r *DeleteGroupsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/delete_offsets_response.go
+++ b/delete_offsets_response.go
@@ -110,3 +110,7 @@ func (r *DeleteOffsetsResponse) headerVersion() int16 {
 func (r *DeleteOffsetsResponse) requiredVersion() KafkaVersion {
 	return V2_4_0_0
 }
+
+func (r *DeleteOffsetsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/delete_records_response.go
+++ b/delete_records_response.go
@@ -88,6 +88,10 @@ func (d *DeleteRecordsResponse) requiredVersion() KafkaVersion {
 	return V0_11_0_0
 }
 
+func (r *DeleteRecordsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 type DeleteRecordsResponseTopic struct {
 	Partitions map[int32]*DeleteRecordsResponsePartition
 }

--- a/delete_topics_response.go
+++ b/delete_topics_response.go
@@ -80,3 +80,7 @@ func (d *DeleteTopicsResponse) requiredVersion() KafkaVersion {
 		return V0_10_1_0
 	}
 }
+
+func (r *DeleteTopicsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/describe_client_quotas_response.go
+++ b/describe_client_quotas_response.go
@@ -233,3 +233,7 @@ func (d *DescribeClientQuotasResponse) headerVersion() int16 {
 func (d *DescribeClientQuotasResponse) requiredVersion() KafkaVersion {
 	return V2_6_0_0
 }
+
+func (r *DescribeClientQuotasResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/describe_configs_response.go
+++ b/describe_configs_response.go
@@ -127,6 +127,10 @@ func (r *DescribeConfigsResponse) requiredVersion() KafkaVersion {
 	}
 }
 
+func (r *DescribeConfigsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 func (r *ResourceResponse) encode(pe packetEncoder, version int16) (err error) {
 	pe.putInt16(r.ErrorCode)
 

--- a/describe_groups_response.go
+++ b/describe_groups_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type DescribeGroupsResponse struct {
 	// Version defines the protocol version to use for encode and decode
 	Version int16
@@ -75,6 +77,10 @@ func (r *DescribeGroupsResponse) requiredVersion() KafkaVersion {
 		return V2_4_0_0
 	}
 	return V0_9_0_0
+}
+
+func (r *DescribeGroupsResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }
 
 // GroupDescription contains each described group.

--- a/describe_log_dirs_response.go
+++ b/describe_log_dirs_response.go
@@ -69,6 +69,10 @@ func (r *DescribeLogDirsResponse) requiredVersion() KafkaVersion {
 	return V1_0_0_0
 }
 
+func (r *DescribeLogDirsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 type DescribeLogDirsResponseDirMetadata struct {
 	ErrorCode KError
 

--- a/describe_user_scram_credentials_response.go
+++ b/describe_user_scram_credentials_response.go
@@ -166,3 +166,7 @@ func (r *DescribeUserScramCredentialsResponse) headerVersion() int16 {
 func (r *DescribeUserScramCredentialsResponse) requiredVersion() KafkaVersion {
 	return V2_7_0_0
 }
+
+func (r *DescribeUserScramCredentialsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/end_txn_response.go
+++ b/end_txn_response.go
@@ -46,3 +46,7 @@ func (r *EndTxnResponse) headerVersion() int16 {
 func (e *EndTxnResponse) requiredVersion() KafkaVersion {
 	return V0_11_0_0
 }
+
+func (r *EndTxnResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -413,6 +413,10 @@ func (r *FetchResponse) requiredVersion() KafkaVersion {
 	}
 }
 
+func (r *FetchResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 func (r *FetchResponse) GetBlock(topic string, partition int32) *FetchResponseBlock {
 	if r.Blocks == nil {
 		return nil

--- a/find_coordinator_response.go
+++ b/find_coordinator_response.go
@@ -94,3 +94,7 @@ func (f *FindCoordinatorResponse) requiredVersion() KafkaVersion {
 		return V0_8_2_0
 	}
 }
+
+func (r *FindCoordinatorResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/heartbeat_response.go
+++ b/heartbeat_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type HeartbeatResponse struct {
 	Version      int16
 	ThrottleTime int32
@@ -49,4 +51,8 @@ func (r *HeartbeatResponse) requiredVersion() KafkaVersion {
 		return V2_3_0_0
 	}
 	return V0_9_0_0
+}
+
+func (r *HeartbeatResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTime) * time.Millisecond
 }

--- a/incremental_alter_configs_response.go
+++ b/incremental_alter_configs_response.go
@@ -64,3 +64,7 @@ func (a *IncrementalAlterConfigsResponse) headerVersion() int16 {
 func (a *IncrementalAlterConfigsResponse) requiredVersion() KafkaVersion {
 	return V2_3_0_0
 }
+
+func (r *IncrementalAlterConfigsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/init_producer_id_response.go
+++ b/init_producer_id_response.go
@@ -83,3 +83,7 @@ func (i *InitProducerIDResponse) requiredVersion() KafkaVersion {
 		return V0_11_0_0
 	}
 }
+
+func (r *InitProducerIDResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/join_group_response.go
+++ b/join_group_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type JoinGroupResponse struct {
 	Version       int16
 	ThrottleTime  int32
@@ -156,4 +158,8 @@ func (r *JoinGroupResponse) requiredVersion() KafkaVersion {
 	default:
 		return V0_9_0_0
 	}
+}
+
+func (r *JoinGroupResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTime) * time.Millisecond
 }

--- a/leave_group_response.go
+++ b/leave_group_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type MemberResponse struct {
 	MemberId        string
 	GroupInstanceId *string
@@ -89,4 +91,8 @@ func (r *LeaveGroupResponse) requiredVersion() KafkaVersion {
 		return V2_3_0_0
 	}
 	return V0_9_0_0
+}
+
+func (r *LeaveGroupResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTime) * time.Millisecond
 }

--- a/list_partition_reassignments_response.go
+++ b/list_partition_reassignments_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type PartitionReplicaReassignmentsStatus struct {
 	Replicas         []int32
 	AddingReplicas   []int32
@@ -166,4 +168,8 @@ func (r *ListPartitionReassignmentsResponse) headerVersion() int16 {
 
 func (r *ListPartitionReassignmentsResponse) requiredVersion() KafkaVersion {
 	return V2_4_0_0
+}
+
+func (r *ListPartitionReassignmentsResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }

--- a/metadata_response.go
+++ b/metadata_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 // PartitionMetadata contains each partition in the topic.
 type PartitionMetadata struct {
 	// Version defines the protocol version to use for encode and decode
@@ -290,6 +292,10 @@ func (r *MetadataResponse) requiredVersion() KafkaVersion {
 	default:
 		return MinVersion
 	}
+}
+
+func (r *MetadataResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }
 
 // testing API

--- a/offset_commit_response.go
+++ b/offset_commit_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type OffsetCommitResponse struct {
 	Version        int16
 	ThrottleTimeMs int32
@@ -113,4 +115,8 @@ func (r *OffsetCommitResponse) requiredVersion() KafkaVersion {
 	default:
 		return MinVersion
 	}
+}
+
+func (r *OffsetCommitResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }

--- a/offset_fetch_response.go
+++ b/offset_fetch_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type OffsetFetchResponseBlock struct {
 	Offset      int64
 	LeaderEpoch int32
@@ -253,6 +255,10 @@ func (r *OffsetFetchResponse) requiredVersion() KafkaVersion {
 	default:
 		return MinVersion
 	}
+}
+
+func (r *OffsetFetchResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }
 
 func (r *OffsetFetchResponse) GetBlock(topic string, partition int32) *OffsetFetchResponseBlock {

--- a/offset_response.go
+++ b/offset_response.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "time"
+
 type OffsetResponseBlock struct {
 	Err       KError
 	Offsets   []int64 // Version 0
@@ -174,6 +176,10 @@ func (r *OffsetResponse) requiredVersion() KafkaVersion {
 	default:
 		return MinVersion
 	}
+}
+
+func (r *OffsetResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }
 
 // testing API

--- a/produce_response.go
+++ b/produce_response.go
@@ -179,6 +179,10 @@ func (r *ProduceResponse) requiredVersion() KafkaVersion {
 	return MinVersion
 }
 
+func (r *ProduceResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}
+
 func (r *ProduceResponse) GetBlock(topic string, partition int32) *ProduceResponseBlock {
 	if r.Blocks == nil {
 		return nil

--- a/sync_group_response.go
+++ b/sync_group_response.go
@@ -1,9 +1,11 @@
 package sarama
 
+import "time"
+
 type SyncGroupResponse struct {
 	// Version defines the protocol version to use for encode and decode
 	Version int16
-	// ThrottleTimeMs contains the duration in milliseconds for which the
+	// ThrottleTime contains the duration in milliseconds for which the
 	// request was throttled due to a quota violation, or zero if the request
 	// did not violate any quota.
 	ThrottleTime int32

--- a/sync_group_response.go
+++ b/sync_group_response.go
@@ -66,3 +66,7 @@ func (r *SyncGroupResponse) requiredVersion() KafkaVersion {
 	}
 	return V0_9_0_0
 }
+
+func (r *SyncGroupResponse) throttleTime() time.Duration {
+	return time.Duration(r.ThrottleTime) * time.Millisecond
+}

--- a/txn_offset_commit_response.go
+++ b/txn_offset_commit_response.go
@@ -85,3 +85,7 @@ func (a *TxnOffsetCommitResponse) headerVersion() int16 {
 func (a *TxnOffsetCommitResponse) requiredVersion() KafkaVersion {
 	return V0_11_0_0
 }
+
+func (r *TxnOffsetCommitResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}


### PR DESCRIPTION
This is PR is refactoring the current throttling metric support with a view to implementing throttling.

Currently, there were three different throttle time field implementations:
1. a `ThrottleTimeMs int32` field - for example, on `MetadataResponse`,
2. a `ThrottleTime int32` field - for example, on `LeaveGroupResponse`, and
3. a `ThrottleTime time.Duration` field - for example, on `ProduceResponse`.

It would be nice to make these more consistent but, since they are public fields, that would need to be a v2 change.
Therefore, in order to make progress now, this PR implements a common, private `throttleTime() time.Duration` method on all of the responses covered by the above three field types. The `updateThrottleMetric` implementation is then refactored to apply more generally to responses that have the new common method (via a trivial new interface `throttleSupport`).

This should make it possible to implement throttling support  - i.e. delaying future requests in accordance with KIP-219.

Two typos are also fixed - one related and one randomly spotted while in `broker.go`.