### PR TITLE
Asynchronously close brokers during a RefreshBrokers

### DIFF
--- a/client.go
+++ b/client.go
@@ -519,16 +519,16 @@ func (client *client) RefreshBrokers(addrs []string) error {
 	defer client.lock.Unlock()
 
 	for _, broker := range client.brokers {
-		_ = broker.Close()
-		delete(client.brokers, broker.ID())
+		safeAsyncClose(broker)
 	}
+	client.brokers = make(map[int32]*Broker)
 
 	for _, broker := range client.seedBrokers {
-		_ = broker.Close()
+		safeAsyncClose(broker)
 	}
 
 	for _, broker := range client.deadSeeds {
-		_ = broker.Close()
+		safeAsyncClose(broker)
 	}
 
 	client.seedBrokers = nil


### PR DESCRIPTION
In production, we noticed that calling RefreshBrokers could take some time before closing the channels, which could cause a bottleneck on the producer.

This PR enables asynchronous closure of brokers (fire and forget) to make the client available as quickly as possible.

We have tested this modification in production, and the results have been satisfactory.