### PR TITLE
chore(ci): disable checkout credentials persist

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -33,6 +33,7 @@ jobs:
       with:
         ref: ${{ github.base_ref }}
         path: "base"
+        persist-credentials: false
     - name: Capture apidiff baseline
       run: apidiff -m -w ../baseline.bin .
       working-directory: "base"
@@ -40,6 +41,7 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         path: "updated"
+        persist-credentials: false
     - name: Run apidiff check
       run: apidiff -m -incompatible ../baseline.bin .
       working-directory: "updated"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
         go-version: [1.22.x]
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
     - name: Setup Go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
@@ -51,6 +53,8 @@ jobs:
       GOFLAGS: -trimpath
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
     - name: Setup Go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
     - name: Initialize CodeQL
       uses: github/codeql-action/init@379614612a29c9e28f31f39a59013eb8012a51f0 # v3.24.3
       with:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@fd07d42ce87ab09f10c61a2d1a5e59e6c655620a # v4.1.1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -23,6 +23,8 @@ jobs:
       GOFLAGS: -trimpath
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
     - name: Setup Go
       uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -29,6 +29,8 @@ jobs:
       SCALA_VERSION: ${{ inputs.scala-version }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
     - name: Setup Docker
       uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       id: buildx


### PR DESCRIPTION
We don't need actions/checkout to persist credentials for any submodules or other fetches. Whilst it is a read-only token, there's no need to leave it around on disk after the checkout has completed.

https://github.com/actions/checkout/blob/v4.1.1/action.yml#L48-L50