### PR TITLE
chore(ci): replace toxiproxy client dep

### DIFF
--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -14,9 +14,10 @@ import (
 	"testing"
 	"time"
 
-	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
 	"github.com/rcrowley/go-metrics"
 	"github.com/stretchr/testify/require"
+
+	"github.com/IBM/sarama/internal/toxiproxy"
 )
 
 const TestBatchSize = 1000

--- a/functional_test.go
+++ b/functional_test.go
@@ -456,7 +456,7 @@ func resetProxies(t testing.TB) {
 }
 
 func SaveProxy(t *testing.T, px string) {
-	if err := FunctionalTestEnv.Proxies[px].Save(); err != nil {
+	if _, err := FunctionalTestEnv.Proxies[px].Save(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/functional_test.go
+++ b/functional_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 	"time"
 
-	toxiproxy "github.com/Shopify/toxiproxy/v2/client"
+	"github.com/IBM/sarama/internal/toxiproxy"
 )
 
 const uncommittedTopic = "uncommitted-topic-test-4"

--- a/internal/toxiproxy/README.md
+++ b/internal/toxiproxy/README.md
@@ -1,0 +1,4 @@
+# toxiproxy
+
+A minimal client implementation to setup proxies and toxics in toxiproxy as used in the FV suite.
+We have our own minimal client implementation to avoid having to pull in the toxiproxy repo which carries a number of transitive dependencies.

--- a/internal/toxiproxy/client.go
+++ b/internal/toxiproxy/client.go
@@ -1,0 +1,19 @@
+package toxiproxy
+
+type Client struct{}
+
+func NewClient(endpoint string) *Client {
+	return &Client{}
+}
+
+func (c *Client) Proxy(name string) (*Proxy, error) {
+	return &Proxy{}, nil
+}
+
+func (c *Client) CreateProxy(name string, listenerAddr string, targetAddr string) (*Proxy, error) {
+	return &Proxy{}, nil
+}
+
+func (c *Client) ResetState() error {
+	return nil
+}

--- a/internal/toxiproxy/client.go
+++ b/internal/toxiproxy/client.go
@@ -1,19 +1,94 @@
 package toxiproxy
 
-type Client struct{}
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"time"
+)
+
+type Client struct {
+	httpClient *http.Client
+	endpoint   string
+}
 
 func NewClient(endpoint string) *Client {
-	return &Client{}
+	return &Client{
+		httpClient: &http.Client{
+			Transport: &http.Transport{
+				Proxy: http.ProxyFromEnvironment,
+				DialContext: (&net.Dialer{
+					Timeout:   30 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).DialContext,
+				ForceAttemptHTTP2:     true,
+				MaxIdleConns:          100,
+				IdleConnTimeout:       90 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ExpectContinueTimeout: 1 * time.Second,
+			},
+		},
+		endpoint: endpoint,
+	}
+}
+
+func (c *Client) CreateProxy(
+	name string,
+	listenAddr string,
+	targetAddr string,
+) (*Proxy, error) {
+	proxy := &Proxy{
+		Name:       name,
+		ListenAddr: listenAddr,
+		TargetAddr: targetAddr,
+		Enabled:    true,
+		client:     c,
+	}
+	return proxy.Save()
 }
 
 func (c *Client) Proxy(name string) (*Proxy, error) {
-	return &Proxy{}, nil
-}
+	req, err := http.NewRequest("GET", c.endpoint+"/proxies/"+name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make proxy request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to http get proxy: %w", err)
+	}
+	defer resp.Body.Close()
 
-func (c *Client) CreateProxy(name string, listenerAddr string, targetAddr string) (*Proxy, error) {
-	return &Proxy{}, nil
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("error getting proxy %s: %s %s", name, resp.Status, body)
+	}
+
+	var p Proxy
+	if err := json.NewDecoder(resp.Body).Decode(&p); err != nil {
+		return nil, fmt.Errorf("error decoding json for proxy %s: %w", name, err)
+	}
+	p.client = c
+
+	return &p, nil
 }
 
 func (c *Client) ResetState() error {
+	req, err := http.NewRequest("POST", c.endpoint+"/reset", http.NoBody)
+	if err != nil {
+		return fmt.Errorf("failed to make reset request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to http post reset: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 204 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("error resetting proxies: %s %s", resp.Status, body)
+	}
+
 	return nil
 }

--- a/internal/toxiproxy/proxy.go
+++ b/internal/toxiproxy/proxy.go
@@ -1,0 +1,23 @@
+package toxiproxy
+
+type Proxy struct {
+	Enabled bool
+}
+
+type Attributes map[string]int
+
+func (p *Proxy) AddToxic(name string, toxicType string, stream string, toxicity float32, attributes Attributes) (*Toxic, error) {
+	return &Toxic{}, nil
+}
+
+func (p *Proxy) Enable() error {
+	return nil
+}
+
+func (p *Proxy) Disable() error {
+	return nil
+}
+
+func (p *Proxy) Save() error {
+	return nil
+}

--- a/internal/toxiproxy/proxy.go
+++ b/internal/toxiproxy/proxy.go
@@ -1,23 +1,114 @@
 package toxiproxy
 
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
 type Proxy struct {
-	Enabled bool
+	client     *Client
+	Name       string `json:"name"`
+	ListenAddr string `json:"listen"`
+	TargetAddr string `json:"upstream"`
+	Enabled    bool   `json:"enabled"`
 }
 
 type Attributes map[string]int
 
-func (p *Proxy) AddToxic(name string, toxicType string, stream string, toxicity float32, attributes Attributes) (*Toxic, error) {
-	return &Toxic{}, nil
+func (p *Proxy) AddToxic(
+	name string,
+	toxicType string,
+	stream string,
+	toxicity float32,
+	attributes Attributes,
+) (*Toxic, error) {
+	toxic := &Toxic{
+		Name:       name,
+		Type:       toxicType,
+		Stream:     stream,
+		Toxicity:   toxicity,
+		Attributes: attributes,
+	}
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(&toxic); err != nil {
+		return nil, fmt.Errorf("failed to json encode toxic: %w", err)
+	}
+	body := bytes.NewReader(b.Bytes())
+
+	c := p.client
+	req, err := http.NewRequest("POST", c.endpoint+"/proxies/"+p.Name+"/toxics", body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make post toxic request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to http post toxic: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("error creating toxic %s: %s %s", name, resp.Status, body)
+	}
+
+	return toxic, nil
 }
 
 func (p *Proxy) Enable() error {
-	return nil
+	p.Enabled = true
+	_, err := p.Save()
+	return err
 }
 
 func (p *Proxy) Disable() error {
-	return nil
+	p.Enabled = false
+	_, err := p.Save()
+	return err
 }
 
-func (p *Proxy) Save() error {
-	return nil
+func (p *Proxy) Save() (*Proxy, error) {
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(&p); err != nil {
+		return nil, fmt.Errorf("failed to json encode proxy: %w", err)
+	}
+	body := bytes.NewReader(b.Bytes())
+
+	c := p.client
+	req, err := http.NewRequest("POST", c.endpoint+"/proxies/"+p.Name, body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make post proxy request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to http post proxy: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 404 {
+		if _, err := body.Seek(0, io.SeekStart); err != nil {
+			return nil, fmt.Errorf("failed to rewind post body: %w", err)
+		}
+		req, err = http.NewRequest("POST", c.endpoint+"/proxies", body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to make post proxy request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+		resp, err = c.httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to http post proxy: %w", err)
+		}
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("error saving proxy: %s %s", resp.Status, body)
+	}
+
+	return p, nil
 }

--- a/internal/toxiproxy/toxic.go
+++ b/internal/toxiproxy/toxic.go
@@ -1,3 +1,9 @@
 package toxiproxy
 
-type Toxic struct{}
+type Toxic struct {
+	Name       string     `json:"name"`
+	Type       string     `json:"type"`
+	Stream     string     `json:"stream,omitempty"`
+	Toxicity   float32    `json:"toxicity"`
+	Attributes Attributes `json:"attributes"`
+}

--- a/internal/toxiproxy/toxic.go
+++ b/internal/toxiproxy/toxic.go
@@ -1,0 +1,3 @@
+package toxiproxy
+
+type Toxic struct{}


### PR DESCRIPTION
The v2.5.0 client implementation happens to have a resource leak, and pulling in HEAD notably carries a large number of transitive dependencies that we don't really want to track in our go.mod just for FVT purposes. Therefore, knock up a minimal implementation of an http client for toxiproxy to satisfy our usage.