### PR TITLE
fix(ci): tighten up github workflows

### DIFF
--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -57,7 +57,7 @@ jobs:
         docker compose version
     - name: Test (Functional)
       run: |
-        nohup sudo tcpdump -i lo -w "fvt-kafka-${{ inputs.kafka-version }}.pcap" portrange 29091-29095 >/dev/null 2>&1 &
+        nohup sudo tcpdump -i lo -w "fvt-kafka-${KAFKA_VERSION}.pcap" portrange 29091-29095 >/dev/null 2>&1 &
         echo $! >tcpdump.pid
         make test_functional
         echo "## Code Coverage" >>$GITHUB_STEP_SUMMARY
@@ -68,7 +68,7 @@ jobs:
       if: always()
       run: |
         if [ -f "tcpdump.pid" ]; then sudo kill "$(cat tcpdump.pid)" || true; fi
-        if [ -f "fvt-kafka-${{ inputs.kafka-version }}.pcap" ]; then sudo chmod a+r "fvt-kafka-${{ inputs.kafka-version }}.pcap"; fi
+        if [ -f "fvt-kafka-${KAFKA_VERSION}.pcap" ]; then sudo chmod a+r "fvt-kafka-${KAFKA_VERSION}.pcap"; fi
     - name: Upload pcap file
       if: always()
       uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,7 +1,3 @@
-# This workflow uses actions that are not certified by GitHub. They are provided
-# by a third-party and are governed by separate terms of service, privacy
-# policy, and support documentation.
-
 name: Scorecard supply-chain security
 on:
   # For Branch-Protection check. Only the default branch is supported. See
@@ -15,7 +11,13 @@ on:
     branches: [ "main" ]
 
 # Declare default permissions as read only.
-permissions: read-all
+permissions:
+  actions: read
+  checks: read
+  contents: read
+  issues: read
+  pull-requests: read
+  statuses: read
 
 jobs:
   analysis:


### PR DESCRIPTION
- consistently pass KAFKA_VERSION as envvar to ensure the shell performs the variable expansion
- update scorecard.yml read-only permissions to be narrower and more explicit