### PR TITLE
Fix the problem when some partitons have no leader

### DIFF
--- a/client.go
+++ b/client.go
@@ -114,7 +114,6 @@ type Client interface {
 	LeastLoadedBroker() *Broker
 
 	// check if partition is readable
-	
 	ParttionNotReadable(topic string, partition int32) bool
 
 	// Close shuts down all broker connections managed by this client. It is required

--- a/client.go
+++ b/client.go
@@ -113,6 +113,10 @@ type Client interface {
 	// LeastLoadedBroker retrieves broker that has the least responses pending
 	LeastLoadedBroker() *Broker
 
+	// check if partition is readable
+	
+	ParttionNotReadable(topic string, partition int32) bool
+
 	// Close shuts down all broker connections managed by this client. It is required
 	// to call this function before a client object passes out of scope, as it will
 	// otherwise leak memory. You must close any Producers or Consumers using a client
@@ -1282,4 +1286,15 @@ type nopCloserClient struct {
 // client's Close() method.
 func (ncc *nopCloserClient) Close() error {
 	return nil
+}
+
+func (client *client) ParttionNotReadable(topic string, partition int32) bool {
+	pm := client.metadata[topic][partition]
+ 	if pm == nil {
+		return true
+	}
+	if pm.Leader == -1 {
+		return true
+	}
+	return false
 }

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -869,7 +869,7 @@ func newConsumerGroupSession(ctx context.Context, parent *consumerGroup, claims 
 				go func (topic string, partition int32) {
 					for {
 						if parent.client.ParttionNotReadable( topic,partition) {
-							time.Sleep(5000)
+							time.Sleep(5*time.Second)
 						} else {
 							break
 						}

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -864,6 +864,9 @@ func newConsumerGroupSession(ctx context.Context, parent *consumerGroup, claims 
 	// start consuming
 	for topic, partitions := range claims {
 		for _, partition := range partitions {
+			if parent.client.ParttionNotReadable( topic,partition) {
+				continue
+			}
 			sess.waitGroup.Add(1)
 
 			go func(topic string, partition int32) {

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -864,12 +864,12 @@ func newConsumerGroupSession(ctx context.Context, parent *consumerGroup, claims 
 	// start consuming
 	for topic, partitions := range claims {
 		for _, partition := range partitions {
-			if parent.client.ParttionNotReadable( topic,partition) {
+			if parent.client.ParttionNotReadable(topic, partition) {
 				// partition not readable, wait for it to become readable
 				go func (topic string, partition int32) {
 					for {
-						if parent.client.ParttionNotReadable( topic,partition) {
-							time.Sleep(5*time.Second)
+						if parent.client.ParttionNotReadable(topic, partition) {
+							time.Sleep(5 * time.Second)
 						} else {
 							break
 						}

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -874,6 +874,7 @@ func newConsumerGroupSession(ctx context.Context, parent *consumerGroup, claims 
 							break
 						}
 					}
+					sess.waitGroup.Add(1)
 					defer sess.waitGroup.Done()
 					defer sess.cancel()
 					sess.consume(topic, partition)


### PR DESCRIPTION
When some topic partitions have no leader due to Kafka broker failures, the Sarama consumer group should be able to continue consuming partitions that have leaders and resume consuming the partitions that previously had no leader once they return to normal. This pull request addresses this issue.