### PR TITLE
fix(consumer): maintain ordering of offset commit requests

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -251,18 +251,23 @@ func (om *offsetManager) Commit() {
 }
 
 func (om *offsetManager) flushToBroker() {
-	req := om.constructRequest()
-	if req == nil {
-		return
-	}
-
 	broker, err := om.coordinator()
 	if err != nil {
 		om.handleError(err)
 		return
 	}
 
-	resp, err := broker.CommitOffset(req)
+	// Care needs to be taken to unlock this. Don't want to defer the unlock as this would
+	// cause the lock to be held while waiting for the broker to reply.
+	broker.lock.Lock()
+	req := om.constructRequest()
+	if req == nil {
+		broker.lock.Unlock()
+		return
+	}
+	resp, rp, err := sendOffsetCommit(broker, req)
+	broker.lock.Unlock()
+
 	if err != nil {
 		om.handleError(err)
 		om.releaseCoordinator(broker)
@@ -270,7 +275,26 @@ func (om *offsetManager) flushToBroker() {
 		return
 	}
 
+	err = handleResponsePromise(req, resp, rp, nil)
+	if err != nil {
+		om.handleError(err)
+		om.releaseCoordinator(broker)
+		_ = broker.Close()
+		return
+	}
+
+	broker.handleThrottledResponse(resp)
 	om.handleResponse(broker, req, resp)
+}
+
+func sendOffsetCommit(coordinator *Broker, req *OffsetCommitRequest) (*OffsetCommitResponse, *responsePromise, error) {
+	resp := new(OffsetCommitResponse)
+	responseHeaderVersion := resp.headerVersion()
+	promise, err := coordinator.send(req, true, responseHeaderVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+	return resp, promise, err
 }
 
 func (om *offsetManager) constructRequest() *OffsetCommitRequest {

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -294,7 +294,7 @@ func sendOffsetCommit(coordinator *Broker, req *OffsetCommitRequest) (*OffsetCom
 	if err != nil {
 		return nil, nil, err
 	}
-	return resp, promise, err
+	return resp, promise, nil
 }
 
 func (om *offsetManager) constructRequest() *OffsetCommitRequest {

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -82,6 +82,9 @@ func TestNewOffsetManager(t *testing.T) {
 	metadataResponse := new(MetadataResponse)
 	metadataResponse.AddBroker(seedBroker.Addr(), seedBroker.BrokerID())
 	seedBroker.Returns(metadataResponse)
+	findCoordResponse := new(FindCoordinatorResponse)
+	findCoordResponse.Coordinator = &Broker{id: seedBroker.brokerID, addr: seedBroker.Addr()}
+	seedBroker.Returns(findCoordResponse)
 	defer seedBroker.Close()
 
 	testClient, err := NewClient([]string{seedBroker.Addr()}, NewTestConfig())


### PR DESCRIPTION
Use the Broker.lock to prevent concurrent calls to commit from potentially being re-ordered between determining which offsets to include in the offset commit request, and sending the request to Kafka. This has the benefit that the lock is only held while the OffsetCommitRequest is sent, not for the period of time that Sarama is waiting for the response from the broker, improving the rate at which commit requests can be made.

The down side is that (without further re-factoring to the Broker) this change duplicates some of the code from the Broker into the offset manager. Potentially, making the code more fragile.