### PR TITLE
Fix data race on Broker.done channel

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -260,6 +260,7 @@ func (b *Broker) Open(conf *Config) error {
 			b.connErr = b.authenticateViaSASLv1()
 			if b.connErr != nil {
 				close(b.responses)
+				<-b.done
 				err = b.conn.Close()
 				if err == nil {
 					DebugLogger.Printf("Closed connection to broker %s\n", b.addr)


### PR DESCRIPTION
The underlying case was not waiting for the goroutine running the `responseReceiver()` method to fully complete if SASL authentication failed. This created a window where a further call to `Broker.Open()` could overwrite the `Broker.done` channel value while the goroutine still running `responseReceiver()` was trying to close the same channel.

Fixes: #2382