### PR TITLE
fix: pre-compile regex for parsing kafka version

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -281,8 +281,11 @@ var (
 )
 
 var (
-	validKafkaVersion1 = regexp.MustCompile(`^0\.\d+\.\d+\.\d+$`)
-	validKafkaVersion2 = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	// This regex validates that a string complies with the pre kafka 1.0.0 format for version strings, for example 0.11.0.3
+	validPreKafka1Version = regexp.MustCompile(`^0\.\d+\.\d+\.\d+$`)
+
+	// This regex validates that a string complies with the post Kafka 1.0.0 format, for example 1.0.0
+	validPostKafka1Version = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
 )
 
 // ParseKafkaVersion parses and returns kafka version or error from a string
@@ -293,9 +296,9 @@ func ParseKafkaVersion(s string) (KafkaVersion, error) {
 	var major, minor, veryMinor, patch uint
 	var err error
 	if s[0] == '0' {
-		err = scanKafkaVersion(s, validKafkaVersion1, "0.%d.%d.%d", [3]*uint{&minor, &veryMinor, &patch})
+		err = scanKafkaVersion(s, validPreKafka1Version, "0.%d.%d.%d", [3]*uint{&minor, &veryMinor, &patch})
 	} else {
-		err = scanKafkaVersion(s, validKafkaVersion2, "%d.%d.%d", [3]*uint{&major, &minor, &veryMinor})
+		err = scanKafkaVersion(s, validPostKafka1Version, "%d.%d.%d", [3]*uint{&major, &minor, &veryMinor})
 	}
 	if err != nil {
 		return DefaultVersion, err

--- a/utils.go
+++ b/utils.go
@@ -280,6 +280,11 @@ var (
 	}
 )
 
+var (
+	validKafkaVersion1 = regexp.MustCompile(`^0\.\d+\.\d+\.\d+$`)
+	validKafkaVersion2 = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+)
+
 // ParseKafkaVersion parses and returns kafka version or error from a string
 func ParseKafkaVersion(s string) (KafkaVersion, error) {
 	if len(s) < 5 {
@@ -288,9 +293,9 @@ func ParseKafkaVersion(s string) (KafkaVersion, error) {
 	var major, minor, veryMinor, patch uint
 	var err error
 	if s[0] == '0' {
-		err = scanKafkaVersion(s, `^0\.\d+\.\d+\.\d+$`, "0.%d.%d.%d", [3]*uint{&minor, &veryMinor, &patch})
+		err = scanKafkaVersion(s, validKafkaVersion1, "0.%d.%d.%d", [3]*uint{&minor, &veryMinor, &patch})
 	} else {
-		err = scanKafkaVersion(s, `^\d+\.\d+\.\d+$`, "%d.%d.%d", [3]*uint{&major, &minor, &veryMinor})
+		err = scanKafkaVersion(s, validKafkaVersion2, "%d.%d.%d", [3]*uint{&major, &minor, &veryMinor})
 	}
 	if err != nil {
 		return DefaultVersion, err
@@ -298,8 +303,8 @@ func ParseKafkaVersion(s string) (KafkaVersion, error) {
 	return newKafkaVersion(major, minor, veryMinor, patch), nil
 }
 
-func scanKafkaVersion(s string, pattern string, format string, v [3]*uint) error {
-	if !regexp.MustCompile(pattern).MatchString(s) {
+func scanKafkaVersion(s string, pattern *regexp.Regexp, format string, v [3]*uint) error {
+	if !pattern.MatchString(s) {
 		return fmt.Errorf("invalid version `%s`", s)
 	}
 	_, err := fmt.Sscanf(s, format, v[0], v[1], v[2])


### PR DESCRIPTION
Fix compiling regular pattern redundantly to optimize CPU usage.

Fixes #2662