### PR TITLE
feat(producer): add MaxBufferBytes to limit retry buffer size

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -16,9 +16,16 @@ import (
 // ErrProducerRetryBufferOverflow is returned when the bridging retry buffer is full and OOM prevention needs to be applied.
 var ErrProducerRetryBufferOverflow = errors.New("retry buffer full: message discarded to prevent buffer overflow")
 
-// minFunctionalRetryBufferLength is the lower limit of Producer.Retry.MaxBufferLength for it to function.
-// Any non-zero maxBufferLength but less than this lower limit is pushed to the lower limit.
-const minFunctionalRetryBufferLength = 4 * 1024
+const (
+	// minFunctionalRetryBufferLength defines the minimum number of messages the retry buffer must support.
+	// If Producer.Retry.MaxBufferLength is set to a non-zero value below this limit, it will be adjusted to this value.
+	// This ensures the retry buffer remains functional under typical workloads.
+	minFunctionalRetryBufferLength = 4 * 1024
+	// minFunctionalRetryBufferBytes defines the minimum total byte size the retry buffer must support.
+	// If Producer.Retry.MaxBufferBytes is set to a non-zero value below this limit, it will be adjusted to this value.
+	// A 32 MB lower limit ensures sufficient capacity for retrying larger messages without exhausting resources.
+	minFunctionalRetryBufferBytes = 32 * 1024 * 1024
+)
 
 // AsyncProducer publishes Kafka messages using a non-blocking API. It routes messages
 // to the correct broker for the provided topic-partition, refreshing metadata as appropriate,
@@ -1214,11 +1221,22 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 // effectively a "bridge" between the flushers and the dispatcher in order to avoid deadlock
 // based on https://godoc.org/github.com/eapache/channels#InfiniteChannel
 func (p *asyncProducer) retryHandler() {
-	maxBufferSize := p.conf.Producer.Retry.MaxBufferLength
-	if 0 < maxBufferSize && maxBufferSize < minFunctionalRetryBufferLength {
-		maxBufferSize = minFunctionalRetryBufferLength
+	maxBufferLength := p.conf.Producer.Retry.MaxBufferLength
+	if 0 < maxBufferLength && maxBufferLength < minFunctionalRetryBufferLength {
+		maxBufferLength = minFunctionalRetryBufferLength
 	}
 
+	maxBufferBytes := p.conf.Producer.Retry.MaxBufferBytes
+	if 0 < maxBufferBytes && maxBufferBytes < minFunctionalRetryBufferBytes {
+		maxBufferBytes = minFunctionalRetryBufferBytes
+	}
+
+	version := 1
+	if p.conf.Version.IsAtLeast(V0_11_0_0) {
+		version = 2
+	}
+
+	var currentByteSize int64
 	var msg *ProducerMessage
 	buf := queue.New()
 
@@ -1229,7 +1247,8 @@ func (p *asyncProducer) retryHandler() {
 			select {
 			case msg = <-p.retries:
 			case p.input <- buf.Peek().(*ProducerMessage):
-				buf.Remove()
+				msgToRemove := buf.Remove().(*ProducerMessage)
+				currentByteSize -= int64(msgToRemove.ByteSize(version))
 				continue
 			}
 		}
@@ -1239,17 +1258,22 @@ func (p *asyncProducer) retryHandler() {
 		}
 
 		buf.Add(msg)
+		currentByteSize += int64(msg.ByteSize(version))
 
-		if maxBufferSize > 0 && buf.Length() >= maxBufferSize {
-			msgToHandle := buf.Peek().(*ProducerMessage)
-			if msgToHandle.flags == 0 {
-				select {
-				case p.input <- msgToHandle:
-					buf.Remove()
-				default:
-					buf.Remove()
-					p.returnError(msgToHandle, ErrProducerRetryBufferOverflow)
-				}
+		if (maxBufferLength <= 0 || buf.Length() < maxBufferLength) && (maxBufferBytes <= 0 || currentByteSize < maxBufferBytes) {
+			continue
+		}
+
+		msgToHandle := buf.Peek().(*ProducerMessage)
+		if msgToHandle.flags == 0 {
+			select {
+			case p.input <- msgToHandle:
+				buf.Remove()
+				currentByteSize -= int64(msgToHandle.ByteSize(version))
+			default:
+				buf.Remove()
+				currentByteSize -= int64(msgToHandle.ByteSize(version))
+				p.returnError(msgToHandle, ErrProducerRetryBufferOverflow)
 			}
 		}
 	}

--- a/config.go
+++ b/config.go
@@ -276,6 +276,13 @@ type Config struct {
 			// Any value between 0 and 4096 is pushed to 4096.
 			// A zero or negative value indicates unlimited.
 			MaxBufferLength int
+			// The maximum total byte size of messages in the bridging buffer between `input`
+			// and `retries` channels in AsyncProducer#retryHandler.
+			// This limit prevents the buffer from consuming excessive memory.
+			// Defaults to 0 for unlimited.
+			// Any value between 0 and 32 MB is pushed to 32 MB.
+			// A zero or negative value indicates unlimited.
+			MaxBufferBytes int64
 		}
 
 		// Interceptors to be called when the producer dispatcher reads the


### PR DESCRIPTION
# Summary

This PR introduces the MaxBufferBytes configuration to Sarama’s producer, allowing users to limit the retry buffer size based on the total byte size of messages. This complements the existing MaxBufferLength configuration, which limits the number of messages in the retry buffer. The implementation ensures more robust control over memory usage and prevents potential OOM issues when dealing with large messages.

The changes are built upon the foundation laid in https://github.com/IBM/sarama/pull/3026, further enhancing the retry buffer’s configurability and usability.

# Key Changes

- Added a new Producer.Retry.MaxBufferBytes configuration.
- The type of MaxBufferBytes is int64, as the maximum value of int32 (approximately 2 GB) is insufficient for buffers holding many messages of large average size, such as 1 MB. Using int64 ensures the buffer can handle higher limits if needed.
- Ensured that any value below the functional lower limit of 32 MB is pushed to this minimum.
- Updated the retry handler to enforce both MaxBufferBytes and MaxBufferLength constraints.
- Added relevant unit tests to validate functionality for both configurations, including edge cases and scenarios with unlimited settings.

This enhancement allows users to fine-tune producer behavior, particularly when working with large message payloads or memory-constrained environments.