### PR TITLE
fix: allow skipping per message size check

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -450,10 +450,12 @@ func (p *asyncProducer) dispatcher() {
 			continue
 		}
 
-		size := msg.ByteSize(version)
-		if size > p.conf.Producer.MaxMessageBytes {
-			p.returnError(msg, ConfigurationError(fmt.Sprintf("Attempt to produce message larger than configured Producer.MaxMessageBytes: %d > %d", size, p.conf.Producer.MaxMessageBytes)))
-			continue
+		if !p.conf.Producer.SkipPerMessageSizeTest {
+			size := msg.ByteSize(version)
+			if size > p.conf.Producer.MaxMessageBytes {
+				p.returnError(msg, ConfigurationError(fmt.Sprintf("Attempt to produce message larger than configured Producer.MaxMessageBytes: %d > %d", size, p.conf.Producer.MaxMessageBytes)))
+				continue
+			}
 		}
 
 		handler := handlers[msg.Topic]

--- a/config.go
+++ b/config.go
@@ -175,6 +175,11 @@ type Config struct {
 		// The maximum permitted size of a message (defaults to 1000000). Should be
 		// set equal to or smaller than the broker's `message.max.bytes`.
 		MaxMessageBytes int
+		// If set don't check the uncompressed size of an individual message against
+		// MaxMessageBytes. MaxMessageBytes is still used to attempt to limit the
+		// overall message batch size (which applies after a set of messages is
+		// compressed)
+		SkipPerMessageSizeTest bool
 		// The level of acknowledgement reliability needed from the broker (defaults
 		// to WaitForLocal). Equivalent to the `request.required.acks` setting of the
 		// JVM producer.


### PR DESCRIPTION
This is useful when producer compression is enabled, as it allows for much larger messages to be sent to the broker (providing the entire batch they are in stays small enough).

The previous workaround suggested in #2142 causes other ill-effects related to message batching (such as in #2797).

Fixes #2142, probably also #2797 and may help mitigate not having merged #2851.

It's not clear how easy it is to write a test for this but happy to try if we're happy enough with this approach.