### PR TITLE
feat(consumer): return err from offsets commit

### DIFF
--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -263,7 +263,9 @@ func TestFuncConsumerGroupOffsetDeletion(t *testing.T) {
 	defer safeClose(t, offsetMgr)
 	markOffset(t, offsetMgr, "test.1", 0, 1)
 	markOffset(t, offsetMgr, "test.4", 0, 2)
-	offsetMgr.Commit()
+	if err := offsetMgr.Commit(); err != nil {
+		t.Fatal(err)
+	}
 
 	admin, err := NewClusterAdminFromClient(client)
 	if err != nil {

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -213,7 +213,10 @@ func TestNewOffsetManagerOffsetsManualCommit(t *testing.T) {
 	// Setup again to test manual commit
 	called = make(chan none)
 
-	om.Commit()
+	err := om.Commit()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	select {
 	case <-called:


### PR DESCRIPTION
This changes the `ConsumerGroupSession` and `OffsetManager` interface in a way that’s compatible for users of these interfaces, but incompatible for implementers.

Contributes-to: IBM/sarama#2417