### PR TITLE
chore(ci): add 32-bit alignment check

### DIFF
--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -1,0 +1,39 @@
+name: i386
+on:
+  merge_group:
+  push:
+    branches:
+    - main
+    paths-ignore:
+    - '**/*.md'
+  pull_request:
+    branches:
+    - "**"
+    paths-ignore:
+    - '**/*.md'
+
+permissions:
+  contents: read  # for actions/checkout to fetch code
+
+jobs:
+  atomicalign:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
+      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      with:
+        persist-credentials: false
+    - name: Setup Go
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      with:
+        go-version: 1.22.x
+    - name: staticcheck
+      env:
+        GOARCH: 386
+        GOFLAGS: -tags=functional
+      run: |
+          git clone --depth=1 https://github.com/dominikh/go-tools /tmp/go-tools
+          ( cd /tmp/go-tools/cmd/staticcheck && go build -o /tmp/staticcheck )
+          /tmp/staticcheck -checks SA1027 ./...

--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -248,6 +248,7 @@ func (c *Consumer) ExpectConsumePartition(topic string, partition int32, offset 
 // channels using YieldMessage and YieldError.
 type PartitionConsumer struct {
 	highWaterMarkOffset           int64 // must be at the top of the struct because https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	suppressedHighWaterMarkOffset int64
 	l                             sync.Mutex
 	t                             ErrorReporter
 	topic                         string
@@ -255,7 +256,6 @@ type PartitionConsumer struct {
 	offset                        int64
 	messages                      chan *sarama.ConsumerMessage
 	suppressedMessages            chan *sarama.ConsumerMessage
-	suppressedHighWaterMarkOffset int64
 	errors                        chan *sarama.ConsumerError
 	singleClose                   sync.Once
 	consumed                      bool


### PR DESCRIPTION
- add a CI check that makes use of [SA1027](https://staticcheck.io/docs/checks#SA1027) from staticcheck which correctly detects alignment bugs when compiled for GOARCH=i386 (it doesn't find it when built under x86_64/arm64)
- align suppressedHighWaterMarkOffset to fix the issue reported in #2873

Fixes #2873