### PR TITLE
chore(ci): bump golangci-lint version to v1.63.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         GOFLAGS: -tags=functional
       uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
       with:
-        version: v1.60.2
+        version: v1.63.4
   test:
     name: Unit Testing with Go ${{ matrix.go-version }}
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,11 +1,10 @@
 run:
-  go: "1.20"
   timeout: 5m
   deadline: 10m
 
 linters-settings:
   govet:
-    check-shadowing: false
+    shadow: false
   golint:
     min-confidence: 0
   gocyclo:


### PR DESCRIPTION
Bring golangci-lint up-to-date