### PR TITLE
fix: improve getMetricName performance

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,7 +1,7 @@
 package sarama
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -26,13 +26,13 @@ func getOrRegisterHistogram(name string, r metrics.Registry) metrics.Histogram {
 func getMetricNameForBroker(name string, broker *Broker) string {
 	// Use broker id like the Java client as it does not contain '.' or ':' characters that
 	// can be interpreted as special character by monitoring tool (e.g. Graphite)
-	return fmt.Sprintf(name+"-for-broker-%d", broker.ID())
+	return name + "-for-broker-" + strconv.FormatInt(int64(broker.ID()), 10)
 }
 
 func getMetricNameForTopic(name string, topic string) string {
 	// Convert dot to _ since reporters like Graphite typically use dot to represent hierarchy
 	// cf. KAFKA-1902 and KAFKA-2337
-	return fmt.Sprintf(name+"-for-topic-%s", strings.ReplaceAll(topic, ".", "_"))
+	return name + "-for-topic-" + strings.ReplaceAll(topic, ".", "_")
 }
 
 func getOrRegisterTopicMeter(name string, topic string, r metrics.Registry) metrics.Meter {

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -38,3 +38,27 @@ func TestGetMetricNameForBroker(t *testing.T) {
 		t.Error("Unexpected metric name", metricName)
 	}
 }
+
+func Benchmark_getMetricNameForTopic(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := getMetricNameForTopic("sarama", "says.hello")
+		if name != "sarama-for-topic-says_hello" {
+			b.Fail()
+		}
+	}
+}
+
+func Benchmark_getMetricNameForBroker(b *testing.B) {
+	broker := &Broker{id: 1965}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		name := getMetricNameForBroker("summer", broker)
+		if name != "summer-for-broker-1965" {
+			b.Fail()
+		}
+	}
+}


### PR DESCRIPTION
Good day,

This PR improve the performance of `getMetricNameForBroker` and `getMetricNameForTopic` by removing the usage of `fmt`.

The [benchstat](https://pkg.go.dev/golang.org/x/perf/cmd/benchstat) result are as follows. The benchmarks when run using `go test -bench '^\QBenchmark_getMetricNameFor' -run=^$ -count=10`.
```
goos: linux
goarch: amd64
pkg: github.com/IBM/sarama
cpu: AMD Ryzen 7 Pro 7735U with Radeon Graphics     
                           │ faec4c823ff893c7fc7b10021b66542fa77f7cb8.txt │ 07db3539fb81f1bf77d8a8a910b2b1e72b4c52c3.txt │
                           │                    sec/op                    │        sec/op         vs base                │
_getMetricNameForTopic-16                                    157.55n ± 0%            66.85n ± 1%  -57.57% (p=0.000 n=10)
_getMetricNameForBroker-16                                   108.50n ± 1%            43.12n ± 1%  -60.25% (p=0.000 n=10)
geomean                                                       130.7n                 53.69n       -58.93%

                           │ faec4c823ff893c7fc7b10021b66542fa77f7cb8.txt │ 07db3539fb81f1bf77d8a8a910b2b1e72b4c52c3.txt │
                           │                     B/op                     │         B/op          vs base                │
_getMetricNameForTopic-16                                      64.00 ± 0%             16.00 ± 0%  -75.00% (p=0.000 n=10)
_getMetricNameForBroker-16                                    28.000 ± 0%             4.000 ± 0%  -85.71% (p=0.000 n=10)
geomean                                                        42.33                  8.000       -81.10%

                           │ faec4c823ff893c7fc7b10021b66542fa77f7cb8.txt │ 07db3539fb81f1bf77d8a8a910b2b1e72b4c52c3.txt │
                           │                  allocs/op                   │      allocs/op        vs base                │
_getMetricNameForTopic-16                                      3.000 ± 0%             1.000 ± 0%  -66.67% (p=0.000 n=10)
_getMetricNameForBroker-16                                     2.000 ± 0%             1.000 ± 0%  -50.00% (p=0.000 n=10)
geomean                                                        2.449                  1.000       -59.18%
```

Thank you for reviewing this PR and let me know if anything needs to change.
Have a great day!