### PR TITLE
chore(test): include kafka 4.0.0 in FV testing

### DIFF
--- a/.github/workflows/fvt-main.yml
+++ b/.github/workflows/fvt-main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.23.x]
-        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.2, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1]
+        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.2, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 4.0.0]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
@@ -36,6 +36,8 @@ jobs:
         - kafka-version: 3.6.2
           scala-version: 2.13
         - kafka-version: 3.8.0
+          scala-version: 2.13
+        - kafka-version: 4.0.0
           scala-version: 2.13
     uses: ./.github/workflows/fvt.yml
     with:

--- a/.github/workflows/fvt-pr.yml
+++ b/.github/workflows/fvt-pr.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.23.x]
-        kafka-version: [1.0.2, 2.6.2, 3.6.2, 3.8.1]
+        kafka-version: [1.0.2, 2.6.2, 3.6.2, 3.8.1, 4.0.0]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
@@ -25,6 +25,8 @@ jobs:
         - kafka-version: 3.6.2
           scala-version: 2.13
         - kafka-version: 3.8.1
+          scala-version: 2.13
+        - kafka-version: 4.0.0
           scala-version: 2.13
     uses: ./.github/workflows/fvt.yml
     with:

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -1,17 +1,17 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.10@sha256:cf095e5668919ba1b4ace3888107684ad9d587b1830d3eb56973e6a54f456e67
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:daa61d6103e98bccf40d7a69a0d4f8786ec390e2204fd94f7cc49053e9949360
 
 USER root
 
 RUN microdnf update -y \
- && microdnf install -y curl gzip java-11-openjdk-headless tar tzdata-java \
+ && microdnf install -y gzip java-17-openjdk-headless tar tzdata-java \
  && microdnf reinstall -y tzdata \
  && microdnf clean all
 
-ENV JAVA_HOME=/usr/lib/jvm/jre-11
+ENV JAVA_HOME=/usr/lib/jvm/jre-17
 
 # https://docs.oracle.com/javase/7/docs/technotes/guides/net/properties.html
 # Ensure Java doesn't cache any dns results
-RUN cd /etc/java/java-11-openjdk/*/conf/security \
+RUN cd /etc/java/java-17-openjdk/*/conf/security \
  && sed -e '/networkaddress.cache.ttl/d' -e '/networkaddress.cache.negative.ttl/d' -i java.security \
  && echo 'networkaddress.cache.ttl=0' >> java.security \
  && echo 'networkaddress.cache.negative.ttl=0' >> java.security
@@ -36,7 +36,7 @@ RUN curl -sLO "https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb
 
 WORKDIR /opt/kafka-${KAFKA_VERSION}
 
-ENV JAVA_MAJOR_VERSION=11
+ENV JAVA_MAJOR_VERSION=17
 
 RUN sed -e "s/JAVA_MAJOR_VERSION=.*/JAVA_MAJOR_VERSION=${JAVA_MAJOR_VERSION}/" -i"" ./bin/kafka-run-class.sh
 

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5@sha256:daa61d6103e98bccf40d
 USER root
 
 RUN microdnf update -y \
- && microdnf install -y gzip java-17-openjdk-headless tar tzdata-java \
+ && microdnf install -y git gzip java-17-openjdk-headless tar tzdata-java \
  && microdnf reinstall -y tzdata \
  && microdnf clean all
 
