### PR TITLE
fix(ci): replace renovate preset with config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,7 +2,6 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "config:best-practices",
-    "enableVulnerabilityAlertsWithLabel(security)",
     "customManagers:dockerfileVersions",
     "customManagers:githubActionsVersions",
     "customManagers:makefileVersions",
@@ -29,6 +28,10 @@
   },
   digest: {
     addLabels: ["bump/digest"],
+  },
+  vulnerabilityAlerts: {
+    enabled: true,
+    labels: ["security"],
   },
   packageRules: [
     {


### PR DESCRIPTION
Despite appearing in the docs as a valid preset [1] and passing renovate-config-validator successfully, this doesn't seem to exist on the version of renovate being used by "ibm-mend" on github.com, so replace it with the equivalent in-line config.

[1] https://docs.renovatebot.com/presets-default/#enablevulnerabilityalertswithlabelarg0

Fixes #3250