### PR TITLE
chore(ci): bump 2.6.x FV to its last patch release

### DIFF
--- a/.github/workflows/fvt-main.yml
+++ b/.github/workflows/fvt-main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.23.x]
-        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.2, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 4.0.0]
+        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.3, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 4.0.0]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
@@ -25,7 +25,7 @@ jobs:
           scala-version: 2.12
         - kafka-version: 2.2.2
           scala-version: 2.12
-        - kafka-version: 2.6.2
+        - kafka-version: 2.6.3
           scala-version: 2.12
         - kafka-version: 2.8.2
           scala-version: 2.12
@@ -35,7 +35,7 @@ jobs:
           scala-version: 2.13
         - kafka-version: 3.6.2
           scala-version: 2.13
-        - kafka-version: 3.8.0
+        - kafka-version: 3.8.1
           scala-version: 2.13
         - kafka-version: 4.0.0
           scala-version: 2.13

--- a/.github/workflows/fvt-pr.yml
+++ b/.github/workflows/fvt-pr.yml
@@ -16,11 +16,11 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.23.x]
-        kafka-version: [1.0.2, 2.6.2, 3.6.2, 3.8.1, 4.0.0]
+        kafka-version: [1.0.2, 2.6.3, 3.6.2, 3.8.1, 4.0.0]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
-        - kafka-version: 2.6.2
+        - kafka-version: 2.6.3
           scala-version: 2.12
         - kafka-version: 3.6.2
           scala-version: 2.13


### PR DESCRIPTION
Just for consistency, use the last patch release of 2.6.x for FV testing. Also fix the scala-version entry for 3.8.1 in the fv-main build matrix.