### PR TITLE
fix(ci): patch zookeeper client to 3.5.9 on older Kafka

### DIFF
--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -50,6 +50,12 @@ RUN curl -sLO "https://repo1.maven.org/maven2/javax/xml/bind/jaxb-api/2.3.0/jaxb
  && for DIR in /opt/kafka-*; do cp -v jaxb-api-2.3.0.jar $DIR/libs/ ; done \
  && rm -f jaxb-api-2.3.0.jar
 
+# older kafka versions with the zookeeper 3.4.13 client aren't compatible with Java 17 so quietly bump them to 3.5.9
+RUN [ -f "/opt/kafka-${KAFKA_VERSION}/libs/zookeeper-3.4.13.jar" ] || exit 0 ; \
+    rm -f "/opt/kafka-${KAFKA_VERSION}/libs/zookeeper-3.4.13.jar" \
+ && curl --fail -sSL -o "/opt/kafka-${KAFKA_VERSION}/libs/zookeeper-3.5.9.jar" "https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper/3.5.9/zookeeper-3.5.9.jar" \
+ && curl --fail -sSL -o "/opt/kafka-${KAFKA_VERSION}/libs/zookeeper-jute-3.5.9.jar" "https://repo1.maven.org/maven2/org/apache/zookeeper/zookeeper-jute/3.5.9/zookeeper-jute-3.5.9.jar"
+
 WORKDIR /opt/kafka-${KAFKA_VERSION}
 
 ENV JAVA_MAJOR_VERSION=17

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   zookeeper-1:
-    hostname: 'zookeeper-1'
+    container_name: 'zookeeper-1'
     image: 'docker.io/library/zookeeper:3.7.2'
     init: true
     restart: always
@@ -13,7 +13,7 @@ services:
       ZOO_MAX_CLIENT_CNXNS: '0'
       ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
   zookeeper-2:
-    hostname: 'zookeeper-2'
+    container_name: 'zookeeper-2'
     image: 'docker.io/library/zookeeper:3.7.2'
     init: true
     restart: always
@@ -26,7 +26,7 @@ services:
       ZOO_MAX_CLIENT_CNXNS: '0'
       ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
   zookeeper-3:
-    hostname: 'zookeeper-3'
+    container_name: 'zookeeper-3'
     image: 'docker.io/library/zookeeper:3.7.2'
     init: true
     restart: always
@@ -39,7 +39,7 @@ services:
       ZOO_MAX_CLIENT_CNXNS: '0'
       ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
   kafka-1:
-    hostname: 'kafka-1'
+    container_name: 'kafka-1'
     image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
     init: true
     build:
@@ -86,7 +86,7 @@ services:
       KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
   kafka-2:
-    hostname: 'kafka-2'
+    container_name: 'kafka-2'
     image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
     init: true
     build:
@@ -133,7 +133,7 @@ services:
       KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
   kafka-3:
-    hostname: 'kafka-3'
+    container_name: 'kafka-3'
     image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
     init: true
     build:
@@ -180,7 +180,7 @@ services:
       KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
   kafka-4:
-    hostname: 'kafka-4'
+    container_name: 'kafka-4'
     image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
     init: true
     build:
@@ -227,7 +227,7 @@ services:
       KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
   kafka-5:
-    hostname: 'kafka-5'
+    container_name: 'kafka-5'
     image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
     init: true
     build:
@@ -274,7 +274,7 @@ services:
       KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
   toxiproxy:
-    hostname: 'toxiproxy'
+    container_name: 'toxiproxy'
     image: 'ghcr.io/shopify/toxiproxy:2.4.0'
     init: true
     healthcheck:


### PR DESCRIPTION
Having purged the caches and re-built the FV images, it is evident that the 3.4.13 zookeeper client is incompatible with Java 17 (see ZOOKEEPER-3779). Rather than use different Java versions for those, just quietly bump the bundled zookeeper client to 3.5.9 (as used in Kafka 2.6) which is API compatible and resolves the issue with Java 17