### PR TITLE
Zstd encoder limit and raise encoder cache size

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -38,6 +38,9 @@ func newZstdEncoder(params ZstdEncoderParams) *zstd.Encoder {
 	}
 	zstdEnc, _ := zstd.NewWriter(nil, zstd.WithZeroFrames(true),
 		zstd.WithEncoderLevel(encoderLevel),
+		// 1MB is the default max message size in Kafka. We will usually not see messages larger than this.
+		// This results in a ~20% performance boost on high compression levels.
+		zstd.WithWindowSize(1024*1024),
 		zstd.WithEncoderConcurrency(1))
 	return zstdEnc
 }

--- a/zstd.go
+++ b/zstd.go
@@ -43,7 +43,6 @@ func newZstdEncoder(params ZstdEncoderParams) *zstd.Encoder {
 }
 
 func getZstdEncoder(params ZstdEncoderParams) *zstd.Encoder {
-
 	zstdMutex.Lock()
 	defer zstdMutex.Unlock()
 

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -2,9 +2,15 @@ package sarama
 
 import (
 	"runtime"
+	"sync"
 	"testing"
 )
 
+// BenchmarkZstdMemoryConsumption benchmarks the memory consumption of the zstd encoder under the following constraints
+// 1. The encoder is created with a high compression level
+// 2. The encoder is used to compress a 1MB buffer
+// 3. We emulate a 96 core system
+// In other words: we test the compression memory and cpu efficiency under minimal parallelism
 func BenchmarkZstdMemoryConsumption(b *testing.B) {
 	params := ZstdEncoderParams{Level: 9}
 	buf := make([]byte, 1024*1024)
@@ -15,15 +21,109 @@ func BenchmarkZstdMemoryConsumption(b *testing.B) {
 	cpus := 96
 
 	gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
+	defer runtime.GOMAXPROCS(gomaxprocsBackup)
+
+	b.SetBytes(int64(len(buf) * 2 * cpus))
+	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 2*cpus; j++ {
 			_, _ = zstdCompress(params, nil, buf)
 		}
-		// drain the buffered encoder
-		getZstdEncoder(params)
-		// previously this would be achieved with
-		// zstdEncMap.Delete(params)
+		// drain the buffered encoder so that we get a fresh one for the next run
+		zstdAvailableEncoders.Delete(params)
 	}
-	runtime.GOMAXPROCS(gomaxprocsBackup)
+
+	b.ReportMetric(float64(cpus), "(gomaxprocs)")
+	b.ReportMetric(float64(1), "(goroutines)")
+}
+
+// BenchmarkZstdMemoryConsumptionConcurrency benchmarks the memory consumption of the zstd encoder under the following constraints
+// 1. The encoder is created with a high compression level
+// 2. The encoder is used to compress a 1MB buffer
+// 3. We emulate a 2 core system
+// 4. We create 1000 goroutines that compress the buffer 2 times each
+// In summary: we test the compression memory and cpu efficiency under extreme concurrency
+func BenchmarkZstdMemoryConsumptionConcurrency(b *testing.B) {
+	params := ZstdEncoderParams{Level: 9}
+	buf := make([]byte, 1024*1024)
+	for i := 0; i < len(buf); i++ {
+		buf[i] = byte((i / 256) + (i * 257))
+	}
+
+	cpus := 4
+	goroutines := 256
+
+	gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
+	defer runtime.GOMAXPROCS(gomaxprocsBackup)
+
+	b.ReportMetric(float64(cpus), "(gomaxprocs)")
+	b.ResetTimer()
+	b.SetBytes(int64(len(buf) * goroutines))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// create n goroutines, wait until all start and then signal them to start compressing
+		var start sync.WaitGroup
+		var done sync.WaitGroup
+		start.Add(goroutines)
+		done.Add(goroutines)
+		for j := 0; j < goroutines; j++ {
+			go func() {
+				start.Done()
+				start.Wait()
+				_, _ = zstdCompress(params, nil, buf)
+				done.Done()
+			}()
+			zstdAvailableEncoders.Delete(params)
+		}
+		done.Wait()
+	}
+
+	b.ReportMetric(float64(cpus), "(gomaxprocs)")
+	b.ReportMetric(float64(goroutines), "(goroutines)")
+}
+
+// BenchmarkZstdMemoryNoConcurrencyLimit benchmarks the encoder behavior when the concurrency limit is disabled.
+func BenchmarkZstdMemoryNoConcurrencyLimit(b *testing.B) {
+	zstdTestingDisableConcurrencyLimit = true
+	defer func() {
+		zstdTestingDisableConcurrencyLimit = false
+	}()
+
+	params := ZstdEncoderParams{Level: 9}
+	buf := make([]byte, 1024*1024)
+	for i := 0; i < len(buf); i++ {
+		buf[i] = byte((i / 256) + (i * 257))
+	}
+
+	cpus := 4
+	goroutines := 256
+
+	gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
+	defer runtime.GOMAXPROCS(gomaxprocsBackup)
+
+	b.ReportMetric(float64(cpus), "(gomaxprocs)")
+	b.ResetTimer()
+	b.SetBytes(int64(len(buf) * goroutines))
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		// create n goroutines, wait until all start and then signal them to start compressing
+		var start sync.WaitGroup
+		var done sync.WaitGroup
+		start.Add(goroutines)
+		done.Add(goroutines)
+		for j := 0; j < goroutines; j++ {
+			go func() {
+				start.Done()
+				start.Wait()
+				_, _ = zstdCompress(params, nil, buf)
+				done.Done()
+			}()
+			zstdAvailableEncoders.Delete(params)
+		}
+		done.Wait()
+	}
+
+	b.ReportMetric(float64(cpus), "(gomaxprocs)")
+	b.ReportMetric(float64(goroutines), "(goroutines)")
 }


