### PR TITLE
Hopefully temporary fix for problem noticed on Confluent 4.0 Brokers

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -267,6 +267,10 @@ func (ca *clusterAdmin) CreateTopic(topic string, detail *TopicDetail, validateO
 		// Version 1 adds validateOnly.
 		request.Version = 1
 	}
+	if ca.conf.ConfluentRequestVersionBump {
+		// It is unkown why version 4 works, but 3 gives EOF error.
+		request.Version = 4
+	}
 
 	return ca.retryOnError(isRetriableControllerError, func() error {
 		b, err := ca.Controller()

--- a/config.go
+++ b/config.go
@@ -522,6 +522,13 @@ type Config struct {
 	// prior to starting Sarama.
 	// See Examples on how to use the metrics registry
 	MetricRegistry metrics.Registry
+	// Confluent Kafka 4.0 CreateTopic version bump.
+	// Defaults to false.
+	// If you want to push request version up to 4 when sending create topic request
+	// to broker hosted by confluent (host doesn't actually matter, problem noticed
+	// on confluent. With version 3, broker returns EOF error on CreateTopic request.
+	// With version 4, broker successfully creates topic on CreateTopic request.)
+	ConfluentRequestVersionBump bool
 }
 
 // NewConfig returns a new configuration instance with sane defaults.
@@ -582,6 +589,7 @@ func NewConfig() *Config {
 	c.ApiVersionsRequest = true
 	c.Version = DefaultVersion
 	c.MetricRegistry = metrics.NewRegistry()
+	c.ConfluentRequestVersionBump = false
 
 	return c
 }


### PR DESCRIPTION
Problem: CreateTopic request with version 3 protocol fails with EOF error. This change adds ConfluentRequestVersionBump config option that overrides protocol version sent in CreateTopic request (setting version to 4) when true.