### PR TITLE
fix: correct decodeRequest bytesRead return value

### DIFF
--- a/request.go
+++ b/request.go
@@ -92,8 +92,8 @@ func decodeRequest(r io.Reader) (*request, int, error) {
 		lengthBytes = make([]byte, 4)
 	)
 
-	if _, err := io.ReadFull(r, lengthBytes); err != nil {
-		return nil, bytesRead, err
+	if n, err := io.ReadFull(r, lengthBytes); err != nil {
+		return nil, n, err
 	}
 
 	bytesRead += len(lengthBytes)
@@ -104,8 +104,8 @@ func decodeRequest(r io.Reader) (*request, int, error) {
 	}
 
 	encodedReq := make([]byte, length)
-	if _, err := io.ReadFull(r, encodedReq); err != nil {
-		return nil, bytesRead, err
+	if n, err := io.ReadFull(r, encodedReq); err != nil {
+		return nil, bytesRead + n, err
 	}
 
 	bytesRead += len(encodedReq)

--- a/request_test.go
+++ b/request_test.go
@@ -537,4 +537,21 @@ func testResponse(t *testing.T, name string, res protocolBody, expected []byte) 
 	}
 }
 
+func TestDecodeRequestErrorReturns(t *testing.T) {
+	_, bytesRead, err := decodeRequest(bytes.NewReader([]byte{0, 0, 0}))
+	if err == nil {
+		t.Error("Decode of short request should give error but was nil")
+	}
+	if bytesRead != 3 {
+		t.Errorf("Decode of short request should read 3 bytes but was %d", bytesRead)
+	}
+	_, bytesRead, err = decodeRequest(bytes.NewReader([]byte{0, 0, 0, 8, 0, 0, 0}))
+	if err == nil {
+		t.Error("Decode of short request should give error but was nil")
+	}
+	if bytesRead != 7 {
+		t.Errorf("Decode of short request should read 7 bytes but was %d", bytesRead)
+	}
+}
+
 func nullString(s string) *string { return &s }


### PR DESCRIPTION
It seems strange to return `bytesRead` but for it to be the wrong value when the correct value is available.
