### PR TITLE
chore: use go install for installing sarama tools

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -8,4 +8,4 @@ Some of these tools mirror tools that ship with Kafka, but these tools won't req
 - [kafka-console-consumer](./kafka-console-consumer): a command line tool to consume arbitrary partitions of a topic on your Kafka cluster.
 - [kafka-producer-performance](./kafka-producer-performance): a command line tool to performance test producers (sync and async) on your Kafka cluster.
 
-To install all tools, run `go get github.com/IBM/sarama/tools/...`
+To install all tools, run `go install github.com/IBM/sarama/tools/...@latest`


### PR DESCRIPTION
install using `go get` is deprecated. https://go.dev/doc/go-get-install-deprecation