### PR TITLE
fix: prevent ConsumerGroup.Close infinitely locking

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -213,8 +213,11 @@ func (c *consumerGroup) Consume(ctx context.Context, topics []string, handler Co
 		return err
 	}
 
-	// Wait for session exit signal
-	<-sess.ctx.Done()
+	// Wait for session exit signal or Close() call
+	select {
+	case <-c.closed:
+	case <-sess.ctx.Done():
+	}
 
 	// Gracefully release session claims
 	return sess.release(true)


### PR DESCRIPTION
If context isn't cancelled, ConsumerGroup.Close can indefinitely lock on waiting for `c.lock` inside `c.leave()` which is holden by the `Consume` method.
