### PR TITLE
fix(test): test timing error

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -1484,8 +1484,8 @@ func Test_handleThrottledResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			broker.metricRegistry = metrics.NewRegistry()
 			broker.brokerThrottleTime = broker.registerHistogram("throttle-time-in-ms")
-			broker.handleThrottledResponse(tt.response)
 			startTime := time.Now()
+			broker.handleThrottledResponse(tt.response)
 			broker.waitIfThrottled()
 			if tt.expectDelay {
 				if time.Since(startTime) < throttleTime {


### PR DESCRIPTION
This test can fail at the moment because the timer is set up (slightly) before we start measuring the wait.
