### PR TITLE
Fix cpu spin loop when pending is closed while buf is not empty

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -865,6 +865,9 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 			select {
 			case res, ok := <-pending:
 				if !ok {
+					if buf.Length() != 0 {
+						time.Sleep(bp.parent.conf.Producer.Retry.Backoff)
+					}
 					continue
 				}
 				buf.Add(res)


### PR DESCRIPTION
it can be situation when 
on line 854 pending is ok
on line 860 we add res to buf
on line 861 pending closes in other goroutine
and then there will be cpu spin loop. 

I will be glad to see your suggestions and comments