### PR TITLE
fix: message.max.bytes should default to 1048576 not 1 MB

### DIFF
--- a/config.go
+++ b/config.go
@@ -523,7 +523,7 @@ func NewConfig() *Config {
 	c.Metadata.Full = true
 	c.Metadata.AllowAutoTopicCreation = true
 
-	c.Producer.MaxMessageBytes = 1000000
+	c.Producer.MaxMessageBytes = 1024 * 1024
 	c.Producer.RequiredAcks = WaitForLocal
 	c.Producer.Timeout = 10 * time.Second
 	c.Producer.Partitioner = NewHashPartitioner


### PR DESCRIPTION
https://kafka.apache.org/documentation/#brokerconfigs_message.max.bytes

Says this default value should be `1048588`, not 1 megabyte (and also weirdly not 1 Mebibyte 🤷‍♀️ ) matching these expected values is important, as one language could publish an event that another language would then refuse to republish.

The produced error message `ConfigurationError(fmt.Sprintf("Attempt to produce message larger than configured Producer.MaxMessageBytes: %d > %d", size, p.conf.Producer.MaxMessageBytes)` is also poorly designed to allow for event handling of that message. It would require an `errors.As` followed by a `strings.HasPrefix(…)` which is really not what Go recommends to handle errors (that is, direct string manipulation, which is inherently fragile as the error string should be easily changeable.) This change doesn’t really address this issue, but I wanted to mention it.