### PR TITLE
fix(client): force Event Hubs to use V1_0_0_0

### DIFF
--- a/client.go
+++ b/client.go
@@ -183,6 +183,13 @@ func NewClient(addrs []string, conf *Config) (Client, error) {
 		return nil, ConfigurationError("You must provide at least one broker address")
 	}
 
+	if strings.Contains(addrs[0], ".servicebus.windows.net") {
+		if conf.Version.IsAtLeast(V1_1_0_0) || !conf.Version.IsAtLeast(V0_11_0_0) {
+			Logger.Println("Connecting to Azure Event Hubs, forcing version to V1_0_0_0 for compatibility")
+			conf.Version = V1_0_0_0
+		}
+	}
+
 	client := &client{
 		conf:                    conf,
 		closer:                  make(chan none),


### PR DESCRIPTION
The problem with supporting Azure Event Hubs is that it isn't Apache Kafka under the covers, it's an intermediate proxy that supports a subset of the Kafka APIs at various versions and then maps them onto Event Hubs protocol(s) at the backend. As as result Sarama's current mechanism of specifying the KAFKA_VERSION to determine what protocol versions to support and use doesn't really work properly with Event Hubs because it supports an unusual set of protocols and even defines minimum versions for ProduceRequest (v3) and FetchRequest (v4). For some reason EventHubs is very behind on FetchRequest and MetadataRequest so the max configuration you can use in Sarama is V1_0_0_0 and the minimum is V0_11_0_0.

As we have recently bumped the default Version to V2_1_0_0 and support a wider range of protocol versions, we're more likely to see issues raised by Event Hubs users unless they have already pinned their version correctly. To try and prevent this, attempt to detect use with Event Hubs by inspecting the bootstrap broker addresses and overriding the Version.

Contributes-to: #2470