### PR TITLE
Fix broken error handling around Idempotent producer + Ensure strict ordering when Net.MaxOpenRequests = 1

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -741,7 +741,7 @@ func (pp *partitionProducer) flushRetryBuffers() {
 		}
 
 		for _, msg := range pp.retryState[pp.highWatermark].buf {
-			if pp.parent.conf.Producer.Idempotent && msg.retries == 0 && msg.flags == 0 && !msg.hasSequence {
+			if pp.parent.conf.Producer.Idempotent && msg.retries == 0 && msg.flags == 0 {
 				if msg.hasSequence {
 					panic("assertion failure: reassigning producer epoch and sequence number to message that already has them")
 				}

--- a/async_producer.go
+++ b/async_producer.go
@@ -1165,7 +1165,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 			bp.parent.returnSuccesses(pSet.msgs)
 		// Retriable errors
 		case ErrInvalidMessage, ErrUnknownTopicOrPartition, ErrLeaderNotAvailable, ErrNotLeaderForPartition,
-			ErrRequestTimedOut, ErrNotEnoughReplicas, ErrNotEnoughReplicasAfterAppend:
+			ErrRequestTimedOut, ErrNotEnoughReplicas, ErrNotEnoughReplicasAfterAppend, ErrKafkaStorageError:
 			if bp.parent.conf.Producer.Retry.Max <= 0 {
 				bp.parent.abandonBrokerConnection(bp.broker)
 				bp.parent.returnErrors(pSet.msgs, block.Err)
@@ -1198,7 +1198,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 
 			switch block.Err {
 			case ErrInvalidMessage, ErrUnknownTopicOrPartition, ErrLeaderNotAvailable, ErrNotLeaderForPartition,
-				ErrRequestTimedOut, ErrNotEnoughReplicas, ErrNotEnoughReplicasAfterAppend:
+				ErrRequestTimedOut, ErrNotEnoughReplicas, ErrNotEnoughReplicasAfterAppend, ErrKafkaStorageError:
 				Logger.Printf("producer/broker/%d state change to [retrying] on %s/%d because %v\n",
 					bp.broker.ID(), topic, partition, block.Err)
 				if bp.currentRetries[topic] == nil {

--- a/async_producer.go
+++ b/async_producer.go
@@ -252,12 +252,15 @@ type ProducerErrors []*ProducerError
 func (pe ProducerErrors) Error() string {
 	if len(pe) > 0 {
 		return fmt.Sprintf(
-			"kafka: Failed to deliver %d messages, sample error: %v after %d retries on topic: %s and partition: %d",
+			"kafka: Failed to deliver %d messages, sample error: %v after %d retries on topic: %s and partition: %d with producerEpoch: %d and sequence: %d(%v)",
 			len(pe),
 			pe[0].Err,
 			pe[0].Msg.retries,
 			pe[0].Msg.Topic,
 			pe[0].Msg.Partition,
+			pe[0].Msg.producerEpoch,
+			pe[0].Msg.sequenceNumber,
+			pe[0].Msg.hasSequence,
 		)
 	}
 	return fmt.Sprintf("kafka: Failed to deliver %d messages.", len(pe))

--- a/async_producer.go
+++ b/async_producer.go
@@ -985,6 +985,11 @@ func (bp *brokerProducer) run() {
 					continue
 				}
 			}
+
+			if !msg.hasSequence {
+				panic("wtf no sequence")
+			}
+
 			if err := bp.buffer.add(msg); err != nil {
 				bp.parent.returnError(msg, err)
 				continue

--- a/async_producer.go
+++ b/async_producer.go
@@ -737,6 +737,14 @@ func (pp *partitionProducer) flushRetryBuffers() {
 		}
 
 		for _, msg := range pp.retryState[pp.highWatermark].buf {
+			if pp.parent.conf.Producer.Idempotent && msg.retries == 0 && msg.flags == 0 && !msg.hasSequence {
+				if msg.hasSequence {
+					// wtf????
+					panic("dupe sequence")
+				}
+				msg.sequenceNumber, msg.producerEpoch = pp.parent.txnmgr.getAndIncrementSequenceNumber(msg.Topic, msg.Partition)
+				msg.hasSequence = true
+			}
 			pp.brokerProducer.input <- msg
 		}
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -1034,7 +1034,7 @@ func (bp *brokerProducer) run() {
 				}
 			}
 
-			if bp.parent.conf.Producer.Idempotent {
+			if bp.parent.conf.Producer.Idempotent && !msg.hasSequence {
 				panic("msg made it to brokerProducer goroutine without being sequenced while idempotency is enabled")
 			}
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -250,6 +250,16 @@ func (pe ProducerError) Unwrap() error {
 type ProducerErrors []*ProducerError
 
 func (pe ProducerErrors) Error() string {
+	if len(pe) > 0 {
+		return fmt.Sprintf(
+			"kafka: Failed to deliver %d messages, sample error: %v after %d retries on topic: %s and partition: %d",
+			len(pe),
+			pe[0].Err,
+			pe[0].Msg.retries,
+			pe[0].Msg.Topic,
+			pe[0].Msg.Partition,
+		)
+	}
 	return fmt.Sprintf("kafka: Failed to deliver %d messages.", len(pe))
 }
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -1176,6 +1176,8 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	produceSet.msgs[topic][partition] = pSet
 	produceSet.bufferBytes += pSet.bufferBytes
 	produceSet.bufferCount += len(pSet.msgs)
+	produceSet.producerID = pSet.recordsToSend.RecordBatch.ProducerID
+	produceSet.producerEpoch = pSet.recordsToSend.RecordBatch.ProducerEpoch
 	for _, msg := range pSet.msgs {
 		if msg.retries >= p.conf.Producer.Retry.Max {
 			p.returnErrors(pSet.msgs, kerr)

--- a/async_producer.go
+++ b/async_producer.go
@@ -1436,7 +1436,6 @@ func (p *asyncProducer) returnError(msg *ProducerMessage, err error) {
 		p.bumpIdempotentProducerEpoch()
 	}
 
-	msg.clear()
 	pErr := &ProducerError{Msg: msg, Err: err}
 	if p.conf.Producer.Return.Errors {
 		p.errors <- pErr
@@ -1455,7 +1454,6 @@ func (p *asyncProducer) returnErrors(batch []*ProducerMessage, err error) {
 func (p *asyncProducer) returnSuccesses(batch []*ProducerMessage) {
 	for _, msg := range batch {
 		if p.conf.Producer.Return.Successes {
-			msg.clear()
 			p.successes <- msg
 		}
 		p.inFlight.Done()

--- a/produce_set.go
+++ b/produce_set.go
@@ -3,7 +3,6 @@ package sarama
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -87,7 +86,8 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 
 	if ps.parent.conf.Version.IsAtLeast(V0_11_0_0) {
 		if ps.parent.conf.Producer.Idempotent && msg.sequenceNumber < set.recordsToSend.RecordBatch.FirstSequence {
-			fmt.Println(
+			Logger.Println(
+				"assertion failed: message out of sequence added to batch",
 				"producer_id",
 				ps.producerID,
 				set.recordsToSend.RecordBatch.ProducerID,
@@ -101,7 +101,6 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 				ps.bufferCount,
 				"msg_has_sequence",
 				msg.hasSequence)
-			panic("out of order")
 			return errors.New("assertion failed: message out of sequence added to a batch")
 		}
 	}

--- a/produce_set.go
+++ b/produce_set.go
@@ -3,6 +3,7 @@ package sarama
 import (
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -86,6 +87,21 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 
 	if ps.parent.conf.Version.IsAtLeast(V0_11_0_0) {
 		if ps.parent.conf.Producer.Idempotent && msg.sequenceNumber < set.recordsToSend.RecordBatch.FirstSequence {
+			fmt.Println(
+				"producer_id",
+				ps.producerID,
+				set.recordsToSend.RecordBatch.ProducerID,
+				"producer_epoch",
+				ps.producerEpoch,
+				set.recordsToSend.RecordBatch.ProducerEpoch,
+				"sequence_number",
+				msg.sequenceNumber,
+				set.recordsToSend.RecordBatch.FirstSequence,
+				"buffer_count",
+				ps.bufferCount,
+				"msg_has_sequence",
+				msg.hasSequence)
+			panic("out of order")
 			return errors.New("assertion failed: message out of sequence added to a batch")
 		}
 	}

--- a/produce_set.go
+++ b/produce_set.go
@@ -106,6 +106,7 @@ func (ps *produceSet) add(msg *ProducerMessage) error {
 		}
 	}
 
+	msg.hasBeenBatched = true
 	// Past this point we can't return an error, because we've already added the message to the set.
 	set.msgs = append(set.msgs, msg)
 

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -244,8 +244,6 @@ func (t *transactionManager) bumpEpoch() {
 	for k := range t.sequenceNumbers {
 		t.sequenceNumbers[k] = 0
 	}
-
-	fmt.Println("bumped epoch to", t.producerEpoch)
 }
 
 func (t *transactionManager) getProducerID() (int64, int16) {

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -244,6 +244,8 @@ func (t *transactionManager) bumpEpoch() {
 	for k := range t.sequenceNumbers {
 		t.sequenceNumbers[k] = 0
 	}
+
+	fmt.Println("bumped epoch to", t.producerEpoch)
 }
 
 func (t *transactionManager) getProducerID() (int64, int16) {


### PR DESCRIPTION
There have been numerous issues filed lately that:

1. Strict ordering no longer works after [request pipelining](https://github.com/IBM/sarama/pull/2094) was introduced even when `Net.MaxOpenRequests` is set to 1.
2. Requests can still end up failing / mis-sequenced when Idempotent producer is enabled.

I was able to reproduce these issues both locally and in a staging environment and have fixed both of them. P.R has many comments explaining the changes.

Relevant issues:

1. #2619
2. #2803
3. #2860 