@@ -19,17 +19,30 @@ RUN cd /etc/java/java-17-openjdk/*/conf/security \
 ARG SCALA_VERSION="2.13"
 ARG KAFKA_VERSION="3.6.2"
 
+WORKDIR /tmp
+
 # https://github.com/apache/kafka/blob/2e2b0a58eda3e677763af974a44a6aaa3c280214/tests/docker/Dockerfile#L77-L105
 ARG KAFKA_MIRROR="https://s3-us-west-2.amazonaws.com/kafka-packages"
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN mkdir -p "/opt/kafka-${KAFKA_VERSION}" \
+RUN --mount=type=bind,target=.,rw=true \
+    mkdir -p "/opt/kafka-${KAFKA_VERSION}" \
  && chmod a+rw "/opt/kafka-${KAFKA_VERSION}" \
- && curl -s "$KAFKA_MIRROR/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" | tar xz --strip-components=1 -C "/opt/kafka-${KAFKA_VERSION}"
+ && if [ "$KAFKA_VERSION" = "4.0.0" ]; then \
+       microdnf install -y java-17-openjdk-devel \
+    && git clone --depth=1 --single-branch -b 4.0 https://github.com/apache/kafka /usr/src/kafka \
+    && export JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=80 \
+    && cd /usr/src/kafka && sed -e '/version=/s/-SNAPSHOT//' -e '/org.gradle.jvmargs/d' -e '/org.gradle.parallel/s/true/false/' -i gradle.properties && ./gradlew -PmaxParallelForks=1 -PmaxScalacThreads=1 --no-daemon releaseTarGz -x siteDocsTar -x javadoc \
+    && tar xzf core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz --strip-components=1 -C "/opt/kafka-${KAFKA_VERSION}" \
+    && cp /tmp/server.properties "/opt/kafka-${KAFKA_VERSION}/config/" \
+    && microdnf remove -y java-17-openjdk-devel \
+    && rm -rf /usr/src/kafka ; \
+    else \
+      curl -s "$KAFKA_MIRROR/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" | tar xz --strip-components=1 -C "/opt/kafka-${KAFKA_VERSION}" ; \
+    fi
 
 # older kafka versions depend upon jaxb-api being bundled with the JDK, but it
 # was removed from Java 11 so work around that by including it in the kafka
 # libs dir regardless
-WORKDIR /tmp
 RUN curl -sLO "https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb-api-2.3.0.jar" \
  && for DIR in /opt/kafka-*; do cp -v jaxb-api-2.3.0.jar $DIR/libs/ ; done \
  && rm -f jaxb-api-2.3.0.jar

--- a/create_topics_request.go
+++ b/create_topics_request.go
@@ -16,6 +16,21 @@ type CreateTopicsRequest struct {
 	ValidateOnly bool
 }
 
+func NewCreateTopicsRequest(version KafkaVersion, topicDetails map[string]*TopicDetail, timeout time.Duration) *CreateTopicsRequest {
+	r := &CreateTopicsRequest{
+		TopicDetails: topicDetails,
+		Timeout:      timeout,
+	}
+	if version.IsAtLeast(V2_0_0_0) {
+		r.Version = 3
+	} else if version.IsAtLeast(V0_11_0_0) {
+		r.Version = 2
+	} else if version.IsAtLeast(V0_10_2_0) {
+		r.Version = 1
+	}
+	return r
+}
+
 func (c *CreateTopicsRequest) encode(pe packetEncoder) error {
 	if err := pe.putArrayLength(len(c.TopicDetails)); err != nil {
 		return err

--- a/delete_topics_request.go
+++ b/delete_topics_request.go
@@ -8,6 +8,21 @@ type DeleteTopicsRequest struct {
 	Timeout time.Duration
 }
 
+func NewDeleteTopicsRequest(version KafkaVersion, topics []string, timeout time.Duration) *DeleteTopicsRequest {
+	d := &DeleteTopicsRequest{
+		Topics:  topics,
+		Timeout: timeout,
+	}
+	if version.IsAtLeast(V2_1_0_0) {
+		d.Version = 3
+	} else if version.IsAtLeast(V2_0_0_0) {
+		d.Version = 2
+	} else if version.IsAtLeast(V0_11_0_0) {
+		d.Version = 1
+	}
+	return d
+}
+
 func (d *DeleteTopicsRequest) encode(pe packetEncoder) error {
 	if err := pe.putStringArray(d.Topics); err != nil {
 		return err

--- a/functional_consumer_test.go
+++ b/functional_consumer_test.go
@@ -447,6 +447,13 @@ func versionRange(lower KafkaVersion) []KafkaVersion {
 		upper = MaxVersion
 	}
 
+	// KIP-896 dictates a minimum lower bound of 2.1 protocol for Kafka 4.0 onwards
+	if upper.IsAtLeast(V4_0_0_0) {
+		if !lower.IsAtLeast(V2_1_0_0) {
+			lower = V2_1_0_0
+		}
+	}
+
 	versions := make([]KafkaVersion, 0, len(fvtRangeVersions))
 	for _, v := range fvtRangeVersions {
 		if !v.IsAtLeast(lower) {

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -46,6 +46,7 @@ func TestFuncProducingZstd(t *testing.T) {
 
 func TestFuncProducingNoResponse(t *testing.T) {
 	config := NewFunctionalTestConfig()
+	config.ApiVersionsRequest = false
 	config.Producer.RequiredAcks = NoResponse
 	testProducingMessages(t, config, MinVersion)
 }
@@ -812,7 +813,11 @@ func testProducingMessages(t *testing.T, config *Config, minVersion KafkaVersion
 	config.Consumer.Return.Errors = true
 
 	kafkaVersions := map[KafkaVersion]bool{}
-	if upper, err := ParseKafkaVersion(os.Getenv("KAFKA_VERSION")); err != nil {
+	upper, err := ParseKafkaVersion(os.Getenv("KAFKA_VERSION"))
+	if err != nil {
+		t.Logf("warning: failed to parse kafka version: %v", err)
+	}
+	if upper.IsAtLeast(minVersion) {
 		kafkaVersions[upper] = true
 		// KIP-896 dictates a minimum lower bound of 2.1 protocol for Kafka 4.0 onwards
 		if upper.IsAtLeast(V4_0_0_0) {
@@ -823,10 +828,11 @@ func testProducingMessages(t *testing.T, config *Config, minVersion KafkaVersion
 	}
 
 	for _, v := range []KafkaVersion{MinVersion, V0_10_0_0, V0_11_0_0, V1_0_0_0, V2_0_0_0, V2_1_0_0} {
-		if v.IsAtLeast(minVersion) {
+		if v.IsAtLeast(minVersion) && upper.IsAtLeast(v) {
 			kafkaVersions[v] = true
 		}
 	}
+
 	for version := range kafkaVersions {
 		name := t.Name() + "-v" + version.String()
 		t.Run(name, func(t *testing.T) {

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -812,15 +812,21 @@ func testProducingMessages(t *testing.T, config *Config, minVersion KafkaVersion
 	config.Consumer.Return.Errors = true
 
 	kafkaVersions := map[KafkaVersion]bool{}
+	if upper, err := ParseKafkaVersion(os.Getenv("KAFKA_VERSION")); err != nil {
+		kafkaVersions[upper] = true
+		// KIP-896 dictates a minimum lower bound of 2.1 protocol for Kafka 4.0 onwards
+		if upper.IsAtLeast(V4_0_0_0) {
+			if !minVersion.IsAtLeast(V2_1_0_0) {
+				minVersion = V2_1_0_0
+			}
+		}
+	}
+
 	for _, v := range []KafkaVersion{MinVersion, V0_10_0_0, V0_11_0_0, V1_0_0_0, V2_0_0_0, V2_1_0_0} {
 		if v.IsAtLeast(minVersion) {
 			kafkaVersions[v] = true
 		}
 	}
-	if upper, err := ParseKafkaVersion(os.Getenv("KAFKA_VERSION")); err != nil {
-		kafkaVersions[upper] = true
-	}
-
 	for version := range kafkaVersions {
 		name := t.Name() + "-v" + version.String()
 		t.Run(name, func(t *testing.T) {

--- a/functional_test.go
+++ b/functional_test.go
@@ -346,16 +346,16 @@ func prepareTestTopics(ctx context.Context, env *testEnvironment) error {
 	defer controller.Close()
 
 	// Start by deleting the test topics (if they already exist)
-	deleteRes, err := controller.DeleteTopics(&DeleteTopicsRequest{
-		Topics:  testTopicNames,
-		Timeout: time.Minute,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to delete test topics: %w", err)
-	}
-	for topic, topicErr := range deleteRes.TopicErrorCodes {
-		if !isTopicNotExistsErrorOrOk(topicErr) {
-			return fmt.Errorf("failed to delete topic %s: %w", topic, topicErr)
+	{
+		request := NewDeleteTopicsRequest(config.Version, testTopicNames, time.Minute)
+		deleteRes, err := controller.DeleteTopics(request)
+		if err != nil {
+			return fmt.Errorf("failed to delete test topics: %w", err)
+		}
+		for topic, topicErr := range deleteRes.TopicErrorCodes {
+			if !isTopicNotExistsErrorOrOk(topicErr) {
+				return fmt.Errorf("failed to delete topic %s: %w", topic, topicErr)
+			}
 		}
 	}
 
@@ -363,11 +363,10 @@ func prepareTestTopics(ctx context.Context, env *testEnvironment) error {
 	// synchronously
 	{
 		var topicsOk bool
+		request := NewMetadataRequest(config.Version, testTopicNames)
 		for i := 0; i < 60 && !topicsOk; i++ {
 			time.Sleep(1 * time.Second)
-			md, err := controller.GetMetadata(&MetadataRequest{
-				Topics: testTopicNames,
-			})
+			md, err := controller.GetMetadata(request)
 			if err != nil {
 				return fmt.Errorf("failed to get metadata for test topics: %w", err)
 			}
@@ -387,16 +386,16 @@ func prepareTestTopics(ctx context.Context, env *testEnvironment) error {
 	}
 
 	// now create the topics empty
-	createRes, err := controller.CreateTopics(&CreateTopicsRequest{
-		TopicDetails: testTopicDetails,
-		Timeout:      time.Minute,
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create test topics: %w", err)
-	}
-	for topic, topicErr := range createRes.TopicErrors {
-		if !isTopicExistsErrorOrOk(topicErr.Err) {
-			return fmt.Errorf("failed to create test topic %s: %w", topic, topicErr)
+	{
+		request := NewCreateTopicsRequest(config.Version, testTopicDetails, time.Minute)
+		createRes, err := controller.CreateTopics(request)
+		if err != nil {
+			return fmt.Errorf("failed to create test topics: %w", err)
+		}
+		for topic, topicErr := range createRes.TopicErrors {
+			if !isTopicExistsErrorOrOk(topicErr.Err) {
+				return fmt.Errorf("failed to create test topic %s: %w", topic, topicErr)
+			}
 		}
 	}
 
@@ -404,11 +403,10 @@ func prepareTestTopics(ctx context.Context, env *testEnvironment) error {
 	// synchronously
 	{
 		var topicsOk bool
+		request := NewMetadataRequest(config.Version, testTopicNames)
 		for i := 0; i < 60 && !topicsOk; i++ {
 			time.Sleep(1 * time.Second)
-			md, err := controller.GetMetadata(&MetadataRequest{
-				Topics: testTopicNames,
-			})
+			md, err := controller.GetMetadata(request)
 			if err != nil {
 				return fmt.Errorf("failed to get metadata for test topics: %w", err)
 			}

--- a/server.properties
+++ b/server.properties
@@ -1,0 +1,138 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This configuration file is intended for use in ZK-based mode, where Apache ZooKeeper is required.
+# See kafka.server.KafkaConfig for additional details and defaults
+#
+
+############################# Server Basics #############################
+
+# The id of the broker. This must be set to a unique integer for each broker.
+broker.id=0
+
+############################# Socket Server Settings #############################
+
+# The address the socket server listens on. If not configured, the host name will be equal to the value of
+# java.net.InetAddress.getCanonicalHostName(), with PLAINTEXT listener name, and port 9092.
+#   FORMAT:
+#     listeners = listener_name://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
+#listeners=PLAINTEXT://:9092
+
+# Listener name, hostname and port the broker will advertise to clients.
+# If not set, it uses the value for "listeners".
+#advertised.listeners=PLAINTEXT://your.host.name:9092
+
+# Maps listener names to security protocols, the default is for them to be the same. See the config documentation for more details
+#listener.security.protocol.map=PLAINTEXT:PLAINTEXT,SSL:SSL,SASL_PLAINTEXT:SASL_PLAINTEXT,SASL_SSL:SASL_SSL
+
+# The number of threads that the server uses for receiving requests from the network and sending responses to the network
+num.network.threads=3
+
+# The number of threads that the server uses for processing requests, which may include disk I/O
+num.io.threads=8
+
+# The send buffer (SO_SNDBUF) used by the socket server
+socket.send.buffer.bytes=102400
+
+# The receive buffer (SO_RCVBUF) used by the socket server
+socket.receive.buffer.bytes=102400
+
+# The maximum size of a request that the socket server will accept (protection against OOM)
+socket.request.max.bytes=104857600
+
+
+############################# Log Basics #############################
+
+# A comma separated list of directories under which to store log files
+log.dirs=/tmp/kafka-logs
+
+# The default number of log partitions per topic. More partitions allow greater
+# parallelism for consumption, but this will also result in more files across
+# the brokers.
+num.partitions=1
+
+# The number of threads per data directory to be used for log recovery at startup and flushing at shutdown.
+# This value is recommended to be increased for installations with data dirs located in RAID array.
+num.recovery.threads.per.data.dir=1
+
+############################# Internal Topic Settings  #############################
+# The replication factor for the group metadata internal topics "__consumer_offsets" and "__transaction_state"
+# For anything other than development testing, a value greater than 1 is recommended to ensure availability such as 3.
+offsets.topic.replication.factor=1
+transaction.state.log.replication.factor=1
+transaction.state.log.min.isr=1
+
+############################# Log Flush Policy #############################
+
+# Messages are immediately written to the filesystem but by default we only fsync() to sync
+# the OS cache lazily. The following configurations control the flush of data to disk.
+# There are a few important trade-offs here:
+#    1. Durability: Unflushed data may be lost if you are not using replication.
+#    2. Latency: Very large flush intervals may lead to latency spikes when the flush does occur as there will be a lot of data to flush.
+#    3. Throughput: The flush is generally the most expensive operation, and a small flush interval may lead to excessive seeks.
+# The settings below allow one to configure the flush policy to flush data after a period of time or
+# every N messages (or both). This can be done globally and overridden on a per-topic basis.
+
+# The number of messages to accept before forcing a flush of data to disk
+#log.flush.interval.messages=10000
+
+# The maximum amount of time a message can sit in a log before we force a flush
+#log.flush.interval.ms=1000
+
+############################# Log Retention Policy #############################
+
+# The following configurations control the disposal of log segments. The policy can
+# be set to delete segments after a period of time, or after a given size has accumulated.
+# A segment will be deleted whenever *either* of these criteria are met. Deletion always happens
+# from the end of the log.
+
+# The minimum age of a log file to be eligible for deletion due to age
+log.retention.hours=168
+
+# A size-based retention policy for logs. Segments are pruned from the log unless the remaining
+# segments drop below log.retention.bytes. Functions independently of log.retention.hours.
+#log.retention.bytes=1073741824
+
+# The maximum size of a log segment file. When this size is reached a new log segment will be created.
+#log.segment.bytes=1073741824
+
+# The interval at which log segments are checked to see if they can be deleted according
+# to the retention policies
+log.retention.check.interval.ms=300000
+
+############################# Zookeeper #############################
+
+# Zookeeper connection string (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+# You can also append an optional chroot string to the urls to specify the
+# root directory for all kafka znodes.
+zookeeper.connect=localhost:2181
+
+# Timeout in ms for connecting to zookeeper
+zookeeper.connection.timeout.ms=18000
+
+
+############################# Group Coordinator Settings #############################
+
+# The following configuration specifies the time, in milliseconds, that the GroupCoordinator will delay the initial consumer rebalance.
+# The rebalance will be further delayed by the value of group.initial.rebalance.delay.ms as new members join the group, up to a maximum of max.poll.interval.ms.
+# The default value for this is 3 seconds.
+# We override this to 0 here as it makes for a better out-of-the-box experience for development and testing.
+# However, in production environments the default value of 3 seconds is more suitable as this will help to avoid unnecessary, and potentially expensive, rebalances during application startup.
+group.initial.rebalance.delay.ms=0

--- a/utils.go
+++ b/utils.go
@@ -206,6 +206,7 @@ var (
 	V3_8_0_0  = newKafkaVersion(3, 8, 0, 0)
 	V3_8_1_0  = newKafkaVersion(3, 8, 1, 0)
 	V3_9_0_0  = newKafkaVersion(3, 9, 0, 0)
+	V4_0_0_0  = newKafkaVersion(4, 0, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -277,9 +278,10 @@ var (
 		V3_8_0_0,
 		V3_8_1_0,
 		V3_9_0_0,
+		V4_0_0_0,
 	}
 	MinVersion     = V0_8_2_0
-	MaxVersion     = V3_9_0_0
+	MaxVersion     = V4_0_0_0
 	DefaultVersion = V2_1_0_0
 
 	// reduced set of protocol versions to matrix test


### PR DESCRIPTION
Whilst 4.0 isn't yet released, in order to allow us to do some up-front testing, compile from src and include in FV runs

Note: we have to include a server.properties for ZooKeeper mode as the 4.0 release no longer includes it. They only ship a Kraft-mode config file and we still want to run in ZooKeeper mode for now as its more convenient for the FV setup to be consistent 