### PR TITLE
fix(fvt): versioned cfg for invalid topic producer

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -38,10 +38,27 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Test (Functional)
+    - name: Setup Docker Compose
       run: |
         curl -sSL "https://github.com/docker/compose/releases/download/v2.20.3/docker-compose-$(uname -s)-$(uname -m)" -o /tmp/docker-compose
         sudo install -m755 /tmp/docker-compose "$(dirname $(which docker-compose))"
         docker version --format 'Docker Engine version v{{.Server.Version}}'
         docker-compose version
+    - name: Test (Functional)
+      run: |
+        nohup sudo tcpdump -i lo -w "fvt-kafka-${{ matrix.kafka-version }}.pcap" portrange 29091-29095 >/dev/null 2>&1 &
+        echo $! >tcpdump.pid
         make test_functional
+    - name: Stop tcpdump
+      if: always()
+      run: |
+        if [ -f "tcpdump.pid" ]; then sudo kill "$(cat tcpdump.pid)" || true; fi
+        if [ -f "fvt-kafka-${{ matrix.kafka-version }}.pcap" ]; then sudo chmod a+r "fvt-kafka-${{ matrix.kafka-version }}.pcap"; fi
+    - name: Upload pcap file
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        name: fvt-kafka-${{ matrix.kafka-version }}.pcap
+        path: fvt-kafka-${{ matrix.kafka-version }}.pcap
+        retention-days: 5
+        if-no-files-found: ignore

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -636,7 +636,9 @@ func TestFuncProducingToInvalidTopic(t *testing.T) {
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
 
-	producer, err := NewSyncProducer(FunctionalTestEnv.KafkaBrokerAddrs, nil)
+	config := NewFunctionalTestConfig()
+	config.Producer.Return.Successes = true
+	producer, err := NewSyncProducer(FunctionalTestEnv.KafkaBrokerAddrs, config)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -807,7 +809,6 @@ func testProducingMessages(t *testing.T, config *Config, minVersion KafkaVersion
 		}
 	}
 
-	config.ClientID = t.Name()
 	config.Producer.Return.Successes = true
 	config.Consumer.Return.Errors = true
 
@@ -822,7 +823,9 @@ func testProducingMessages(t *testing.T, config *Config, minVersion KafkaVersion
 	}
 
 	for version := range kafkaVersions {
-		t.Run(t.Name()+"-v"+version.String(), func(t *testing.T) {
+		name := t.Name() + "-v" + version.String()
+		t.Run(name, func(t *testing.T) {
+			config.ClientID = name
 			checkKafkaVersion(t, version.String())
 			config.Version = version
 			client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, config)


### PR DESCRIPTION
- also use per-versioned test name clientID in testProducingMessages helper