### PR TITLE
fix(fvt): fresh metrics registry for each test

### DIFF
--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -826,8 +826,10 @@ func testProducingMessages(t *testing.T, config *Config, minVersion KafkaVersion
 		name := t.Name() + "-v" + version.String()
 		t.Run(name, func(t *testing.T) {
 			config.ClientID = name
+			config.MetricRegistry = metrics.NewRegistry()
 			checkKafkaVersion(t, version.String())
 			config.Version = version
+
 			client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, config)
 			if err != nil {
 				t.Fatal(err)

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -1021,7 +1021,7 @@ func validateProducerMetrics(t *testing.T, client Client) {
 		// We record compression ratios of 1.00 (100 with a histogram) for every TestBatchSize record
 		if client.Config().Version.IsAtLeast(V0_11_0_0) {
 			// records will be grouped in batchSet rather than msgSet
-			metricValidators.registerForGlobalAndTopic("test_1", minCountHistogramValidator("compression-ratio", 4))
+			metricValidators.registerForGlobalAndTopic("test_1", minCountHistogramValidator("compression-ratio", 3))
 		} else {
 			metricValidators.registerForGlobalAndTopic("test_1", countHistogramValidator("compression-ratio", TestBatchSize))
 		}


### PR DESCRIPTION
Trying to nail down flakiness with the verification of metrics in these tests. Since adding the additional versions these have been flakey and I think the reason is that the registry is getting re-used between tests as it is only created fresh on a call to NewConfig