### PR TITLE
chore(ci): add goleak to TestMain

### DIFF
--- a/functional_test.go
+++ b/functional_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/goleak"
+
 	"github.com/IBM/sarama/internal/toxiproxy"
 )
 
@@ -68,6 +70,7 @@ func TestMain(m *testing.M) {
 }
 
 func testMain(m *testing.M) int {
+	defer goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/rcrowley/go-metrics.(*meterArbiter).tick"))
 	ctx := context.Background()
 	var env testEnvironment
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/stretchr/testify v1.8.4
 	github.com/xdg-go/scram v1.1.2
+	go.uber.org/goleak v1.2.1
 	golang.org/x/net v0.14.0
 	golang.org/x/sync v0.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3k
 github.com/xdg-go/stringprep v1.0.4 h1:XLI/Ng3O1Atzq0oBs3TWm+5ZVgkq2aqdlvP9JtoZ6c8=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=

--- a/mocks/mocks_test.go
+++ b/mocks/mocks_test.go
@@ -1,11 +1,6 @@
-//go:build !functional
-// +build !functional
-
-package sarama
+package mocks
 
 import (
-	"flag"
-	"log"
 	"os"
 	"testing"
 
@@ -18,9 +13,5 @@ func TestMain(m *testing.M) {
 
 func testMain(m *testing.M) int {
 	defer goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/rcrowley/go-metrics.(*meterArbiter).tick"))
-	flag.Parse()
-	if f := flag.Lookup("test.v"); f != nil && f.Value.String() == "true" {
-		Logger = log.New(os.Stderr, "[DEBUG] ", log.Lmicroseconds|log.Ltime)
-	}
 	return m.Run()
 }


### PR DESCRIPTION
Whilst this isn't as helpful as a per test `defer goleak.VerifyNone` in terms of showing _which_ test was responsible for the leak, it's still worth having as a baseline check in PRs and CI to prevent new leaks being introduced now that we're all cleaned up. If a PR fails we can subsequently run tests individually in order to determine which one is the leaker.

See https://github.com/uber-go/goleak#quick-start and https://github.com/uber-go/goleak#determine-source-of-package-leaks