### PR TITLE
fix: use least loaded broker to refresh metadata

### DIFF
--- a/admin_test.go
+++ b/admin_test.go
@@ -1712,11 +1712,15 @@ func TestRefreshMetaDataWithDifferentController(t *testing.T) {
 			seedBroker1.BrokerID(), b.ID())
 	}
 
+	metadataResponse := NewMockMetadataResponse(t).
+		SetController(seedBroker2.BrokerID()).
+		SetBroker(seedBroker1.Addr(), seedBroker1.BrokerID()).
+		SetBroker(seedBroker2.Addr(), seedBroker2.BrokerID())
 	seedBroker1.SetHandlerByMap(map[string]MockResponse{
-		"MetadataRequest": NewMockMetadataResponse(t).
-			SetController(seedBroker2.BrokerID()).
-			SetBroker(seedBroker1.Addr(), seedBroker1.BrokerID()).
-			SetBroker(seedBroker2.Addr(), seedBroker2.BrokerID()),
+		"MetadataRequest": metadataResponse,
+	})
+	seedBroker2.SetHandlerByMap(map[string]MockResponse{
+		"MetadataRequest": metadataResponse,
 	})
 
 	if b, _ := ca.refreshController(); seedBroker2.BrokerID() != b.ID() {

--- a/functional_test.go
+++ b/functional_test.go
@@ -228,7 +228,7 @@ mainLoop:
 			}
 			for _, broker := range brokers {
 				err := broker.Open(client.Config())
-				if err != nil {
+				if err != nil && !errors.Is(err, ErrAlreadyConnected) {
 					client.Close()
 					continue retryLoop
 				}

--- a/mockbroker.go
+++ b/mockbroker.go
@@ -98,6 +98,20 @@ func (b *MockBroker) SetHandlerByMap(handlerMap map[string]MockResponse) {
 	})
 }
 
+// SetHandlerFuncByMap defines mapping of Request types to RequestHandlerFunc. When a
+// request is received by the broker, it looks up the request type in the map
+// and invoke the found RequestHandlerFunc instance to generate an appropriate reply.
+func (b *MockBroker) SetHandlerFuncByMap(handlerMap map[string]requestHandlerFunc) {
+	fnMap := make(map[string]requestHandlerFunc)
+	for k, v := range handlerMap {
+		fnMap[k] = v
+	}
+	b.setHandler(func(req *request) (res encoderWithHeader) {
+		reqTypeName := reflect.TypeOf(req.body).Elem().Name()
+		return fnMap[reqTypeName](req)
+	})
+}
+
 // SetNotifier set a function that will get invoked whenever a request has been
 // processed successfully and will provide the number of bytes read and written
 func (b *MockBroker) SetNotifier(notifier RequestNotifierFunc) {

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -37,7 +37,7 @@ func initOffsetManagerWithBackoffFunc(
 		t.Fatal(err)
 	}
 
-	broker.Returns(&ConsumerMetadataResponse{
+	coordinator.Returns(&ConsumerMetadataResponse{
 		CoordinatorID:   coordinator.BrokerID(),
 		CoordinatorHost: "127.0.0.1",
 		CoordinatorPort: coordinator.Port(),
@@ -251,7 +251,7 @@ func TestOffsetManagerFetchInitialFail(t *testing.T) {
 	// Refresh coordinator
 	newCoordinator := NewMockBroker(t, 3)
 	defer newCoordinator.Close()
-	broker.Returns(&ConsumerMetadataResponse{
+	coordinator.Returns(&ConsumerMetadataResponse{
 		CoordinatorID:   newCoordinator.BrokerID(),
 		CoordinatorHost: "127.0.0.1",
 		CoordinatorPort: newCoordinator.Port(),
@@ -492,36 +492,34 @@ func TestPartitionOffsetManagerCommitErr(t *testing.T) {
 	ocResponse.AddError("my_topic", 1, ErrNoError)
 	coordinator.Returns(ocResponse)
 
-	newCoordinator := NewMockBroker(t, 3)
-	defer newCoordinator.Close()
-
 	// For RefreshCoordinator()
-	broker.Returns(&ConsumerMetadataResponse{
-		CoordinatorID:   newCoordinator.BrokerID(),
+	coordinator.Returns(&ConsumerMetadataResponse{
+		CoordinatorID:   coordinator.BrokerID(),
 		CoordinatorHost: "127.0.0.1",
-		CoordinatorPort: newCoordinator.Port(),
+		CoordinatorPort: coordinator.Port(),
 	})
 
 	// Nothing in response.Errors at all
 	ocResponse2 := new(OffsetCommitResponse)
-	newCoordinator.Returns(ocResponse2)
+	coordinator.Returns(ocResponse2)
 
 	// No error, no need to refresh coordinator
 
 	// Error on the wrong partition for this pom
 	ocResponse3 := new(OffsetCommitResponse)
 	ocResponse3.AddError("my_topic", 1, ErrNoError)
-	newCoordinator.Returns(ocResponse3)
-
-	// No error, no need to refresh coordinator
+	coordinator.Returns(ocResponse3)
 
 	// ErrUnknownTopicOrPartition/ErrNotLeaderForPartition/ErrLeaderNotAvailable block
 	ocResponse4 := new(OffsetCommitResponse)
 	ocResponse4.AddError("my_topic", 0, ErrUnknownTopicOrPartition)
-	newCoordinator.Returns(ocResponse4)
+	coordinator.Returns(ocResponse4)
+
+	newCoordinator := NewMockBroker(t, 3)
+	defer newCoordinator.Close()
 
 	// For RefreshCoordinator()
-	broker.Returns(&ConsumerMetadataResponse{
+	coordinator.Returns(&ConsumerMetadataResponse{
 		CoordinatorID:   newCoordinator.BrokerID(),
 		CoordinatorHost: "127.0.0.1",
 		CoordinatorPort: newCoordinator.Port(),

--- a/sync_producer_test.go
+++ b/sync_producer_test.go
@@ -89,7 +89,7 @@ func TestSyncProducerTransactional(t *testing.T) {
 	findCoordinatorResponse := new(FindCoordinatorResponse)
 	findCoordinatorResponse.Coordinator = client.Brokers()[0]
 	findCoordinatorResponse.Version = 1
-	seedBroker.Returns(findCoordinatorResponse)
+	leader.Returns(findCoordinatorResponse)
 
 	initProducerIdResponse := new(InitProducerIDResponse)
 	leader.Returns(initProducerIdResponse)


### PR DESCRIPTION
Seed brokers never change after client initialization. If the first seed
broker became stale (still online, but moved to other Kafka cluster),
Sarama client may use this stale broker to get the wrong metadata. To
avoid using the stale broker to do metadata refresh, we will choose the
least loaded broker in the cached broker list which is the similar to
how the Java client implementation works:

https://github.com/apache/kafka/blob/7483991a/clients/src/main/java/org/apache/kafka/clients/NetworkClient.java#L671-L736

Contributes-to: https://github.com/IBM/sarama/issues/2637