### PR TITLE
draft: added support incremental rebalance in one session

### DIFF
--- a/config.go
+++ b/config.go
@@ -304,6 +304,8 @@ type Config struct {
 				Interval time.Duration
 			}
 			Rebalance struct {
+				// IsIncremental to allow don't stopping the rebalance process when a new member joins the group.
+				IsIncremental bool
 				// Strategy for allocating topic partitions to members.
 				// Deprecated: Strategy exists for historical compatibility
 				// and should not be used. Please use GroupStrategies.


### PR DESCRIPTION
The idea is to get rid of stop the world during rebalancing without changing the main consumer interfaces. During the response from the heartbeat ErrRebalanceInProgress, the execution of fetch requests continues. In parallel, the reading from the departed partitions is closed.


tests is coming