### PR DESCRIPTION
This PR addresses #2965 with a different approach.

This PR addresses 2 issues with the current implementation
1. The number of in-use zstd encoders can exceed GOMAXPROCS if a large number of goroutines are used
2. The number of cached encoders is too low for highly parallel sarama use, leading to repeated encoder creation and thus low throughput

The PR preserves the following property
- Encoders are lazy created

The memory behavior of applications can change slightly.
Before applying the patch:

- The maximum memory usage from encoders was tied to the concurrency (goroutines) but would shrink to 1 on idle

After applying the patch:
- The maximum memory usage from encoders is tied to the peak parallelism per compression level

This should not change the worst case for the great majority of users, but it might be relevant in cases where applications were alternating between high sarama use and other uses.

There are 2 new benchmarks and a testing flag (zstdTestingDisableConcurrencyLimit) to verify the concurrency limiting.
I've also added some more information to the tests (like setting the bytes so throughput can be measured).
Here is a sample output from my machine (AMD framework 13):
```
# go test -benchmem -run=^$ -test.v -bench ^BenchmarkZstdMemory github.com/IBM/sarama
goos: linux
goarch: amd64
pkg: github.com/IBM/sarama
cpu: AMD Ryzen 7 7840U w/ Radeon  780M Graphics     
BenchmarkZstdMemoryConsumption
BenchmarkZstdMemoryConsumption-16                             16          68034969 ns/op        2959.16 MB/s            96.00 (gomaxprocs)               1.000 (goroutines)     21974595 B/op           815 allocs/op
BenchmarkZstdMemoryConsumptionConcurrency
BenchmarkZstdMemoryConsumptionConcurrency-16                  39          30498097 ns/op        8801.71 MB/s             4.000 (gomaxprocs)            256.0 (goroutines)       86327669 B/op          1479 allocs/op
BenchmarkZstdMemoryNoConcurrencyLimit
BenchmarkZstdMemoryNoConcurrencyLimit-16                      21          52053651 ns/op        5156.90 MB/s             4.000 (gomaxprocs)            256.0 (goroutines)       437548737 B/op         2196 allocs/op
PASS
ok      github.com/IBM/sarama   3.566s
```