### PR TITLE
fix: stuck on the batch with zero records with long gap

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -743,7 +743,12 @@ func (child *partitionConsumer) parseResponse(response *FetchResponse) ([]*Consu
 		} else if block.LastRecordsBatchOffset != nil && *block.LastRecordsBatchOffset < block.HighWaterMarkOffset {
 			// check last record offset to avoid stuck if high watermark was not reached
 			Logger.Printf("consumer/broker/%d received batch with zero records but high watermark was not reached, topic %s, partition %d, offset %d\n", child.broker.broker.ID(), child.topic, child.partition, *block.LastRecordsBatchOffset)
-			child.offset = *block.LastRecordsBatchOffset + 1
+
+			if child.offset <= *block.LastRecordsBatchOffset {
+				child.offset = *block.LastRecordsBatchOffset + 1
+			} else {
+				child.offset++
+			}
 		}
 
 		return nil, nil

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -2026,6 +2026,40 @@ func Test_partitionConsumer_parseResponseEmptyBatch(t *testing.T) {
 	}
 }
 
+func Test_partitionConsumer_parseResponseEmptyBatchWithBigGap(t *testing.T) {
+	lrbOffset := int64(5)
+	block := &FetchResponseBlock{
+		HighWaterMarkOffset:    10,
+		LastStableOffset:       10,
+		LastRecordsBatchOffset: &lrbOffset,
+		LogStartOffset:         0,
+	}
+	response := &FetchResponse{
+		Blocks:  map[string]map[int32]*FetchResponseBlock{"my_topic": {0: block}},
+		Version: 2,
+	}
+	child := &partitionConsumer{
+		broker: &brokerConsumer{
+			broker: &Broker{},
+		},
+		conf:      NewTestConfig(),
+		topic:     "my_topic",
+		partition: 0,
+		offset:    lrbOffset + 1,
+	}
+	got, err := child.parseResponse(response)
+	if err != nil {
+		t.Errorf("partitionConsumer.parseResponse() error = %v", err)
+		return
+	}
+	if got != nil {
+		t.Errorf("partitionConsumer.parseResponse() should be nil, got %v", got)
+	}
+	if child.offset != 7 {
+		t.Errorf("child.offset should be LastRecordsBatchOffset + 1: %d, got %d", lrbOffset+1, child.offset)
+	}
+}
+
 func testConsumerInterceptor(
 	t *testing.T,
 	interceptors []ConsumerInterceptor,


### PR DESCRIPTION
Hi! We found a bug.  If a repeated fetch with an increased offset has returned the void again, then fetching is constantly trying to request a batch with the same offset. It is always necessary to increase the offset in such cases.