### PR TITLE
chore(ci): adopt gotestsum and re-run flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,14 @@ jobs:
       if: always()
       run: |
         # renovate: datasource=github-releases depName=mfridman/tparse
-        go run github.com/mfridman/tparse@v0.18.0 -all -file _test/unittests.json | tee -a $GITHUB_STEP_SUMMARY
+        go run github.com/mfridman/tparse@v0.18.0 -all -format markdown -file _test/unittests.json | tee -a $GITHUB_STEP_SUMMARY
     - name: Report Per Func Test Coverage
       if: always()
       run: |
         cat >>$GITHUB_STEP_SUMMARY <<EOF
-        <details><summary>Code Coverage Report</summary>
+        <details>
+        <summary>Click for per-func code coverage</summary>
+
         |Filename|Function|Coverage|
         |--------|--------|--------|
         $(go tool cover -func=profile.out | sed -E -e 's/[[:space:]]+/|/g' -e 's/$/|/g' -e 's/^/|/g')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 permissions:
-  contents: read  # for actions/checkout to fetch code
+  contents: read # for actions/checkout to fetch code
 
 env:
   # Use the Go toolchain installed by setup-go
@@ -26,8 +26,8 @@ env:
 jobs:
   lint:
     permissions:
-      contents: read  # for actions/checkout to fetch code
-      pull-requests: read  # for golangci/golangci-lint-action to fetch pull requests
+      contents: read # for actions/checkout to fetch code
+      pull-requests: read # for golangci/golangci-lint-action to fetch pull requests
     name: Linting with Go ${{ matrix.go-version }}
     runs-on: ubuntu-latest
     strategy:
@@ -77,3 +77,18 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Test (Unit)
       run: make test
+    - name: Report Test Results
+      if: always()
+      run: |
+        # renovate: datasource=github-releases depName=mfridman/tparse
+        go run github.com/mfridman/tparse@v0.18.0 -all -file _test/unittests.json | tee -a $GITHUB_STEP_SUMMARY
+    - name: Report Per Func Test Coverage
+      if: always()
+      run: |
+        cat >>$GITHUB_STEP_SUMMARY <<EOF
+        <details><summary>Code Coverage Report</summary>
+        |Filename|Function|Coverage|
+        |--------|--------|--------|
+        $(go tool cover -func=profile.out | sed -E -e 's/[[:space:]]+/|/g' -e 's/$/|/g' -e 's/^/|/g')
+        </details>
+        EOF

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -72,12 +72,14 @@ jobs:
       if: always()
       run: |
         # renovate: datasource=github-releases depName=mfridman/tparse
-        go run github.com/mfridman/tparse@v0.18.0 -all -file _test/fvt.json | tee -a $GITHUB_STEP_SUMMARY
+        go run github.com/mfridman/tparse@v0.18.0 -all -format markdown -file _test/fvt.json | tee -a $GITHUB_STEP_SUMMARY
     - name: Report Per Func Test Coverage
       if: always()
       run: |
         cat >>$GITHUB_STEP_SUMMARY <<EOF
-        <details><summary>Code Coverage Report</summary>
+        <details>
+        <summary>Click for per-func code coverage</summary>
+
         |Filename|Function|Coverage|
         |--------|--------|--------|
         $(go tool cover -func=profile.out | sed -E -e 's/[[:space:]]+/|/g' -e 's/$/|/g' -e 's/^/|/g')

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -9,18 +9,18 @@ on:
       kafka-version:
         required: false
         type: string
-        default: 3.6.2
+        default: "3.6.2"
       scala-version:
         required: false
         type: string
-        default: 2.13
+        default: "2.13"
 
 concurrency:
   group: ${{ github.workflow }}-kafka-${{ inputs.kafka-version}}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 permissions:
-  contents: read  # for actions/checkout to fetch code
+  contents: read # for actions/checkout to fetch code
 
 env:
   # Use the Go toolchain installed by setup-go
@@ -68,10 +68,21 @@ jobs:
         nohup sudo tcpdump -i lo -w "fvt-kafka-${KAFKA_VERSION}.pcap" portrange 29091-29095 >/dev/null 2>&1 &
         echo $! >tcpdump.pid
         make test_functional
