### PR TITLE
chore: add version consts for 3.8.1+3.9.0

### DIFF
--- a/.github/workflows/fvt-main.yml
+++ b/.github/workflows/fvt-main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.23.x]
-        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.2, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.0]
+        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.2, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11

--- a/.github/workflows/fvt-pr.yml
+++ b/.github/workflows/fvt-pr.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.23.x]
-        kafka-version: [1.0.2, 2.6.2, 3.6.2, 3.8.0]
+        kafka-version: [1.0.2, 2.6.2, 3.6.2, 3.8.1]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
@@ -24,7 +24,7 @@ jobs:
           scala-version: 2.12
         - kafka-version: 3.6.2
           scala-version: 2.13
-        - kafka-version: 3.8.0
+        - kafka-version: 3.8.1
           scala-version: 2.13
     uses: ./.github/workflows/fvt.yml
     with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ fail_fast: false
 default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -32,10 +32,10 @@ repos:
         files: \.go$
         args: []
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.16.3
+    rev: v8.21.2
     hooks:
       - id: gitleaks
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.52.2
+    rev: v1.61.0
     hooks:
       - id: golangci-lint

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -17,9 +17,9 @@ RUN cd /etc/java/java-11-openjdk/*/conf/security \
  && echo 'networkaddress.cache.negative.ttl=0' >> java.security
 
 ARG SCALA_VERSION="2.13"
-ARG KAFKA_VERSION="3.6.0"
+ARG KAFKA_VERSION="3.6.2"
 
-# https://github.com/apache/kafka/blob/0eaaff88cf68bc2c24d4874ff9bc1cc2b493c24b/tests/docker/Dockerfile#L75-L103
+# https://github.com/apache/kafka/blob/2e2b0a58eda3e677763af974a44a6aaa3c280214/tests/docker/Dockerfile#L77-L105
 ARG KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN mkdir -p "/opt/kafka-${KAFKA_VERSION}" \

--- a/utils.go
+++ b/utils.go
@@ -205,6 +205,8 @@ var (
 	V3_7_0_0  = newKafkaVersion(3, 7, 0, 0)
 	V3_7_1_0  = newKafkaVersion(3, 7, 1, 0)
 	V3_8_0_0  = newKafkaVersion(3, 8, 0, 0)
+	V3_8_1_0  = newKafkaVersion(3, 8, 1, 0)
+	V3_9_0_0  = newKafkaVersion(3, 9, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -274,9 +276,11 @@ var (
 		V3_7_0_0,
 		V3_7_1_0,
 		V3_8_0_0,
+		V3_8_1_0,
+		V3_9_0_0,
 	}
 	MinVersion     = V0_8_2_0
-	MaxVersion     = V3_8_0_0
+	MaxVersion     = V3_9_0_0
 	DefaultVersion = V2_1_0_0
 
 	// reduced set of protocol versions to matrix test


### PR DESCRIPTION
Also bump the 3.8 FV to use the 3.8.1 packages.

Will add Kafka 3.9.0 to the FV once it is available from: https://s3-us-west-2.amazonaws.com/kafka-packages