### PR TITLE
fix: provide IsMessageSizeTooLarge() function

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -452,7 +452,7 @@ func (p *asyncProducer) dispatcher() {
 
 		size := msg.ByteSize(version)
 		if size > p.conf.Producer.MaxMessageBytes {
-			p.returnError(msg, ConfigurationError(fmt.Sprintf("Attempt to produce message larger than configured Producer.MaxMessageBytes: %d > %d", size, p.conf.Producer.MaxMessageBytes)))
+			p.returnError(msg, newMessageSizeTooLargeConfigurationError(size, p.conf.Producer.MaxMessageBytes))
 			continue
 		}
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSentinelWithSingleWrappedError(t *testing.T) {
@@ -62,4 +64,10 @@ func TestSentinelWithMultipleWrappedErrors(t *testing.T) {
 	if errors.Is(unwrapped, ErrOutOfBrokers) || !errors.Is(unwrapped, myNetError) || !errors.Is(unwrapped, myAddrError) {
 		t.Errorf("unwrapped value unexpected result")
 	}
+}
+
+func TestIsMessageSizeTooLarge(t *testing.T) {
+	assert.True(t, IsMessageSizeTooLarge(ErrMessageSizeTooLarge), "broker side error must be regarded as a too large error")
+	assert.True(t, IsMessageSizeTooLarge(newMessageSizeTooLargeConfigurationError(2, 1)), "config side error must be regarded as a too large error")
+	assert.False(t, IsMessageSizeTooLarge(nil), "nil is not an error")
 }


### PR DESCRIPTION
This provides a method for producers to workaround the regression introduced by #2628. Fixes #2655.