### PR TITLE
fix(lint): resolve IDENTICAL_BRANCHES issue in broker

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -1426,9 +1426,6 @@ func (b *Broker) sendAndReceiveSASLPlainAuthV0() error {
 func (b *Broker) sendAndReceiveSASLPlainAuthV1(authSendReceiver func(authBytes []byte) (*SaslAuthenticateResponse, error)) error {
 	authBytes := []byte(b.conf.Net.SASL.AuthIdentity + "\x00" + b.conf.Net.SASL.User + "\x00" + b.conf.Net.SASL.Password)
 	_, err := authSendReceiver(authBytes)
-	if err != nil {
-		return err
-	}
 	return err
 }
 


### PR DESCRIPTION
The same code is executed when the condition "err != nil" is true or false, because the code in the if-then branch and after the if statement is identical.