### PR TITLE
chore: refactor to use modern atomic types

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -29,7 +29,7 @@ type Broker struct {
 	conn          net.Conn
 	connErr       error
 	lock          sync.Mutex
-	opened        int32
+	opened        atomic.Int32
 	responses     chan *responsePromise
 	done          chan bool
 
@@ -162,7 +162,7 @@ func NewBroker(addr string) *Broker {
 // follow it by a call to Connected(). The only errors Open will return directly are ConfigurationError or
 // AlreadyConnected. If conf is nil, the result of NewConfig() is used.
 func (b *Broker) Open(conf *Config) error {
-	if !atomic.CompareAndSwapInt32(&b.opened, 0, 1) {
+	if !b.opened.CompareAndSwap(0, 1) {
 		return ErrAlreadyConnected
 	}
 
@@ -189,7 +189,7 @@ func (b *Broker) Open(conf *Config) error {
 		if b.connErr != nil {
 			Logger.Printf("Failed to connect to broker %s: %s\n", b.addr, b.connErr)
 			b.conn = nil
-			atomic.StoreInt32(&b.opened, 0)
+			b.opened.Store(0)
 			return
 		}
 		if conf.Net.TLS.Enable {
@@ -254,7 +254,7 @@ func (b *Broker) Open(conf *Config) error {
 					Logger.Printf("Error while closing connection to broker %s (due to SASL v0 auth error: %s): %s\n", b.addr, b.connErr, err)
 				}
 				b.conn = nil
-				atomic.StoreInt32(&b.opened, 0)
+				b.opened.Store(0)
 				return
 			}
 		}
@@ -275,7 +275,7 @@ func (b *Broker) Open(conf *Config) error {
 					Logger.Printf("Error while closing connection to broker %s (due to SASL v1 auth error: %s): %s\n", b.addr, b.connErr, err)
 				}
 				b.conn = nil
-				atomic.StoreInt32(&b.opened, 0)
+				b.opened.Store(0)
 				return
 			}
 		}
@@ -349,8 +349,7 @@ func (b *Broker) Close() error {
 	} else {
 		Logger.Printf("Error while closing connection to broker %s: %s\n", b.addr, err)
 	}
-
-	atomic.StoreInt32(&b.opened, 0)
+	b.opened.Store(0)
 
 	return err
 }

--- a/broker.go
+++ b/broker.go
@@ -29,7 +29,7 @@ type Broker struct {
 	conn          net.Conn
 	connErr       error
 	lock          sync.Mutex
-	opened        atomic.Int32
+	opened        atomic.Bool
 	responses     chan *responsePromise
 	done          chan bool
 
@@ -162,7 +162,7 @@ func NewBroker(addr string) *Broker {
 // follow it by a call to Connected(). The only errors Open will return directly are ConfigurationError or
 // AlreadyConnected. If conf is nil, the result of NewConfig() is used.
 func (b *Broker) Open(conf *Config) error {
-	if !b.opened.CompareAndSwap(0, 1) {
+	if !b.opened.CompareAndSwap(false, true) {
 		return ErrAlreadyConnected
 	}
 
@@ -189,7 +189,7 @@ func (b *Broker) Open(conf *Config) error {
 		if b.connErr != nil {
 			Logger.Printf("Failed to connect to broker %s: %s\n", b.addr, b.connErr)
 			b.conn = nil
-			b.opened.Store(0)
+			b.opened.Store(false)
 			return
 		}
 		if conf.Net.TLS.Enable {
@@ -254,7 +254,7 @@ func (b *Broker) Open(conf *Config) error {
 					Logger.Printf("Error while closing connection to broker %s (due to SASL v0 auth error: %s): %s\n", b.addr, b.connErr, err)
 				}
 				b.conn = nil
-				b.opened.Store(0)
+				b.opened.Store(false)
 				return
 			}
 		}
@@ -275,7 +275,7 @@ func (b *Broker) Open(conf *Config) error {
 					Logger.Printf("Error while closing connection to broker %s (due to SASL v1 auth error: %s): %s\n", b.addr, b.connErr, err)
 				}
 				b.conn = nil
-				b.opened.Store(0)
+				b.opened.Store(false)
 				return
 			}
 		}
@@ -349,7 +349,7 @@ func (b *Broker) Close() error {
 	} else {
 		Logger.Printf("Error while closing connection to broker %s: %s\n", b.addr, err)
 	}
-	b.opened.Store(0)
+	b.opened.Store(false)
 
 	return err
 }

--- a/consumer.go
+++ b/consumer.go
@@ -392,7 +392,7 @@ type PartitionConsumer interface {
 }
 
 type partitionConsumer struct {
-	highWaterMarkOffset int64 // must be at the top of the struct because https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	highWaterMarkOffset atomic.Int64 // must be at the top of the struct because https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 
 	consumer *consumer
 	conf     *Config
@@ -411,9 +411,9 @@ type partitionConsumer struct {
 	responseResult error
 	fetchSize      int32
 	offset         int64
-	retries        int32
+	retries        atomic.Int32
 
-	paused int32
+	paused atomic.Int32 // accessed atomically, 0 = not paused, 1 = paused
 }
 
 var errTimedOut = errors.New("timed out feeding messages to the user") // not user-facing
@@ -434,7 +434,7 @@ func (child *partitionConsumer) sendError(err error) {
 
 func (child *partitionConsumer) computeBackoff() time.Duration {
 	if child.conf.Consumer.Retry.BackoffFunc != nil {
-		retries := atomic.AddInt32(&child.retries, 1)
+		retries := child.retries.Add(1)
 		return child.conf.Consumer.Retry.BackoffFunc(int(retries))
 	}
 	return child.conf.Consumer.Retry.Backoff
@@ -508,7 +508,7 @@ func (child *partitionConsumer) chooseStartingOffset(offset int64) error {
 		return err
 	}
 
-	child.highWaterMarkOffset = newestOffset
+	child.highWaterMarkOffset.Store(newestOffset)
 
 	oldestOffset, err := child.consumer.client.GetOffset(child.topic, child.partition, OffsetOldest)
 	if err != nil {
@@ -562,7 +562,7 @@ func (child *partitionConsumer) Close() error {
 }
 
 func (child *partitionConsumer) HighWaterMarkOffset() int64 {
-	return atomic.LoadInt64(&child.highWaterMarkOffset)
+	return child.highWaterMarkOffset.Load()
 }
 
 func (child *partitionConsumer) responseFeeder() {
@@ -575,7 +575,7 @@ feederLoop:
 		msgs, child.responseResult = child.parseResponse(response)
 
 		if child.responseResult == nil {
-			atomic.StoreInt32(&child.retries, 0)
+			child.retries.Store(0)
 		}
 
 		for i, msg := range msgs {
@@ -751,7 +751,7 @@ func (child *partitionConsumer) parseResponse(response *FetchResponse) ([]*Consu
 
 	// we got messages, reset our fetch size in case it was increased for a previous request
 	child.fetchSize = child.conf.Consumer.Fetch.Default
-	atomic.StoreInt64(&child.highWaterMarkOffset, block.HighWaterMarkOffset)
+	child.highWaterMarkOffset.Store(block.HighWaterMarkOffset)
 
 	// abortedProducerIDs contains producerID which message should be ignored as uncommitted
 	// - producerID are added when the partitionConsumer iterate over the offset at which an aborted transaction begins (abortedTransaction.FirstOffset)
@@ -837,17 +837,17 @@ func (child *partitionConsumer) interceptors(msg *ConsumerMessage) {
 
 // Pause implements PartitionConsumer.
 func (child *partitionConsumer) Pause() {
-	atomic.StoreInt32(&child.paused, 1)
+	child.paused.Store(1)
 }
 
 // Resume implements PartitionConsumer.
 func (child *partitionConsumer) Resume() {
-	atomic.StoreInt32(&child.paused, 0)
+	child.paused.Store(0)
 }
 
 // IsPaused implements PartitionConsumer.
 func (child *partitionConsumer) IsPaused() bool {
-	return atomic.LoadInt32(&child.paused) == 1
+	return child.paused.Load() == 1
 }
 
 type brokerConsumer struct {

--- a/consumer.go
+++ b/consumer.go
@@ -413,7 +413,7 @@ type partitionConsumer struct {
 	offset         int64
 	retries        atomic.Int32
 
-	paused atomic.Int32 // accessed atomically, 0 = not paused, 1 = paused
+	paused atomic.Bool // accessed atomically, 0 = not paused, 1 = paused
 }
 
 var errTimedOut = errors.New("timed out feeding messages to the user") // not user-facing
@@ -837,17 +837,17 @@ func (child *partitionConsumer) interceptors(msg *ConsumerMessage) {
 
 // Pause implements PartitionConsumer.
 func (child *partitionConsumer) Pause() {
-	child.paused.Store(1)
+	child.paused.Store(true)
 }
 
 // Resume implements PartitionConsumer.
 func (child *partitionConsumer) Resume() {
-	child.paused.Store(0)
+	child.paused.Store(false)
 }
 
 // IsPaused implements PartitionConsumer.
 func (child *partitionConsumer) IsPaused() bool {
-	return child.paused.Load() == 1
+	return child.paused.Load()
 }
 
 type brokerConsumer struct {

--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -398,7 +398,7 @@ func (pc *PartitionConsumer) YieldMessage(msg *sarama.ConsumerMessage) *Partitio
 	msg.Partition = pc.partition
 
 	if pc.paused {
-		msg.Offset = atomic.AddInt64(&pc.suppressedHighWaterMarkOffset, 1)
+		msg.Offset = atomic.AddInt64(&pc.suppressedHighWaterMarkOffset, 1) - 1
 		pc.suppressedMessages <- msg
 	} else {
 		msg.Offset = pc.highWaterMarkOffset.Add(1) - 1


### PR DESCRIPTION
**What type of PR is this?**
> Other

**What does this PR do? Why is it needed?**
This PR updates our atomic operations to use `Go 1.19's` newer typed atomic approach instead of the old function-based method. We're changing fields like `int64` to `atomic.Int64` so we can write cleaner code like `child.retries.Add(1)` instead of `atomic.AddInt32(&child.retries, 1)`. This removes the need for pointer handling and gives us better compile-time safety when multiple threads access the same variables in  operations.

**Which issues(s) does this PR fix?**
The function-based atomics allowed accidental non-atomic access to shared variables, causing race conditions in concurrent  operations. The verbose `atomic.AddInt32(&child.retries, 1)` syntax was harder to maintain. Typed atomics enforce atomic-only access at compile time and use cleaner method calls, preventing threading bugs.
