### PR TITLE
fix: return ErrMessageSizeTooLarge when message is too large

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -450,9 +450,8 @@ func (p *asyncProducer) dispatcher() {
 			continue
 		}
 
-		size := msg.ByteSize(version)
-		if size > p.conf.Producer.MaxMessageBytes {
-			p.returnError(msg, ConfigurationError(fmt.Sprintf("Attempt to produce message larger than configured Producer.MaxMessageBytes: %d > %d", size, p.conf.Producer.MaxMessageBytes)))
+		if msg.ByteSize(version) > p.conf.Producer.MaxMessageBytes {
+			p.returnError(msg, ErrMessageSizeTooLarge)
 			continue
 		}
 

--- a/sync_producer_test.go
+++ b/sync_producer_test.go
@@ -58,8 +58,8 @@ func TestSyncProducer(t *testing.T) {
 		Value:    ByteEncoder(make([]byte, config.Producer.MaxMessageBytes+1)), // will exceed default max size, e.g. configuration side
 		Metadata: "test",
 	})
-	if err != ErrMessageSizeTooLarge {
-		t.Error("expected err to be ErrMessageSizeTooLarge - many people rely on this, please do not change with searching for previous discussions")
+	if err != ErrMessageSizeTooLarge { //nolint:errorlint // linter complains that we use errors.Is(), but we know code bases out there don't, so this test is specifically to test that we don't wrap this
+		t.Error("expected err to be ErrMessageSizeTooLarge - many people rely on this, please do not change without searching for previous discussions")
 	}
 
 	// try to send small message the server rejects because too large
@@ -77,8 +77,8 @@ func TestSyncProducer(t *testing.T) {
 		Value:    StringEncoder(TestMessage),
 		Metadata: "test",
 	})
-	if err != ErrMessageSizeTooLarge {
-		t.Error("expected err to be ErrMessageSizeTooLarge - many people rely on this, please do not change with searching for previous discussions")
+	if err != ErrMessageSizeTooLarge { //nolint:errorlint // linter complains that we use errors.Is(), but we know code bases out there don't, so this test is specifically to test that we don't wrap this
+		t.Error("expected err to be ErrMessageSizeTooLarge - many people rely on this, please do not change without searching for previous discussions")
 	}
 
 	safeClose(t, producer)

--- a/sync_producer_test.go
+++ b/sync_producer_test.go
@@ -52,6 +52,35 @@ func TestSyncProducer(t *testing.T) {
 		}
 	}
 
+	// try to send a message too large
+	_, _, err = producer.SendMessage(&ProducerMessage{
+		Topic:    "my_topic",
+		Value:    ByteEncoder(make([]byte, config.Producer.MaxMessageBytes+1)), // will exceed default max size, e.g. configuration side
+		Metadata: "test",
+	})
+	if err != ErrMessageSizeTooLarge {
+		t.Error("expected err to be ErrMessageSizeTooLarge - many people rely on this, please do not change with searching for previous discussions")
+	}
+
+	// try to send small message the server rejects because too large
+	leader.Returns(&ProduceResponse{
+		Blocks: map[string]map[int32]*ProduceResponseBlock{
+			"my_topic": {
+				0: &ProduceResponseBlock{
+					Err: ErrMessageSizeTooLarge,
+				},
+			},
+		},
+	})
+	_, _, err = producer.SendMessage(&ProducerMessage{
+		Topic:    "my_topic",
+		Value:    StringEncoder(TestMessage),
+		Metadata: "test",
+	})
+	if err != ErrMessageSizeTooLarge {
+		t.Error("expected err to be ErrMessageSizeTooLarge - many people rely on this, please do not change with searching for previous discussions")
+	}
+
 	safeClose(t, producer)
 	leader.Close()
 	seedBroker.Close()


### PR DESCRIPTION
For most of this library's existence it has returned ErrMessageSizeTooLarge when the message exceeded the configured size.

For a short period in 2019 this error was renamed (#1218) but shortly revered back (#1262). Later in 2023 this error was changed to a ConfigurationError (#2628) to fix #2137, however this has caused issues with clients who rely on the previous error code being distinct from other ConfigurationError conditions (#2655).

This commit reverts to previous behaviour, and adds a test to pickup if this changes again in the future.