### PR TITLE
Fix printing of final metrics

### DIFF
--- a/tools/kafka-producer-performance/main.go
+++ b/tools/kafka-producer-performance/main.go
@@ -313,9 +313,6 @@ func main() {
 
 	cancel()
 	<-done
-
-	// Print final metrics.
-	printMetrics(os.Stdout, config.MetricRegistry)
 }
 
 func runAsyncProducer(topic string, partition, messageLoad, messageSize int,
@@ -325,6 +322,8 @@ func runAsyncProducer(topic string, partition, messageLoad, messageSize int,
 		printErrorAndExit(69, "Failed to create producer: %s", err)
 	}
 	defer func() {
+		// Print final metrics.
+		printMetrics(os.Stdout, config.MetricRegistry)
 		if err := producer.Close(); err != nil {
 			printErrorAndExit(69, "Failed to close producer: %s", err)
 		}
@@ -370,6 +369,8 @@ func runSyncProducer(topic string, partition, messageLoad, messageSize, routines
 		printErrorAndExit(69, "Failed to create producer: %s", err)
 	}
 	defer func() {
+		// Print final metrics.
+		printMetrics(os.Stdout, config.MetricRegistry)
 		if err := producer.Close(); err != nil {
 			printErrorAndExit(69, "Failed to close producer: %s", err)
 		}


### PR DESCRIPTION
For short test runs `kafka-producer-performance` may not print any metrics at all. This is fixed by moving the final call to `printMetrics` just before closing the producer. Calling `printMetrics` after the producer is closed does nothing as the producer metrics are unregistered as part of the close.