### PR TITLE
fix: non-flexible ElectLeadersRequest V0/V1 encode/decode

### DIFF
--- a/elect_leaders_request_test.go
+++ b/elect_leaders_request_test.go
@@ -4,25 +4,39 @@ package sarama
 
 import "testing"
 
-var electLeadersRequestOneTopic = []byte{
-	0,                         // preferred election type
-	2,                         // 2-1=1 topic
-	6, 116, 111, 112, 105, 99, // topic name "topic" as compact string
-	2,          // 2-1=1 partition
-	0, 0, 0, 0, // partition 0
-	0, 0, // empty tagged fields
-	0, 39, 16, 0, // timeout 10000
-}
+var (
+	electLeadersRequestOneTopicV1 = []byte{
+		0,          // preferred election type
+		0, 0, 0, 1, // 1 topic
+		0, 5, 116, 111, 112, 105, 99, // topic name "topic" as compact string
+		0, 0, 0, 1, // 1 partition
+		0, 0, 0, 0, // partition 0
+		0, 0, 39, 16, // timeout 10000
+	}
+	electLeadersRequestOneTopicV2 = []byte{
+		0,                         // preferred election type
+		2,                         // 2-1=1 topic
+		6, 116, 111, 112, 105, 99, // topic name "topic" as compact string
+		2,          // 2-1=1 partition
+		0, 0, 0, 0, // partition 0
+		0,            // empty tagged fields
+		0, 0, 39, 16, // timeout 10000
+		0, // empty tagged fields
+	}
+)
 
 func TestElectLeadersRequest(t *testing.T) {
 	var request = &ElectLeadersRequest{
 		TimeoutMs: int32(10000),
-		Version:   int16(2),
+		Version:   int16(1),
 		TopicPartitions: map[string][]int32{
 			"topic": {0},
 		},
 		Type: PreferredElection,
 	}
 
-	testRequest(t, "one topic", request, electLeadersRequestOneTopic)
+	testRequest(t, "one topic V1", request, electLeadersRequestOneTopicV1)
+
+	request.Version = 2
+	testRequest(t, "one topic V2", request, electLeadersRequestOneTopicV2)
 }


### PR DESCRIPTION
And clean up the misleading layout/comment of the []bytes in the test:

Test layout for V2 `[]byte` was:
```
	0, 0, // empty tagged fields
	0, 39, 16, 0, // timeout 10000
```
but, while the bytes were correct the comments were misleading as the encoding is really:
```
	0,            // empty tagged fields
	0, 0, 39, 16, // timeout 10000
	0, // empty tagged fields
```