### PR TITLE
fix(doc): correct JVM's config name corresponding to MaxWaitTime

### DIFF
--- a/config.go
+++ b/config.go
@@ -387,7 +387,7 @@ type Config struct {
 		// default is 250ms, since 0 causes the consumer to spin when no events are
 		// available. 100-500ms is a reasonable range for most cases. Kafka only
 		// supports precision up to milliseconds; nanoseconds will be truncated.
-		// Equivalent to the JVM's `fetch.wait.max.ms`.
+		// Equivalent to the JVM's `fetch.max.wait.ms`.
 		MaxWaitTime time.Duration
 
 		// The maximum amount of time the consumer expects a message takes to


### PR DESCRIPTION
Fixed JVM config name for `MaxWaitTime` config in docs.

Incorrect JVM config: `fetch.wait.max.ms` <-- docs mention this.
[Correct JVM config](https://kafka.apache.org/36/documentation.html#consumerconfigs_fetch.max.wait.ms): `fetch.max.wait.ms`
