### PR TITLE
chore(proto): match HeartbeatResponse version

### DIFF
--- a/mockresponses.go
+++ b/mockresponses.go
@@ -1340,7 +1340,10 @@ func NewMockHeartbeatResponse(t TestReporter) *MockHeartbeatResponse {
 }
 
 func (m *MockHeartbeatResponse) For(reqBody versionedDecoder) encoderWithHeader {
-	resp := &HeartbeatResponse{}
+	req := reqBody.(*HeartbeatRequest)
+	resp := &HeartbeatResponse{
+		Version: req.version(),
+	}
 	return resp
 }
 


### PR DESCRIPTION
In mockresponses.go ensure we reply to a HeartbeatRequest with a matching Version of HeartbeatResponse