### PR TITLE
chore: rollup fvt kafka to latest three

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.19.x]
-        kafka-version: [2.8.2, 3.1.2, 3.2.3, 3.3.2]
+        kafka-version: [3.3.2, 3.4.1, 3.5.1]
     env:
       DEBUG: true
       GOFLAGS: -trimpath

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -18,10 +18,9 @@ RUN cd /etc/java/java-11-openjdk/*/conf/security \
 
 # https://github.com/apache/kafka/blob/53eeaad946cd053e9eb1a762972d4efeacb8e4fc/tests/docker/Dockerfile#L65-L69
 ARG KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
-RUN mkdir -p "/opt/kafka-2.8.2" && chmod a+rw /opt/kafka-2.8.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-2.8.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-2.8.2"
-RUN mkdir -p "/opt/kafka-3.1.2" && chmod a+rw /opt/kafka-3.1.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.1.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.1.2"
-RUN mkdir -p "/opt/kafka-3.2.3" && chmod a+rw /opt/kafka-3.2.3 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.2.3.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.2.3"
-RUN mkdir -p "/opt/kafka-3.3.2" && chmod a+rw /opt/kafka-3.3.2 && curl -s "$KAFKA_MIRROR/kafka_2.12-3.3.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.3.2"
+RUN mkdir -p "/opt/kafka-3.3.2" && chmod a+rw /opt/kafka-3.3.2 && curl -s "$KAFKA_MIRROR/kafka_2.13-3.3.2.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.3.2"
+RUN mkdir -p "/opt/kafka-3.4.1" && chmod a+rw /opt/kafka-3.4.1 && curl -s "$KAFKA_MIRROR/kafka_2.13-3.4.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.4.1"
+RUN mkdir -p "/opt/kafka-3.5.1" && chmod a+rw /opt/kafka-3.5.1 && curl -s "$KAFKA_MIRROR/kafka_2.13-3.5.1.tgz" | tar xz --strip-components=1 -C "/opt/kafka-3.5.1"
 
 COPY entrypoint.sh /
 

--- a/utils.go
+++ b/utils.go
@@ -194,6 +194,10 @@ var (
 	V3_3_0_0  = newKafkaVersion(3, 3, 0, 0)
 	V3_3_1_0  = newKafkaVersion(3, 3, 1, 0)
 	V3_3_2_0  = newKafkaVersion(3, 3, 2, 0)
+	V3_4_0_0  = newKafkaVersion(3, 4, 0, 0)
+	V3_4_1_0  = newKafkaVersion(3, 4, 1, 0)
+	V3_5_0_0  = newKafkaVersion(3, 5, 0, 0)
+	V3_5_1_0  = newKafkaVersion(3, 5, 1, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -250,12 +254,16 @@ var (
 		V3_3_0_0,
 		V3_3_1_0,
 		V3_3_2_0,
+		V3_4_0_0,
+		V3_4_1_0,
+		V3_5_0_0,
+		V3_5_1_0,
 	}
 	MinVersion     = V0_8_2_0
-	MaxVersion     = V3_3_2_0
+	MaxVersion     = V3_5_1_0
 	DefaultVersion = V1_0_0_0
 
-	// reduced set of versions to matrix test
+	// reduced set of protocol versions to matrix test
 	fvtRangeVersions = []KafkaVersion{
 		V0_8_2_2,
 		V0_10_2_2,


### PR DESCRIPTION
Also add KafkaVersion constants in utils.go