### PR TITLE
chore: pre-commit autoupdate to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         GOFLAGS: -tags=functional
       uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
-        version: v2.1.6
+        version: v2.4.0
   test:
     name: Unit Testing with Go ${{ matrix.go-version }}
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ fail_fast: false
 default_install_hook_types: [pre-commit, commit-msg]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: check-yaml
@@ -32,10 +32,10 @@ repos:
         files: \.go$
         args: []
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.23.3
+    rev: v8.28.0
     hooks:
       - id: gitleaks
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.63.4
+    rev: v2.4.0
     hooks:
       - id: golangci-lint


### PR DESCRIPTION
Bump golangci-lint version in ci to v2.4.0 to match too