### PR TITLE
fix(ci): always run CodeQL on every commit

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,13 +4,9 @@ on:
   push:
     branches:
     - main
-    paths-ignore:
-    - '**/*.md'
   pull_request:
     branches:
     - "**"
-    paths-ignore:
-    - '**/*.md'
   schedule:
   - cron: "39 12 * * 1"
 


### PR DESCRIPTION
Scorecard checks expect that every commit is checked, regardless of content. The check is fairly quick to run so just go ahead and always run it.