### PR TITLE
refactor to use reflect.TypeFor

### DIFF
--- a/mockbroker.go
+++ b/mockbroker.go
@@ -90,7 +90,7 @@ func (b *MockBroker) SetHandlerByMap(handlerMap map[string]MockResponse) {
 		fnMap[k] = v
 	}
 	b.setHandler(func(req *request) (res encoderWithHeader) {
-		reqTypeName := reflect.TypeOf(req.body).Elem().Name()
+		reqTypeName := reflect.TypeFor[protocolBody]().Name()
 		mockResponse := fnMap[reqTypeName]
 		if mockResponse == nil {
 			return nil
@@ -108,7 +108,7 @@ func (b *MockBroker) SetHandlerFuncByMap(handlerMap map[string]requestHandlerFun
 		fnMap[k] = v
 	}
 	b.setHandler(func(req *request) (res encoderWithHeader) {
-		reqTypeName := reflect.TypeOf(req.body).Elem().Name()
+		reqTypeName := reflect.TypeFor[protocolBody]().Name()
 		return fnMap[reqTypeName](req)
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
> Other

**What does this PR do? Why is it needed?**
This PR replaces `reflect.TypeOf` with the newer `reflect.TypeFor`. The change removes the need for dummy values, avoids unnecessary allocations, and improves type safety with cleaner code.

**Which issues(s) does this PR fix?**
No specific issue; this is a code quality improvement using modern Go reflection.


