### PR TITLE
chore(lint): bump golangci-lint and tweak config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         GOFLAGS: -tags=functional
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.54.0
+        version: v1.54.2
   test:
     name: Unit Testing with Go ${{ matrix.go-version }}
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,18 +23,24 @@ linters-settings:
   gocritic:
     enabled-tags:
       - diagnostic
+      - performance
       # - experimental
       # - opinionated
-      # - performance
       # - style
+    enabled-checks:
+      - importShadow
+      - nestingReduce
+      - stringsCompare
+      # - unnamedResult
+      # - whyNoLint
     disabled-checks:
       - assignOp
       - appendAssign
       - commentedOutCode
+      - hugeParam
       - ifElseChain
       - singleCaseSwitch
       - sloppyReassign
-      - wrapperFunc
   funlen:
     lines: 300
     statements: 300
@@ -50,37 +56,25 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    # - deadcode
     - depguard
     - exportloopref
     - dogsled
-    # - dupl
     - errcheck
     - errorlint
     - funlen
     - gochecknoinits
-    # - goconst
     - gocritic
     - gocyclo
     - gofmt
     - goimports
-    # - golint
     - gosec
-    # - gosimple
     - govet
-    # - ineffassign
     - misspell
-    # - nakedret
     - nilerr
-    # - paralleltest
-    # - scopelint
     - staticcheck
-    # - structcheck
-    # - stylecheck
     - typecheck
     - unconvert
     - unused
-    # - varcheck
     - whitespace
 
 issues:

