### PR TITLE
fix: make clear that error is configuration issue not server error

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -449,8 +449,10 @@ func (p *asyncProducer) dispatcher() {
 			p.returnError(msg, ConfigurationError("Producing headers requires Kafka at least v0.11"))
 			continue
 		}
-		if msg.ByteSize(version) > p.conf.Producer.MaxMessageBytes {
-			p.returnError(msg, ErrMessageSizeTooLarge)
+
+		size := msg.ByteSize(version)
+		if size > p.conf.Producer.MaxMessageBytes {
+			p.returnError(msg, ConfigurationError(fmt.Sprintf("Attempt to produce message larger than configured Producer.MaxMessageBytes: %d > %d", size, p.conf.Producer.MaxMessageBytes)))
 			continue
 		}
 


### PR DESCRIPTION
Since we already return a `ConfigurationError` on line 449 it should be reasonable to return one here rather than returning an error that suggests that the server has rejected the message.

Fixes #1225