### PR TITLE
fix(ci): correct docker-compose install

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -50,8 +50,8 @@ jobs:
         go-version: ${{ inputs.go-version }}
     - name: Setup Docker Compose
       run: |
-        curl -sSL "https://github.com/docker/compose/releases/download/v2.20.3/docker-compose-$(uname -s)-$(uname -m)" -o /tmp/docker-compose
-        sudo install -m755 /tmp/docker-compose "$(dirname $(which docker-compose))"
+        curl --fail -sSL "https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-$(uname -s)-$(uname -m)" -o /tmp/docker-compose
+        sudo install -m755 /tmp/docker-compose "$(dirname $(which docker))"
         docker version --format 'Docker Engine version v{{.Server.Version}}'
         docker-compose version
     - name: Test (Functional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
   zookeeper-1:
     hostname: 'zookeeper-1'


### PR DESCRIPTION
The base actions image no longer appears to include an old version of `docker-compose` so there's no thing to replace. Switch to installing `docker-compose` in a directory alongside the `docker` binary.

Also bump docker-compose to the latest release whilst making changes here.