### PR TITLE
fix(decoder): handle null arrays correctly

### DIFF
--- a/real_decoder.go
+++ b/real_decoder.go
@@ -306,7 +306,7 @@ func (rd *realDecoder) getInt32Array() ([]int32, error) {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData
 	}
-	n := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+	n := int(int32(binary.BigEndian.Uint32(rd.raw[rd.off:])))
 	rd.off += 4
 
 	if rd.remaining() < 4*n {
@@ -335,7 +335,7 @@ func (rd *realDecoder) getInt64Array() ([]int64, error) {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData
 	}
-	n := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+	n := int(int32(binary.BigEndian.Uint32(rd.raw[rd.off:])))
 	rd.off += 4
 
 	if rd.remaining() < 8*n {
@@ -364,7 +364,7 @@ func (rd *realDecoder) getStringArray() ([]string, error) {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData
 	}
-	n := int(binary.BigEndian.Uint32(rd.raw[rd.off:]))
+	n := int(int32(binary.BigEndian.Uint32(rd.raw[rd.off:])))
 	rd.off += 4
 
 	if n == 0 {


### PR DESCRIPTION
Array lengths in the Kafka protocol are encoded as a 32-bit signed integer in big-endian format. For a null value this corresponds to the byte sequence FF FF FF FF which is intended to represent null as a length of -1. To correctly read that we need to cast the value to int32 before widening to int.