### PR TITLE
fix: remove redundant nil check

### DIFF
--- a/mocks/async_producer.go
+++ b/mocks/async_producer.go
@@ -74,7 +74,7 @@ func NewAsyncProducer(t ErrorReporter, config *sarama.Config) *AsyncProducer {
 				partitioners[msg.Topic] = partitioner
 			}
 			mp.l.Lock()
-			if mp.expectations == nil || len(mp.expectations) == 0 {
+			if len(mp.expectations) == 0 {
 				mp.expectations = nil
 				mp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
 			} else {


### PR DESCRIPTION
[mocks/async_producer.go](https://github.com/IBM/sarama/blob/e2fa7bf18c064719197abba64a2ce14c8227a92d/mocks/async_producer.go#L77) remove unnecessay nil check.

```
var slice []byte
if slice == nil || len(slice) == 0 {}
// is the same as
if len(slice) == 0 {}
```
because `len(slice)` where slice == nil is always equal to 0,

`staticcheck` will highlight this optimization with the following message:
```
mocks/async_producer.go:77:7: should omit nil check; len() for []*github.com/IBM/sarama/mocks.producerExpectation is defined as zero (S1009)
```

for reference: [staticcheck S1009](https://staticcheck.dev/docs/checks#S1009)