### PR TITLE
feat(ci): add dedicated staticcheck run

### DIFF
--- a/.github/actions/staticcheck-matchers.json
+++ b/.github/actions/staticcheck-matchers.json
@@ -1,0 +1,16 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "staticcheck",
+      "pattern": [
+        {
+          "regexp": "^\\s*(.+\\.go):(?:(\\d+):(\\d+):)? (.*)",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
         go-version: ${{ matrix.go-version }}
+    - name: Staticcheck
+      shell: bash
+      env:
+        BUILDTAGS: "functional"
+        VERSION: "v0.5.1"
+      run: |
+        go install "honnef.co/go/tools/cmd/staticcheck@${VERSION}"
+        echo "::add-matcher::./.github/actions/staticcheck-matchers.json"
+        $(go env GOPATH)/bin/staticcheck -tags "${BUILDTAGS}" ./...
     - name: golangci-lint
       env:
         GOFLAGS: -tags=functional

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,16 +1,15 @@
+# yaml-language-server: $schema=https://golangci-lint.run/jsonschema/golangci.jsonschema.json
 run:
   timeout: 5m
-  deadline: 10m
 
 linters-settings:
   govet:
-    shadow: false
-  golint:
-    min-confidence: 0
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
   gocyclo:
     min-complexity: 99
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 100
   goconst:
@@ -71,7 +70,6 @@ linters:
     - govet
     - misspell
     - nilerr
-    - staticcheck
     - typecheck
     - unconvert
     - unused

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,10 +32,10 @@ repos:
         files: \.go$
         args: []
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.23.3
     hooks:
       - id: gitleaks
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.61.0
+    rev: v1.63.4
     hooks:
       - id: golangci-lint

--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -989,7 +989,7 @@ func (p *partitionMovements) getTheActualPartitionToBeMoved(partition topicParti
 	return reversePairPartition
 }
 
-//nolint:unused // this is used but only in unittests as a helper (which are excluded by the integration build tag)
+//lint:ignore U1000 // this is used but only in unittests as a helper (which are excluded by the integration build tag)
 func (p *partitionMovements) isLinked(src, dst string, pairs []consumerPair, currentPath []string) ([]string, bool) {
 	if src == dst {
 		return currentPath, false
@@ -1024,7 +1024,7 @@ func (p *partitionMovements) isLinked(src, dst string, pairs []consumerPair, cur
 	return currentPath, false
 }
 
-//nolint:unused // this is used but only in unittests as a helper (which are excluded by the integration build tag)
+//lint:ignore U1000 // this is used but only in unittests as a helper (which are excluded by the integration build tag)
 func (p *partitionMovements) in(cycle []string, cycles [][]string) bool {
 	superCycle := make([]string, len(cycle)-1)
 	for i := 0; i < len(cycle)-1; i++ {
@@ -1039,7 +1039,7 @@ func (p *partitionMovements) in(cycle []string, cycles [][]string) bool {
 	return false
 }
 
-//nolint:unused // this is used but only in unittests as a helper (which are excluded by the integration build tag)
+//lint:ignore U1000 // this is used but only in unittests as a helper (which are excluded by the integration build tag)
 func (p *partitionMovements) hasCycles(pairs []consumerPair) bool {
 	cycles := make([][]string, 0)
 	for _, pair := range pairs {
@@ -1071,7 +1071,7 @@ func (p *partitionMovements) hasCycles(pairs []consumerPair) bool {
 	return false
 }
 
-//nolint:unused // this is used but only in unittests as a helper (which are excluded by the integration build tag)
+//lint:ignore U1000 // this is used but only in unittests as a helper (which are excluded by the integration build tag)
 func (p *partitionMovements) isSticky() bool {
 	for topic, movements := range p.PartitionMovementsByTopic {
 		movementPairs := make([]consumerPair, len(movements))
@@ -1089,7 +1089,7 @@ func (p *partitionMovements) isSticky() bool {
 	return true
 }
 
-//nolint:unused // this is used but only in unittests as a helper (which are excluded by the integration build tag)
+//lint:ignore U1000 // this is used but only in unittests as a helper (which are excluded by the integration build tag)
 func indexOfSubList(source []string, target []string) int {
 	targetSize := len(target)
 	maxCandidate := len(source) - targetSize

--- a/metrics_helpers_test.go
+++ b/metrics_helpers_test.go
@@ -116,7 +116,7 @@ func minCountHistogramValidator(name string, minCount int) *metricValidator {
 	})
 }
 
-//nolint:unused // this is used but only in unittests which are excluded by the integration build tag
+//lint:ignore U1000 // this is used but only in unittests which are excluded by the integration build tag
 func minMaxHistogramValidator(name string, expectedMin int, expectedMax int) *metricValidator {
 	return histogramValidator(name, func(t *testing.T, histogram metrics.Histogram) {
 		t.Helper()

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -52,8 +52,8 @@ func messageValueChecker(f ValueChecker) MessageChecker {
 
 var (
 	errProduceSuccess              error = nil
-	errOutOfExpectations                 = errors.New("No more expectations set on mock")
-	errPartitionConsumerNotStarted       = errors.New("The partition consumer was never started")
+	errOutOfExpectations                 = errors.New("no more expectations set on mock")
+	errPartitionConsumerNotStarted       = errors.New("the partition consumer was never started")
 )
 
 const AnyOffset int64 = -1000


### PR DESCRIPTION
As we've noted that a standlone run of staticcheck can find different
issues compared with running it from golangci-lint, add a standalone run
to github actions and remove it from the golangci-lint config