### PR TITLE
fix: send null instead of empty string when describing default client quotas

### DIFF
--- a/describe_client_quotas_request.go
+++ b/describe_client_quotas_request.go
@@ -87,7 +87,7 @@ func (d *QuotaFilterComponent) encode(pe packetEncoder) error {
 			return err
 		}
 	} else if d.MatchType == QuotaMatchDefault {
-		if err := pe.putString(""); err != nil {
+		if err := pe.putNullableString(nil); err != nil {
 			return err
 		}
 	} else {

--- a/describe_client_quotas_request_test.go
+++ b/describe_client_quotas_request_test.go
@@ -13,8 +13,8 @@ var (
 	describeClientQuotasRequestDefaultUser = []byte{
 		0, 0, 0, 1, // components len
 		0, 4, 'u', 's', 'e', 'r', // entity type
-		1,    // match type (default)
-		0, 0, // match *string
+		1,        // match type (default)
+		255, 255, // match *string
 		0, // strict
 	}
 
@@ -32,8 +32,8 @@ var (
 		2,        // match type (any)
 		255, 255, // match *string
 		0, 9, 'c', 'l', 'i', 'e', 'n', 't', '-', 'i', 'd', // entity type
-		1,    // match type (default)
-		0, 0, // match *string
+		1,        // match type (default)
+		255, 255, // match *string
 		0, // strict
 	}
 )

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -51,7 +51,6 @@ func TestFuncAdminQuotas(t *testing.T) {
 	}
 
 	// Check that we now have a quota entry
-	// Check that we can query a specific quota entry
 	defaultUserFilter := QuotaFilterComponent{
 		EntityType: QuotaEntityUser,
 		MatchType:  QuotaMatchDefault,

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -51,7 +51,12 @@ func TestFuncAdminQuotas(t *testing.T) {
 	}
 
 	// Check that we now have a quota entry
-	quotas, err = adminClient.DescribeClientQuotas(nil, false)
+	// Check that we can query a specific quota entry
+	defaultUserFilter := QuotaFilterComponent{
+		EntityType: QuotaEntityUser,
+		MatchType:  QuotaMatchDefault,
+	}
+	quotas, err = adminClient.DescribeClientQuotas([]QuotaFilterComponent{defaultUserFilter}, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
DescribeClientQuota currently fails with the following error message logged by the Kafka broker when trying to describe default client quotas:
```
org.apache.kafka.common.errors.InvalidRequestException: Request specified MATCH_TYPE_DEFAULT, but also specified a match string
```
This is because we are currently sending an empty string (`""`) instead of a null as the match string

The Java client simply ignores the match string here to avoid this issue, so I propose we do the same https://github.com/apache/kafka/blob/3ed590288fd773902f7791959e8f081ff937c144/clients/src/main/java/org/apache/kafka/common/requests/DescribeClientQuotasRequest.java#L54-L55