### PR TITLE
Fix metadata refresh backoff for idempotent producers

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -1119,6 +1119,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 
 	if len(retryTopics) > 0 {
 		if bp.parent.conf.Producer.Idempotent {
+			time.Sleep(1 * time.Second)
 			err := bp.parent.client.RefreshMetadata(retryTopics...)
 			if err != nil {
 				Logger.Printf("Failed refreshing metadata because of %v\n", err)


### PR DESCRIPTION
There is a bug that Idempotent producers will not apply the correct backoff to refresh metadata:
https://github.com/IBM/sarama/issues/2469

This commit is an attempt (hack) to make it work.