### PR TITLE
fix(ci): switch to crontab for renovate.json

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,7 +34,7 @@
     {
       description: "Update Docker and Docker Compose dependencies daily at 9:00 PM UTC, grouped into a single PR",
       matchManagers: ["dockerfile", "docker-compose"],
-      schedule: ["every day at 9:00pm"],
+      schedule: ["* 21 * * *"],
       commitMessagePrefix: "chore(ci): ",
       groupName: "docker dependencies",
       addLabels: ["docker", "ignore-for-release"],
@@ -42,7 +42,7 @@
     {
       description: "Update GitHub Actions weekly, grouped into a single PR for actions/* packages",
       matchManagers: ["github-actions"],
-      schedule: ["every week"],
+      schedule: ["* 0 * * 0"],
       commitMessagePrefix: "chore(ci): ",
       groupName: "actions",
       matchPackageNames: ["actions/*", "github/codeql-action"],
@@ -53,7 +53,7 @@
       description: "Update Go modules daily at 3:00 PM UTC",
       matchManagers: ["gomod"],
       matchPaths: ["/**"],
-      schedule: ["every day at 3:00pm"],
+      schedule: ["* 15 * * *"],
     },
     {
       description: "Group OpenTelemetry Go dependencies into a single PR",

--- a/.github/workflows/renovate-config.yml
+++ b/.github/workflows/renovate-config.yml
@@ -1,0 +1,21 @@
+name: renovate-config-validator
+
+on:
+  pull_request:
+    paths:
+      - '.github/renovate.json5'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            .github/renovate.json5
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - run: npx --package=renovate@latest -- renovate-config-validator


### PR DESCRIPTION
Porting the dependabot schedules didn't quite match the "later" syntax that Renovate supports. I also note from their docs that they strongly recommend just using crontab syntax everywhere now, so switch to that instead:
https://docs.renovatebot.com/configuration-options/#schedule

Also add a simple github workflow to ensure any changes to renovate config are valid going forward