### PR TITLE
Put require.NoError ahead of trying to use the maybe-nil parameter.

### DIFF
--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -444,8 +444,8 @@ func TestFuncTxnProduceAndCommitOffset(t *testing.T) {
 	defer consumer.Close()
 
 	pc, err := consumer.ConsumePartition("test.1", 0, OffsetNewest)
-	msgChannel := pc.Messages()
 	require.NoError(t, err)
+	msgChannel := pc.Messages()
 	defer pc.Close()
 
 	// Ensure consumer is started


### PR DESCRIPTION
Fixes #3280 