### PR TITLE
chore(ci): fetch kafka 4.0 via tar.gz rather than git

### DIFF
--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -29,10 +29,10 @@ RUN --mount=type=bind,target=.,rw=true \
  && chmod a+rw "/opt/kafka-${KAFKA_VERSION}" \
  && if [ "$KAFKA_VERSION" = "4.0.0" ]; then \
        microdnf install -y java-17-openjdk-devel \
-    && git clone --depth=50 --single-branch -b 4.0 https://github.com/apache/kafka /usr/src/kafka \
+    && git clone --depth=1024 --single-branch -b 4.0 https://github.com/apache/kafka /usr/src/kafka \
     && cd /usr/src/kafka \
     && : PIN TO COMMIT BEFORE KAFKA-17616 ZOOKEEPER REMOVAL STARTED \
-    && git reset --hard d1504649fb \
+    && git reset --hard d1504649fbe45064a0b0120ff33de9326b2fc662 \
     && export JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=80 \
     && sed -e '/version=/s/-SNAPSHOT//' -e '/org.gradle.jvmargs/d' -e '/org.gradle.parallel/s/true/false/' -i gradle.properties && ./gradlew -PmaxParallelForks=1 -PmaxScalacThreads=1 --no-daemon releaseTarGz -x siteDocsTar -x javadoc \
     && tar xzf core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz --strip-components=1 -C "/opt/kafka-${KAFKA_VERSION}" \

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -29,10 +29,11 @@ RUN --mount=type=bind,target=.,rw=true \
  && chmod a+rw "/opt/kafka-${KAFKA_VERSION}" \
  && if [ "$KAFKA_VERSION" = "4.0.0" ]; then \
        microdnf install -y java-17-openjdk-devel \
-    && git clone --depth=1024 --single-branch -b 4.0 https://github.com/apache/kafka /usr/src/kafka \
+    && mkdir -p /usr/src/kafka \
+    && : PIN TO COMMIT OF 4.0 BRANCH BEFORE KAFKA-17616 ZOOKEEPER REMOVAL STARTED \
+    && curl --fail -sSL https://github.com/apache/kafka/archive/d1504649fbe45064a0b0120ff33de9326b2fc662.tar.gz | \
+         tar zxf - -C /usr/src/kafka --strip-components=1 \
     && cd /usr/src/kafka \
-    && : PIN TO COMMIT BEFORE KAFKA-17616 ZOOKEEPER REMOVAL STARTED \
-    && git reset --hard d1504649fbe45064a0b0120ff33de9326b2fc662 \
     && export JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=80 \
     && sed -e '/version=/s/-SNAPSHOT//' -e '/org.gradle.jvmargs/d' -e '/org.gradle.parallel/s/true/false/' -i gradle.properties && ./gradlew -PmaxParallelForks=1 -PmaxScalacThreads=1 --no-daemon releaseTarGz -x siteDocsTar -x javadoc \
     && tar xzf core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz --strip-components=1 -C "/opt/kafka-${KAFKA_VERSION}" \


### PR DESCRIPTION
The build is broken again because the pinned commit has dropped off the last 50 commits of branch 4.0. Bump up the depth and use a full qualified sha too.