### PR TITLE
Ensure ordering of offset commit requests

### DIFF
--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -82,6 +82,9 @@ func TestNewOffsetManager(t *testing.T) {
 	metadataResponse := new(MetadataResponse)
 	metadataResponse.AddBroker(seedBroker.Addr(), seedBroker.BrokerID())
 	seedBroker.Returns(metadataResponse)
+	findCoordResponse := new(FindCoordinatorResponse)
+	findCoordResponse.Coordinator = &Broker{id: seedBroker.brokerID, addr: seedBroker.Addr()}
+	seedBroker.Returns(findCoordResponse)
 	defer seedBroker.Close()
 
 	testClient, err := NewClient([]string{seedBroker.Addr()}, NewTestConfig())


### PR DESCRIPTION
Add locking to prevent concurrent calls to commit from potentially being re-ordered between determining which offsets to include in the offset commit request, and sending the request to Kafka.

Note: we think this can be improved upon (by not adding more locks). A potential improvement would be to use the [broker lock](https://github.com/IBM/sarama/blob/d2246cc9b9df113f3ffed7c442fd81e8b9cf736e/broker.go#L31), and only hold this until the request is sent (avoiding holding a lock for the entire network round-trip time). However, it looks like #2409 has made [sendAndReceive](https://github.com/IBM/sarama/blob/d2246cc9b9df113f3ffed7c442fd81e8b9cf736e/broker.go#L1038) hold the broker lock until a response is received from the broker, so we need to understand that a little better first.

Fixes: #2940