### PR TITLE
Fix bugs related to Idempotency and Strict ordering when MaxOpenRequests=1

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -985,6 +985,11 @@ func (bp *brokerProducer) run() {
 					continue
 				}
 			}
+
+			if !msg.hasSequence {
+				panic("wtf no sequence")
+			}
+
 			if err := bp.buffer.add(msg); err != nil {
 				bp.parent.returnError(msg, err)
 				continue

--- a/async_producer.go
+++ b/async_producer.go
@@ -737,6 +737,14 @@ func (pp *partitionProducer) flushRetryBuffers() {
 		}
 
 		for _, msg := range pp.retryState[pp.highWatermark].buf {
+			if pp.parent.conf.Producer.Idempotent && msg.retries == 0 && msg.flags == 0 && !msg.hasSequence {
+				if msg.hasSequence {
+					// wtf????
+					panic("dupe sequence")
+				}
+				msg.sequenceNumber, msg.producerEpoch = pp.parent.txnmgr.getAndIncrementSequenceNumber(msg.Topic, msg.Partition)
+				msg.hasSequence = true
+			}
 			pp.brokerProducer.input <- msg
 		}
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -1176,6 +1176,8 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	produceSet.msgs[topic][partition] = pSet
 	produceSet.bufferBytes += pSet.bufferBytes
 	produceSet.bufferCount += len(pSet.msgs)
+	produceSet.producerID = pSet.recordsToSend.RecordBatch.ProducerID
+	produceSet.producerEpoch = pSet.recordsToSend.RecordBatch.ProducerEpoch
 	for _, msg := range pSet.msgs {
 		if msg.retries >= p.conf.Producer.Retry.Max {
 			p.returnErrors(pSet.msgs, kerr)

--- a/produce_set.go
+++ b/produce_set.go
@@ -3,7 +3,6 @@ package sarama
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -87,7 +86,8 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 
 	if ps.parent.conf.Version.IsAtLeast(V0_11_0_0) {
 		if ps.parent.conf.Producer.Idempotent && msg.sequenceNumber < set.recordsToSend.RecordBatch.FirstSequence {
-			fmt.Println(
+			Logger.Println(
+				"assertion failed: message out of sequence added to batch",
 				"producer_id",
 				ps.producerID,
 				set.recordsToSend.RecordBatch.ProducerID,
@@ -101,7 +101,6 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 				ps.bufferCount,
 				"msg_has_sequence",
 				msg.hasSequence)
-			panic("out of order")
 			return errors.New("assertion failed: message out of sequence added to a batch")
 		}
 	}

--- a/produce_set.go
+++ b/produce_set.go
@@ -3,6 +3,7 @@ package sarama
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -86,6 +87,21 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 
 	if ps.parent.conf.Version.IsAtLeast(V0_11_0_0) {
 		if ps.parent.conf.Producer.Idempotent && msg.sequenceNumber < set.recordsToSend.RecordBatch.FirstSequence {
+			fmt.Println(
+				"producer_id",
+				ps.producerID,
+				set.recordsToSend.RecordBatch.ProducerID,
+				"producer_epoch",
+				ps.producerEpoch,
+				set.recordsToSend.RecordBatch.ProducerEpoch,
+				"sequence_number",
+				msg.sequenceNumber,
+				set.recordsToSend.RecordBatch.FirstSequence,
+				"buffer_count",
+				ps.bufferCount,
+				"msg_has_sequence",
+				msg.hasSequence)
+			panic("out of order")
 			return errors.New("assertion failed: message out of sequence added to a batch")
 		}
 	}

--- a/produce_set.go
+++ b/produce_set.go
@@ -106,6 +106,7 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 		}
 	}
 
+	msg.hasBeenBatched = true
 	// Past this point we can't return an error, because we've already added the message to the set.
 	set.msgs = append(set.msgs, msg)
 

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -244,8 +244,6 @@ func (t *transactionManager) bumpEpoch() {
 	for k := range t.sequenceNumbers {
 		t.sequenceNumbers[k] = 0
 	}
-
-	fmt.Println("bumped epoch to", t.producerEpoch)
 }
 
 func (t *transactionManager) getProducerID() (int64, int16) {

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -244,6 +244,8 @@ func (t *transactionManager) bumpEpoch() {
 	for k := range t.sequenceNumbers {
 		t.sequenceNumbers[k] = 0
 	}
+
+	fmt.Println("bumped epoch to", t.producerEpoch)
 }
 
 func (t *transactionManager) getProducerID() (int64, int16) {


### PR DESCRIPTION
I found a lot of bugs by just running a synthetic workload and randomly restarting brokers and changing partition assignments.