### PR TITLE
fix: avoid logging value of proxy.Dialer

### DIFF
--- a/config.go
+++ b/config.go
@@ -856,7 +856,7 @@ func (c *Config) Validate() error {
 
 func (c *Config) getDialer() proxy.Dialer {
 	if c.Net.Proxy.Enable {
-		Logger.Printf("using proxy %s", c.Net.Proxy.Dialer)
+		Logger.Println("using proxy")
 		return c.Net.Proxy.Dialer
 	} else {
 		return &net.Dialer{


### PR DESCRIPTION
If Go's logging implementation is plugged into Sarama then it will introspect the contents of the Dialer, potentially giving rise to concurrent access to a map used to implement the dialer.

Fixes #2547