### PR TITLE
fix(proto): ensure req+resp requiredVersion match

### DIFF
--- a/describe_configs_request.go
+++ b/describe_configs_request.go
@@ -109,11 +109,13 @@ func (r *DescribeConfigsRequest) isValidVersion() bool {
 
 func (r *DescribeConfigsRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
-	case 1:
-		return V1_1_0_0
 	case 2:
 		return V2_0_0_0
-	default:
+	case 1:
+		return V1_1_0_0
+	case 0:
 		return V0_11_0_0
+	default:
+		return V2_0_0_0
 	}
 }

--- a/describe_configs_response.go
+++ b/describe_configs_response.go
@@ -122,12 +122,14 @@ func (r *DescribeConfigsResponse) isValidVersion() bool {
 
 func (r *DescribeConfigsResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
-	case 1:
-		return V1_0_0_0
 	case 2:
 		return V2_0_0_0
-	default:
+	case 1:
+		return V1_1_0_0
+	case 0:
 		return V0_11_0_0
+	default:
+		return V2_0_0_0
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -241,6 +241,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				resp := allocateResponseBody(req)
 				assert.NotNil(t, resp, fmt.Sprintf("%s has no matching response type in allocateResponseBody", reflect.TypeOf(req)))
 				assert.Equal(t, req.isValidVersion(), resp.isValidVersion(), fmt.Sprintf("%s isValidVersion should match %s", reflect.TypeOf(req), reflect.TypeOf(resp)))
+				assert.Equal(t, req.requiredVersion(), resp.requiredVersion(), fmt.Sprintf("%s requiredVersion should match %s", reflect.TypeOf(req), reflect.TypeOf(resp)))
 				for _, body := range []protocolBody{req, resp} {
 					assert.Equal(t, key, body.key())
 					assert.Equal(t, version, body.version())


### PR DESCRIPTION
Add a test to ensure that the requiredVersion of the request and response pairs matches. Accordingly fix DescribeConfigs which had a V1_0_0_0 instead of V1_1_0_0 bug for V1 in the Response