### PR TITLE
chore: bump minimum Go version to 1.23.0

### DIFF
--- a/.github/workflows/apidiff.yml
+++ b/.github/workflows/apidiff.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read  # for actions/checkout to fetch code
 
+env:
+  # Use the Go toolchain installed by setup-go
+  GOTOOLCHAIN: local
+
 jobs:
   apidiff:
     runs-on: ubuntu-latest
@@ -23,7 +27,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
-        go-version: 1.23.x
+        go-version: stable
     - name: Add GOBIN to PATH
       run: echo "$(go env GOPATH)/bin" >>$GITHUB_PATH
     - name: Install apidiff cmd

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read  # for actions/checkout to fetch code
 
+env:
+  # Use the Go toolchain installed by setup-go
+  GOTOOLCHAIN: local
+
 jobs:
   lint:
     permissions:
@@ -25,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x]
+        go-version: [stable]
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -55,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.21.x, 1.23.x]
+        go-version: [oldstable, stable]
     env:
       DEBUG: true
       GOFLAGS: -trimpath

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read  # for actions/checkout to fetch code
 
+env:
+  # Use the Go toolchain installed by setup-go
+  GOTOOLCHAIN: local
+
 jobs:
   analyze:
     name: Analyze
@@ -37,7 +41,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
-        go-version: 1.23.x
+        go-version: stable
     - name: Autobuild
       uses: github/codeql-action/autobuild@b56ba49b26e50535fa1e7f7db0f4f7b4bf65d80d # v3.28.10
     - name: Perform CodeQL Analysis

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read  # for actions/checkout to fetch code
 
+env:
+  # Use the Go toolchain installed by setup-go
+  GOTOOLCHAIN: local
+
 jobs:
   test:
     name: Fuzz
@@ -28,6 +32,6 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
-        go-version: 1.23.x
+        go-version: stable
     - name: Run any fuzzing tests
       run: go test -list . | grep '^Fuzz' | parallel 'go test -v -run=^{}$ -fuzz=^{}$ -fuzztime=5m'

--- a/.github/workflows/fvt-main.yml
+++ b/.github/workflows/fvt-main.yml
@@ -10,13 +10,17 @@ on:
 permissions:
   contents: read  # for actions/checkout to fetch code
 
+env:
+  # Use the Go toolchain installed by setup-go
+  GOTOOLCHAIN: local
+
 jobs:
   fvt:
     name: Test with Kafka ${{ matrix.kafka-version }}
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x]
+        go-version: [stable]
         kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.3, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 4.0.0]
         include:
         - kafka-version: 1.0.2

--- a/.github/workflows/fvt-pr.yml
+++ b/.github/workflows/fvt-pr.yml
@@ -9,13 +9,17 @@ on:
 permissions:
   contents: read  # for actions/checkout to fetch code
 
+env:
+  # Use the Go toolchain installed by setup-go
+  GOTOOLCHAIN: local
+
 jobs:
   fvt:
     name: Test with Kafka ${{ matrix.kafka-version }}
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x]
+        go-version: [stable]
         kafka-version: [1.0.2, 2.6.3, 3.6.2, 3.8.1, 4.0.0]
         include:
         - kafka-version: 1.0.2

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -5,7 +5,7 @@ on:
       go-version:
         required: false
         type: string
-        default: 1.23.x
+        default: stable
       kafka-version:
         required: false
         type: string
@@ -17,6 +17,10 @@ on:
 
 permissions:
   contents: read  # for actions/checkout to fetch code
+
+env:
+  # Use the Go toolchain installed by setup-go
+  GOTOOLCHAIN: local
 
 jobs:
   fvt:

--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read  # for actions/checkout to fetch code
 
+env:
+  # Use the Go toolchain installed by setup-go
+  GOTOOLCHAIN: local
+
 jobs:
   atomicalign:
     permissions:
@@ -28,7 +32,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
-        go-version: 1.23.x
+        go-version: stable
     - name: staticcheck
       env:
         GOARCH: 386

--- a/examples/consumergroup/go.mod
+++ b/examples/consumergroup/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/sarama/examples/consumer
 
-go 1.21
+go 1.23.0
 
 require github.com/IBM/sarama v1.45.0
 

--- a/examples/exactly_once/go.mod
+++ b/examples/exactly_once/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/sarama/examples/exactly_once
 
-go 1.21
+go 1.23.0
 
 require github.com/IBM/sarama v1.45.0
 

--- a/examples/http_server/go.mod
+++ b/examples/http_server/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/sarama/examples/http_server
 
-go 1.21
+go 1.23.0
 
 require github.com/IBM/sarama v1.45.0
 

--- a/examples/interceptors/go.mod
+++ b/examples/interceptors/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/sarama/examples/interceptors
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/IBM/sarama v1.45.0

--- a/examples/sasl_scram_client/go.mod
+++ b/examples/sasl_scram_client/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/sarama/examples/sasl_scram_client
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/IBM/sarama v1.45.0

--- a/examples/txn_producer/go.mod
+++ b/examples/txn_producer/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/sarama/examples/txn_producer
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/IBM/sarama v1.45.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/sarama
 
-go 1.21
+go 1.23.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
Dependencies are all starting to move to go 1.23.0 going forwards, so we'll sadly have to start bumping Sarama's go directive more aggressively as well in order to keep up. The Go maintainers have unfortunately decided that:

> A module’s go line must declare a version greater than or equal to the
> go version declared by each of the modules listed in require
> statements.

and

> Before Go 1.21, Go toolchains treated the go line as an advisory
> requirement: if builds succeeded the toolchain assumed everything
> worked, and if not it printed a note about the potential version
> mismatch. Go 1.21 changed the go line to be a mandatory requirement
> instead.

So we really have no option here, especially with the golang.org/x modules bumping to 1.23.0 as soon as 1.24.0 was released, we can no longer continue to support older Go toolchains.

Also bump CI testing to use the "oldstable" and "stable" aliases for N-1 and N going forwards as we're unlikely to want to test with anything else.