### PR TITLE
Fixing error in using chan `consumer.ready` for waiting consumer has been set up

### DIFF
--- a/examples/consumergroup/main.go
+++ b/examples/consumergroup/main.go
@@ -116,7 +116,7 @@ func main() {
 			if ctx.Err() != nil {
 				return
 			}
-			consumer.ready = make(chan bool)
+			consumer.ready <- true
 		}
 	}()
 


### PR DESCRIPTION
Fixing error in using chan `consumer.ready` for waiting consumer has been set up.