-        echo "## Code Coverage" >>$GITHUB_STEP_SUMMARY
-        echo "|Filename|Function|Coverage|" >>$GITHUB_STEP_SUMMARY
-        echo "|--------|--------|--------|" >>$GITHUB_STEP_SUMMARY
-        go tool cover -func=profile.out | sed -E -e 's/[[:space:]]+/|/g' -e 's/$/|/g' -e 's/^/|/g' >>$GITHUB_STEP_SUMMARY
+    - name: Report Test Results
+      if: always()
+      run: |
+        # renovate: datasource=github-releases depName=mfridman/tparse
+        go run github.com/mfridman/tparse@v0.18.0 -all -file _test/fvt.json | tee -a $GITHUB_STEP_SUMMARY
+    - name: Report Per Func Test Coverage
+      if: always()
+      run: |
+        cat >>$GITHUB_STEP_SUMMARY <<EOF
+        <details><summary>Code Coverage Report</summary>
+        |Filename|Function|Coverage|
+        |--------|--------|--------|
+        $(go tool cover -func=profile.out | sed -E -e 's/[[:space:]]+/|/g' -e 's/$/|/g' -e 's/^/|/g')
+        </details>
+        EOF
     - name: Stop tcpdump
       if: always()
       run: |

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,20 @@ default: fmt get update test lint
 GO       := go
 GOBIN    := $(shell pwd)/bin
 GOBUILD  := CGO_ENABLED=0 $(GO) build $(BUILD_FLAG)
-GOTEST   := $(GO) test -v -race -coverprofile=profile.out -covermode=atomic
 
-FILES    := $(shell find . -name '*.go' -type f -not -name '*.pb.go' -not -name '*_generated.go' -not -name '*_test.go')
-TESTS    := $(shell find . -name '*.go' -type f -not -name '*.pb.go' -not -name '*_generated.go' -name '*_test.go')
+GOTESTSUM         := $(GOBIN)/gotestsum
+GOTESTSUM_VERSION := v1.13.0
+$(GOTESTSUM):
+	GOBIN=$(GOBIN) go install gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
 
-$(GOBIN)/tparse:
-	GOBIN=$(GOBIN) go install github.com/mfridman/tparse@v0.16.0
+TESTSTAT         := $(GOBIN)/teststat
+TESTSTAT_VERSION := v0.1.26
+$(TESTSTAT):
+	GOBIN=$(GOBIN) go install github.com/vearutop/teststat@$(TESTSTAT_VERSION)
+
+FILES := $(shell find . -name '*.go' -type f -not -name '*.pb.go' -not -name '*_generated.go' -not -name '*_test.go')
+TESTS := $(shell find . -name '*.go' -type f -not -name '*.pb.go' -not -name '*_generated.go' -name '*_test.go')
+
 get:
 	$(GO) get ./...
 	$(GO) mod verify
@@ -26,14 +33,15 @@ fmt:
 lint:
 	GOFLAGS="-tags=functional" golangci-lint run
 
-test: $(GOBIN)/tparse
-	$(GOTEST) -timeout 2m -json ./... \
-		| tee output.json | $(GOBIN)/tparse -follow -all
-	[ -z "$${GITHUB_STEP_SUMMARY}" ] \
-		|| NO_COLOR=1 $(GOBIN)/tparse -format markdown -file output.json -all >"$${GITHUB_STEP_SUMMARY:-/dev/null}"
+test: $(GOTESTSUM) $(TESTSTAT) $(TPARSE)
+	@$(GOTESTSUM) $(if ${CI},--format github-actions,--format testdox) --jsonfile _test/unittests.json --junitfile _test/unittests.xml \
+		--rerun-fails --packages="./..." \
+		-- -v -race -coverprofile=profile.out -covermode=atomic -timeout 2m
+	@$(TESTSTAT) _test/unittests.json
+
 .PHONY: test_functional
-test_functional: $(GOBIN)/tparse
-	$(GOTEST) -timeout 15m -tags=functional -json ./... \
-		| tee output.json | $(GOBIN)/tparse -follow -all
-	[ -z "$${GITHUB_STEP_SUMMARY:-}" ] \
-		|| NO_COLOR=1 $(GOBIN)/tparse -format markdown -file output.json -all >"$${GITHUB_STEP_SUMMARY:-/dev/null}"
+test_functional: $(GOTESTSUM) $(TESTSTAT) $(TPARSE)
+	@$(GOTESTSUM) $(if ${CI},--format github-actions,--format testdox) --jsonfile _test/fvt.json --junitfile _test/fvt.xml \
+		--rerun-fails --packages="./..." \
+		-- -v -race -coverprofile=profile.out -covermode=atomic -timeout 15m -tags=functional
+	@$(TESTSTAT) _test/fvt.json


### PR DESCRIPTION
Switch to using gotestsum as a runner in the Makefile and move tparse into the .github/workflows as it is GitHub Actions specific and so that we can run it with `always()` rather than only when tests pass.

Additionally add missing coverage dump for unittest runs (we already had it for FV runs) and also output teststat information in Makefile which highlights the slowest tests and any re-run flakes.