### PR TITLE
feat: export NewKerberosClientFunc to config for allow custom client

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1295,8 +1295,8 @@ func (b *Broker) authenticateViaSASLv1() error {
 
 func (b *Broker) sendAndReceiveKerberos() error {
 	b.kerberosAuthenticator.Config = &b.conf.Net.SASL.GSSAPI
-	if b.kerberosAuthenticator.NewKerberosClientFunc == nil {
-		b.kerberosAuthenticator.NewKerberosClientFunc = NewKerberosClient
+	if b.kerberosAuthenticator.Config.NewKerberosClientFunc == nil {
+		b.kerberosAuthenticator.Config.NewKerberosClientFunc = NewKerberosClient
 	}
 	return b.kerberosAuthenticator.Authorize(b)
 }

--- a/broker_test.go
+++ b/broker_test.go
@@ -723,14 +723,14 @@ func TestGSSAPIKerberosAuth_Authorize(t *testing.T) {
 			}
 			mockBroker.SetGSSAPIHandler(gssapiHandler.MockKafkaGSSAPI)
 			if test.mockKerberosClient {
-				broker.kerberosAuthenticator.NewKerberosClientFunc = func(config *GSSAPIConfig) (KerberosClient, error) {
+				conf.Net.SASL.GSSAPI.NewKerberosClientFunc = func(config *GSSAPIConfig) (KerberosClient, error) {
 					return &MockKerberosClient{
 						mockError:  test.error,
 						errorStage: test.errorStage,
 					}, nil
 				}
 			} else {
-				broker.kerberosAuthenticator.NewKerberosClientFunc = nil
+				conf.Net.SASL.GSSAPI.NewKerberosClientFunc = nil
 			}
 
 			err := broker.Open(conf)

--- a/gssapi_kerberos.go
+++ b/gssapi_kerberos.go
@@ -30,23 +30,23 @@ const (
 )
 
 type GSSAPIConfig struct {
-	AuthType           int
-	KeyTabPath         string
-	CCachePath         string
-	KerberosConfigPath string
-	ServiceName        string
-	Username           string
-	Password           string
-	Realm              string
-	DisablePAFXFAST    bool
+	AuthType              int
+	KeyTabPath            string
+	CCachePath            string
+	KerberosConfigPath    string
+	ServiceName           string
+	Username              string
+	Password              string
+	Realm                 string
+	DisablePAFXFAST       bool
+	NewKerberosClientFunc func(config *GSSAPIConfig) (KerberosClient, error)
 }
 
 type GSSAPIKerberosAuth struct {
-	Config                *GSSAPIConfig
-	ticket                messages.Ticket
-	encKey                types.EncryptionKey
-	NewKerberosClientFunc func(config *GSSAPIConfig) (KerberosClient, error)
-	step                  int
+	Config *GSSAPIConfig
+	ticket messages.Ticket
+	encKey types.EncryptionKey
+	step   int
 }
 
 type KerberosClient interface {
@@ -199,7 +199,7 @@ func (krbAuth *GSSAPIKerberosAuth) initSecContext(bytes []byte, kerberosClient K
 
 /* This does the handshake for authorization */
 func (krbAuth *GSSAPIKerberosAuth) Authorize(broker *Broker) error {
-	kerberosClient, err := krbAuth.NewKerberosClientFunc(krbAuth.Config)
+	kerberosClient, err := krbAuth.Config.NewKerberosClientFunc(krbAuth.Config)
 	if err != nil {
 		Logger.Printf("Kerberos client error: %s", err)
 		return err


### PR DESCRIPTION
## what this pr is 

The new pr is a custom config enhancement that allows the creation of user-defined KerberosClient.

After allow custom NewKerberosClientFunc, then we can custom spn, this also will satisfy https://github.com/IBM/sarama/pull/2437/files
## how to implement 

move `NewKerberosClientFunc` from `GSSAPIKerberosAuth` private field to `GSSAPIConfig` public field, allow user set `NewKerberosClientFunc` from config struct.

## tests result

```
?       github.com/IBM/sarama/internal/toxiproxy        [no test files]
?       github.com/IBM/sarama/tools/kafka-console-consumer      [no test files]
?       github.com/IBM/sarama/tools/kafka-console-partitionconsumer     [no test files]
?       github.com/IBM/sarama/tools/kafka-console-producer      [no test files]
?       github.com/IBM/sarama/tools/kafka-producer-performance  [no test files]
?       github.com/IBM/sarama/tools/tls [no test files]
ok      github.com/IBM/sarama   31.257s
ok      github.com/IBM/sarama/mocks     (cached)
```