--- a/admin.go
+++ b/admin.go
@@ -404,6 +404,7 @@ func (ca *clusterAdmin) ListTopics() (map[string]TopicDetail, error) {
 		topicDetails.ConfigEntries = make(map[string]*string)
 
 		for _, entry := range resource.Configs {
+			entry := entry
 			// only include non-default non-sensitive config
 			// (don't actually think topic config will ever be sensitive)
 			if entry.Default || entry.Sensitive {

--- a/async_producer.go
+++ b/async_producer.go
@@ -20,7 +20,6 @@ import (
 // leaks and message lost: it will not be garbage-collected automatically when it passes
 // out of scope and buffered messages may not be flushed.
 type AsyncProducer interface {
-
 	// AsyncClose triggers a shutdown of the producer. The shutdown has completed
 	// when both the Errors and Successes channels have been closed. When calling
 	// AsyncClose, you *must* continue to read from those channels in order to
@@ -366,17 +365,17 @@ func (p *asyncProducer) Close() error {
 		})
 	}
 
-	var errors ProducerErrors
+	var pErrs ProducerErrors
 	if p.conf.Producer.Return.Errors {
 		for event := range p.errors {
-			errors = append(errors, event)
+			pErrs = append(pErrs, event)
 		}
 	} else {
 		<-p.errors
 	}
 
-	if len(errors) > 0 {
-		return errors
+	if len(pErrs) > 0 {
+		return pErrs
 	}
 	return nil
 }

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -66,12 +66,12 @@ func closeProducer(t *testing.T, p AsyncProducer) {
 	closeProducerWithTimeout(t, p, 5*time.Minute)
 }
 
-func expectResultsWithTimeout(t *testing.T, p AsyncProducer, successes, errors int, timeout time.Duration) {
+func expectResultsWithTimeout(t *testing.T, p AsyncProducer, successCount, errorCount int, timeout time.Duration) {
 	t.Helper()
-	expect := successes + errors
+	expect := successCount + errorCount
 	defer func() {
-		if successes != 0 || errors != 0 {
-			t.Error("Unexpected successes", successes, "or errors", errors)
+		if successCount != 0 || errorCount != 0 {
+			t.Error("Unexpected successes", successCount, "or errors", errorCount)
 		}
 	}()
 	timer := time.NewTimer(timeout)
@@ -84,26 +84,26 @@ func expectResultsWithTimeout(t *testing.T, p AsyncProducer, successes, errors i
 			if msg.Msg.flags != 0 {
 				t.Error("Message had flags set")
 			}
-			errors--
+			errorCount--
 			expect--
-			if errors < 0 {
+			if errorCount < 0 {
 				t.Error(msg.Err)
 			}
 		case msg := <-p.Successes():
 			if msg.flags != 0 {
 				t.Error("Message had flags set")
 			}
-			successes--
+			successCount--
 			expect--
-			if successes < 0 {
+			if successCount < 0 {
 				t.Error("Too many successes")
 			}
 		}
 	}
 }
 
-func expectResults(t *testing.T, p AsyncProducer, successes, errors int) {
-	expectResultsWithTimeout(t, p, successes, errors, 5*time.Minute)
+func expectResults(t *testing.T, p AsyncProducer, successCount, errorCount int) {
+	expectResultsWithTimeout(t, p, successCount, errorCount, 5*time.Minute)
 }
 
 type testPartitioner chan *int32

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -1004,20 +1004,21 @@ func (p *partitionMovements) isLinked(src, dst string, pairs []consumerPair, cur
 	}
 
 	for _, pair := range pairs {
-		if pair.SrcMemberID == src {
-			// create a deep copy of the pairs, excluding the current pair
-			reducedSet := make([]consumerPair, len(pairs)-1)
-			i := 0
-			for _, p := range pairs {
-				if p != pair {
-					reducedSet[i] = pair
-					i++
-				}
-			}
-
-			currentPath = append(currentPath, pair.SrcMemberID)
-			return p.isLinked(pair.DstMemberID, dst, reducedSet, currentPath)
+		if pair.SrcMemberID != src {
+			continue
 		}
+		// create a deep copy of the pairs, excluding the current pair
+		reducedSet := make([]consumerPair, len(pairs)-1)
+		i := 0
+		for _, p := range pairs {
+			if p != pair {
+				reducedSet[i] = pair
+				i++
+			}
+		}
+
+		currentPath = append(currentPath, pair.SrcMemberID)
+		return p.isLinked(pair.DstMemberID, dst, reducedSet, currentPath)
 	}
 	return currentPath, false
 }
@@ -1117,7 +1118,7 @@ func (pq assignmentPriorityQueue) Len() int { return len(pq) }
 func (pq assignmentPriorityQueue) Less(i, j int) bool {
 	// order assignment priority queue in descending order using assignment-count/member-id
 	if len(pq[i].assignments) == len(pq[j].assignments) {
-		return strings.Compare(pq[i].id, pq[j].id) > 0
+		return pq[i].id > pq[j].id
 	}
 	return len(pq[i].assignments) > len(pq[j].assignments)
 }

--- a/broker.go
+++ b/broker.go
@@ -1480,7 +1480,7 @@ func (b *Broker) sendAndReceiveSASLSCRAMv0() error {
 		length := len(msg)
 		authBytes := make([]byte, length+4) // 4 byte length header + auth data
 		binary.BigEndian.PutUint32(authBytes, uint32(length))
-		copy(authBytes[4:], []byte(msg))
+		copy(authBytes[4:], msg)
 		_, err := b.write(authBytes)
 		b.updateOutgoingCommunicationMetrics(length + 4)
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -553,17 +553,17 @@ func (client *client) RefreshMetadata(topics ...string) error {
 	return client.tryRefreshMetadata(topics, client.conf.Metadata.Retry.Max, deadline)
 }
 
-func (client *client) GetOffset(topic string, partitionID int32, time int64) (int64, error) {
+func (client *client) GetOffset(topic string, partitionID int32, timestamp int64) (int64, error) {
 	if client.Closed() {
 		return -1, ErrClosedClient
 	}
 
-	offset, err := client.getOffset(topic, partitionID, time)
+	offset, err := client.getOffset(topic, partitionID, timestamp)
 	if err != nil {
 		if err := client.RefreshMetadata(topic); err != nil {
 			return -1, err
 		}
-		return client.getOffset(topic, partitionID, time)
+		return client.getOffset(topic, partitionID, timestamp)
 	}
 
 	return offset, err
@@ -905,7 +905,7 @@ func (client *client) cachedLeader(topic string, partitionID int32) (*Broker, in
 	return nil, -1, ErrUnknownTopicOrPartition
 }
 
-func (client *client) getOffset(topic string, partitionID int32, time int64) (int64, error) {
+func (client *client) getOffset(topic string, partitionID int32, timestamp int64) (int64, error) {
 	broker, err := client.Leader(topic, partitionID)
 	if err != nil {
 		return -1, err
@@ -927,7 +927,7 @@ func (client *client) getOffset(topic string, partitionID int32, time int64) (in
 		request.Version = 1
 	}
 
-	request.AddBlock(topic, partitionID, time, 1)
+	request.AddBlock(topic, partitionID, timestamp, 1)
 
 	response, err := broker.GetAvailableOffsets(request)
 	if err != nil {

--- a/metrics.go
+++ b/metrics.go
@@ -32,7 +32,7 @@ func getMetricNameForBroker(name string, broker *Broker) string {
 func getMetricNameForTopic(name string, topic string) string {
 	// Convert dot to _ since reporters like Graphite typically use dot to represent hierarchy
 	// cf. KAFKA-1902 and KAFKA-2337
-	return fmt.Sprintf(name+"-for-topic-%s", strings.Replace(topic, ".", "_", -1))
+	return fmt.Sprintf(name+"-for-topic-%s", strings.ReplaceAll(topic, ".", "_"))
 }
 
 func getOrRegisterTopicMeter(name string, topic string, r metrics.Registry) metrics.Meter {

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -253,7 +253,7 @@ func (mor *MockOffsetResponse) For(reqBody versionedDecoder) encoderWithHeader {
 	offsetResponse := &OffsetResponse{Version: offsetRequest.Version}
 	for topic, partitions := range offsetRequest.blocks {
 		for partition, block := range partitions {
-			offset := mor.getOffset(topic, partition, block.time)
+			offset := mor.getOffset(topic, partition, block.timestamp)
 			offsetResponse.AddTopicPartition(topic, partition, offset)
 		}
 	}

--- a/record_test.go
+++ b/record_test.go
@@ -232,6 +232,7 @@ func recordBatchTestCases() []struct {
 
 func TestRecordBatchEncoding(t *testing.T) {
 	for _, tc := range recordBatchTestCases() {
+		tc := tc
 		testEncodable(t, tc.name, &tc.batch, tc.encoded)
 	}
 }


### PR DESCRIPTION
- bump golangci-lint to v1.54.2
- enable a few additional gocritic checks
- fix the association linter warnings