### PR TITLE
fix(test): add missing closes to admin client tests

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -41,7 +41,10 @@ func TestClusterAdminInvalidController(t *testing.T) {
 
 	config := NewTestConfig()
 	config.Version = V1_0_0_0
-	_, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
+	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
+	if admin != nil {
+		defer safeClose(t, admin)
+	}
 	if err == nil {
 		t.Fatal(errors.New("controller not set still cluster admin was created"))
 	}

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -23,6 +23,7 @@ func TestFuncAdminQuotas(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer safeClose(t, adminClient)
 
 	// Check that we can read the quotas, and that they are empty
 	quotas, err := adminClient.DescribeClientQuotas(nil, false)
@@ -143,6 +144,7 @@ func TestFuncAdminDescribeGroups(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer safeClose(t, adminClient)
 
 	config1 := NewFunctionalTestConfig()
 	config1.ClientID = "M1"

--- a/functional_consumer_staticmembership_test.go
+++ b/functional_consumer_staticmembership_test.go
@@ -46,6 +46,8 @@ func TestFuncConsumerGroupStaticMembership_Basic(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer safeClose(t, admin)
+
 	res, err := admin.DescribeConsumerGroups([]string{groupID})
 	if err != nil {
 		t.Fatal(err)
@@ -93,6 +95,8 @@ func TestFuncConsumerGroupStaticMembership_RejoinAndLeave(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer safeClose(t, admin)
+
 	res1, err := admin.DescribeConsumerGroups([]string{groupID})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
These were leaking goroutines