### PR TITLE
Fix: Update version parsing logic and clean up go warning

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -196,7 +196,7 @@ func TestBrokerFailedRequest(t *testing.T) {
 	}
 }
 
-var ErrTokenFailure = errors.New("Failure generating token")
+var errTokenFailure = errors.New("failure generating token")
 
 type TokenProvider struct {
 	accessToken *AccessToken
@@ -268,7 +268,7 @@ func TestSASLOAuthBearer(t *testing.T) {
 			mockSASLAuthResponse: NewMockSaslAuthenticateResponse(t),
 			expectClientErr:      true,
 			expectedBrokerError:  ErrNoError,
-			tokProvider:          newTokenProvider(&AccessToken{Token: "access-token-123"}, ErrTokenFailure),
+			tokProvider:          newTokenProvider(&AccessToken{Token: "access-token-123"}, errTokenFailure),
 		},
 		{
 			name: "SASL/OAUTHBEARER invalid extension",

--- a/utils.go
+++ b/utils.go
@@ -281,11 +281,8 @@ var (
 )
 
 var (
-	// This regex validates that a string complies with the pre kafka 1.0.0 format for version strings, for example 0.11.0.3
-	validPreKafka1Version = regexp.MustCompile(`^0\.\d+\.\d+\.\d+$`)
-
 	// This regex validates that a string complies with the post Kafka 1.0.0 format, for example 1.0.0
-	validPostKafka1Version = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+	validPostKafka1Version = regexp.MustCompile(`^[1-9]+\.\d+\.\d+$`)
 )
 
 // ParseKafkaVersion parses and returns kafka version or error from a string
@@ -295,23 +292,15 @@ func ParseKafkaVersion(s string) (KafkaVersion, error) {
 	}
 	var major, minor, veryMinor, patch uint
 	var err error
-	if s[0] == '0' {
-		err = scanKafkaVersion(s, validPreKafka1Version, "0.%d.%d.%d", [3]*uint{&minor, &veryMinor, &patch})
+	if validPostKafka1Version.MatchString(s) {
+		_, err = fmt.Sscanf(s, "%d.%d.%d", &major, &minor, &veryMinor)
 	} else {
-		err = scanKafkaVersion(s, validPostKafka1Version, "%d.%d.%d", [3]*uint{&major, &minor, &veryMinor})
+		_, err = fmt.Sscanf(s, "0.%d.%d.%d", &minor, &veryMinor, &patch)
 	}
 	if err != nil {
-		return DefaultVersion, err
+		return DefaultVersion, fmt.Errorf("invalid version `%s`", s)
 	}
 	return newKafkaVersion(major, minor, veryMinor, patch), nil
-}
-
-func scanKafkaVersion(s string, pattern *regexp.Regexp, format string, v [3]*uint) error {
-	if !pattern.MatchString(s) {
-		return fmt.Errorf("invalid version `%s`", s)
-	}
-	_, err := fmt.Sscanf(s, format, v[0], v[1], v[2])
-	return err
 }
 
 func (v KafkaVersion) String() string {


### PR DESCRIPTION
The intention of this PR is to clean up the version parsing logic as we didn't need to use a function for such a trivial job, this should both improve performance and code clarity.

I also cleaned up a minor code quality warning where an error string was capitalized and  the variable was public, it is now private and not capitalized 