### PR TITLE
feat: add metadata field to consumer message

### DIFF
--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1723,8 +1723,9 @@ func TestAsyncProducerInterceptors(t *testing.T) {
 					t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expectedValue)
 				}
 
-				if str, ok := msg.Metadata.(string); ok != true || str != "sarama" {
-					t.Errorf("Interceptor should have set the metadata, got %s, expected sarama", msg.Metadata)
+				expectedMetadata := "sarama"
+				if metadata, ok := msg.Metadata.(string); !ok || metadata != expectedMetadata {
+					t.Errorf("Interceptor should have set the metadata, got %s, expected %s", msg.Metadata, expectedMetadata)
 				}
 			},
 		},

--- a/consumer.go
+++ b/consumer.go
@@ -21,6 +21,11 @@ type ConsumerMessage struct {
 	Topic      string
 	Partition  int32
 	Offset     int64
+
+	// This field is used to hold arbitrary data you wish to include
+	// Sarama completely ignores this field and is only to be used for
+	// pass-through data.
+	Metadata interface{}
 }
 
 // ConsumerError is what is provided to the user when an error occurs.

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -2102,8 +2102,9 @@ func TestConsumerInterceptors(t *testing.T) {
 					t.Errorf("Interceptor should have incremented the value, got %s, expected %s", v, expectedValue)
 				}
 
-				if str, ok := msg.Metadata.(string); ok != true || str != "sarama" {
-					t.Errorf("Interceptor should have set the metadata, got %s, expected %s", msg.Metadata, "sarama")
+				expectedMetadata := "sarama"
+				if metadata, ok := msg.Metadata.(string); !ok || metadata != expectedMetadata {
+					t.Errorf("Interceptor should have set the metadata, got %s, expected %s", msg.Metadata, expectedMetadata)
 				}
 			},
 		},


### PR DESCRIPTION
Hello everyone!

I've been using sarama for a while both in production and in my personal projects. One of the issues I'm lacking is that we don't have the chance to transfer information in the message we consume. I added the Metadata field in the produced messages into the consumed message structure. I think it will be very useful especially for tracing. 

I am waiting for your comments, thanks in advance.