### PR TITLE
chore(proto): permit CreatePartitionsRequest V1

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -468,6 +468,9 @@ func (ca *clusterAdmin) CreatePartitions(topic string, count int32, assignment [
 		Timeout:         ca.conf.Admin.Timeout,
 		ValidateOnly:    validateOnly,
 	}
+	if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+		request.Version = 1
+	}
 
 	return ca.retryOnError(isErrNoController, func() error {
 		b, err := ca.Controller()

--- a/create_partitions_request.go
+++ b/create_partitions_request.go
@@ -73,11 +73,18 @@ func (r *CreatePartitionsRequest) headerVersion() int16 {
 }
 
 func (r *CreatePartitionsRequest) isValidVersion() bool {
-	return r.Version == 0
+	return r.Version >= 0 && r.Version <= 1
 }
 
 func (r *CreatePartitionsRequest) requiredVersion() KafkaVersion {
-	return V1_0_0_0
+	switch r.Version {
+	case 1:
+		return V2_0_0_0
+	case 0:
+		return V1_0_0_0
+	default:
+		return V2_0_0_0
+	}
 }
 
 type TopicPartition struct {

--- a/create_partitions_response.go
+++ b/create_partitions_response.go
@@ -69,11 +69,18 @@ func (r *CreatePartitionsResponse) headerVersion() int16 {
 }
 
 func (r *CreatePartitionsResponse) isValidVersion() bool {
-	return r.Version == 0
+	return r.Version >= 0 && r.Version <= 1
 }
 
 func (r *CreatePartitionsResponse) requiredVersion() KafkaVersion {
-	return V1_0_0_0
+	switch r.Version {
+	case 1:
+		return V2_0_0_0
+	case 0:
+		return V1_0_0_0
+	default:
+		return V2_0_0_0
+	}
 }
 
 func (r *CreatePartitionsResponse) throttleTime() time.Duration {

--- a/describe_configs_request.go
+++ b/describe_configs_request.go
@@ -109,11 +109,13 @@ func (r *DescribeConfigsRequest) isValidVersion() bool {
 
 func (r *DescribeConfigsRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
-	case 1:
-		return V1_1_0_0
 	case 2:
 		return V2_0_0_0
-	default:
+	case 1:
+		return V1_1_0_0
+	case 0:
 		return V0_11_0_0
+	default:
+		return V2_0_0_0
 	}
 }

--- a/describe_configs_response.go
+++ b/describe_configs_response.go
@@ -122,12 +122,14 @@ func (r *DescribeConfigsResponse) isValidVersion() bool {
 
 func (r *DescribeConfigsResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
-	case 1:
-		return V1_0_0_0
 	case 2:
 		return V2_0_0_0
-	default:
+	case 1:
+		return V1_1_0_0
+	case 0:
 		return V0_11_0_0
+	default:
+		return V2_0_0_0
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -241,6 +241,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				resp := allocateResponseBody(req)
 				assert.NotNil(t, resp, fmt.Sprintf("%s has no matching response type in allocateResponseBody", reflect.TypeOf(req)))
 				assert.Equal(t, req.isValidVersion(), resp.isValidVersion(), fmt.Sprintf("%s isValidVersion should match %s", reflect.TypeOf(req), reflect.TypeOf(resp)))
+				assert.Equal(t, req.requiredVersion(), resp.requiredVersion(), fmt.Sprintf("%s requiredVersion should match %s", reflect.TypeOf(req), reflect.TypeOf(resp)))
 				for _, body := range []protocolBody{req, resp} {
 					assert.Equal(t, key, body.key())
 					assert.Equal(t, version, body.version())


### PR DESCRIPTION
This is identical in format to V0, but just influences the broker's response behaviour:
> starting in version 1, on quota violation, brokers send out responses
> before throttling.