### PR TITLE
chore(fvt): refactor docker-compose and support KRaft

### DIFF
--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -27,22 +27,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN --mount=type=bind,target=.,rw=true \
     mkdir -p "/opt/kafka-${KAFKA_VERSION}" \
  && chmod a+rw "/opt/kafka-${KAFKA_VERSION}" \
- && if [ "$KAFKA_VERSION" = "4.0.0" ]; then \
-       microdnf install -y java-17-openjdk-devel \
-    && mkdir -p /usr/src/kafka \
-    && : PIN TO COMMIT OF 4.0 BRANCH BEFORE KAFKA-17616 ZOOKEEPER REMOVAL STARTED \
-    && curl --fail -sSL https://github.com/apache/kafka/archive/d1504649fbe45064a0b0120ff33de9326b2fc662.tar.gz | \
-         tar zxf - -C /usr/src/kafka --strip-components=1 \
-    && cd /usr/src/kafka \
-    && export JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=80 \
-    && sed -e '/version=/s/-SNAPSHOT//' -e '/org.gradle.jvmargs/d' -e '/org.gradle.parallel/s/true/false/' -i gradle.properties && ./gradlew -PmaxParallelForks=1 -PmaxScalacThreads=1 --no-daemon releaseTarGz -x siteDocsTar -x javadoc \
-    && tar xzf core/build/distributions/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz --strip-components=1 -C "/opt/kafka-${KAFKA_VERSION}" \
-    && cp /tmp/server.properties "/opt/kafka-${KAFKA_VERSION}/config/" \
-    && microdnf remove -y java-17-openjdk-devel \
-    && rm -rf /usr/src/kafka ; \
-    else \
-      curl -s "$KAFKA_MIRROR/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" | tar xz --strip-components=1 -C "/opt/kafka-${KAFKA_VERSION}" ; \
-    fi
+ && curl -s "$KAFKA_MIRROR/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" | tar xz --strip-components=1 -C "/opt/kafka-${KAFKA_VERSION}"
 
 # older kafka versions depend upon jaxb-api being bundled with the JDK, but it
 # was removed from Java 11 so work around that by including it in the kafka

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,278 +1,158 @@
+x-zookeeper-base: &zookeeper-base
+  image: 'docker.io/library/zookeeper:3.7.2'
+  init: true
+  restart: always
+  profiles:
+    - zookeeper
+  environment: &zookeeper-base-env
+    ZOO_SERVERS: 'server.1=zookeeper-1:2888:3888 server.2=zookeeper-2:2888:3888 server.3=zookeeper-3:2888:3888'
+    ZOO_CFG_EXTRA: 'clientPort=2181 peerPort=2888 leaderPort=3888'
+    ZOO_INIT_LIMIT: '10'
+    ZOO_SYNC_LIMIT: '5'
+    ZOO_MAX_CLIENT_CNXNS: '0'
+    ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
+
+x-kafka-base: &kafka-base
+  image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
+  init: true
+  build:
+    context: .
+    dockerfile: Dockerfile.kafka
+    args:
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
+      SCALA_VERSION: ${SCALA_VERSION:-2.13}
+  depends_on:
+    - toxiproxy
+  restart: always
+  environment: &kafka-base-env
+    KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
+    KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: '2'
+    KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '2'
+    KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '2'
+    KAFKA_CFG_ZOOKEEPER_SESSION_TIMEOUT_MS: '6000'
+    KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS: '6000'
+    KAFKA_CFG_REPLICA_SELECTOR_CLASS: 'org.apache.kafka.common.replica.RackAwareReplicaSelector'
+    KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
+    KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'false'
+    KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+    KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
+    KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'LISTENER_INTERNAL'
+    KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'LISTENER_INTERNAL:PLAINTEXT,LISTENER_LOCAL:PLAINTEXT,CONTROLLER:PLAINTEXT'
+    # ZooKeeper-specific
+    KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
+    # KRaft-specific
+    KAFKA_CFG_PROCESS_ROLES: 'broker,controller'
+    KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: '1@kafka-1:9093,2@kafka-2:9093,3@kafka-3:9093,4@kafka-4:9093,5@kafka-5:9093'
+    KAFKA_CFG_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+    KAFKA_CFG_CLUSTER_ID: 'cDZEekk4T3hTNGVlNzB3LUtUbkxaQQo='
+
 services:
   zookeeper-1:
+    <<: *zookeeper-base
     container_name: 'zookeeper-1'
-    image: 'docker.io/library/zookeeper:3.7.2'
-    init: true
-    restart: always
     environment:
+      <<: *zookeeper-base-env
       ZOO_MY_ID: '1'
-      ZOO_SERVERS: 'server.1=zookeeper-1:2888:3888 server.2=zookeeper-2:2888:3888 server.3=zookeeper-3:2888:3888'
-      ZOO_CFG_EXTRA: 'clientPort=2181 peerPort=2888 leaderPort=3888'
-      ZOO_INIT_LIMIT: '10'
-      ZOO_SYNC_LIMIT: '5'
-      ZOO_MAX_CLIENT_CNXNS: '0'
-      ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
+
   zookeeper-2:
+    <<: *zookeeper-base
     container_name: 'zookeeper-2'
-    image: 'docker.io/library/zookeeper:3.7.2'
-    init: true
-    restart: always
     environment:
+      <<: *zookeeper-base-env
       ZOO_MY_ID: '2'
-      ZOO_SERVERS: 'server.1=zookeeper-1:2888:3888 server.2=zookeeper-2:2888:3888 server.3=zookeeper-3:2888:3888'
-      ZOO_CFG_EXTRA: 'clientPort=2181 peerPort=2888 leaderPort=3888'
-      ZOO_INIT_LIMIT: '10'
-      ZOO_SYNC_LIMIT: '5'
-      ZOO_MAX_CLIENT_CNXNS: '0'
-      ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
+
   zookeeper-3:
+    <<: *zookeeper-base
     container_name: 'zookeeper-3'
-    image: 'docker.io/library/zookeeper:3.7.2'
-    init: true
-    restart: always
     environment:
+      <<: *zookeeper-base-env
       ZOO_MY_ID: '3'
-      ZOO_SERVERS: 'server.1=zookeeper-1:2888:3888 server.2=zookeeper-2:2888:3888 server.3=zookeeper-3:2888:3888'
-      ZOO_CFG_EXTRA: 'clientPort=2181 peerPort=2888 leaderPort=3888'
-      ZOO_INIT_LIMIT: '10'
-      ZOO_SYNC_LIMIT: '5'
-      ZOO_MAX_CLIENT_CNXNS: '0'
-      ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
+
   kafka-1:
+    <<: *kafka-base
     container_name: 'kafka-1'
-    image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
-    init: true
-    build:
-      context: .
-      dockerfile: Dockerfile.kafka
-      args:
-        KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-        SCALA_VERSION: ${SCALA_VERSION:-2.13}
     healthcheck:
-      test:
-        [
-          'CMD',
-          '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh',
-          '--bootstrap-server',
-          'kafka-1:9091',
-        ]
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-1:9091']
       interval: 15s
       timeout: 15s
       retries: 10
       start_period: 360s
-    depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
-      - toxiproxy
-    restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-      KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
-      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29091'
-      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-1:9091,LISTENER_LOCAL://localhost:29091'
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'LISTENER_INTERNAL'
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'LISTENER_INTERNAL:PLAINTEXT,LISTENER_LOCAL:PLAINTEXT'
-      KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '2'
+      <<: *kafka-base-env
       KAFKA_CFG_BROKER_ID: '1'
+      KAFKA_CFG_NODE_ID: '1'
       KAFKA_CFG_BROKER_RACK: '1'
-      KAFKA_CFG_ZOOKEEPER_SESSION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_REPLICA_SELECTOR_CLASS: 'org.apache.kafka.common.replica.RackAwareReplicaSelector'
-      KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'false'
-      KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
+      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29091,CONTROLLER://:9093'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-1:9091,LISTENER_LOCAL://localhost:29091'
+
   kafka-2:
+    <<: *kafka-base
     container_name: 'kafka-2'
-    image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
-    init: true
-    build:
-      context: .
-      dockerfile: Dockerfile.kafka
-      args:
-        KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-        SCALA_VERSION: ${SCALA_VERSION:-2.13}
     healthcheck:
-      test:
-        [
-          'CMD',
-          '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh',
-          '--bootstrap-server',
-          'kafka-2:9091',
-        ]
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-2:9091']
       interval: 15s
       timeout: 15s
       retries: 10
       start_period: 360s
-    depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
-      - toxiproxy
-    restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-      KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
-      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29092'
-      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-2:9091,LISTENER_LOCAL://localhost:29092'
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'LISTENER_INTERNAL'
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'LISTENER_INTERNAL:PLAINTEXT,LISTENER_LOCAL:PLAINTEXT'
-      KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '2'
+      <<: *kafka-base-env
       KAFKA_CFG_BROKER_ID: '2'
+      KAFKA_CFG_NODE_ID: '2'
       KAFKA_CFG_BROKER_RACK: '2'
-      KAFKA_CFG_ZOOKEEPER_SESSION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_REPLICA_SELECTOR_CLASS: 'org.apache.kafka.common.replica.RackAwareReplicaSelector'
-      KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'false'
-      KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
+      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29092,CONTROLLER://:9093'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-2:9091,LISTENER_LOCAL://localhost:29092'
+
   kafka-3:
+    <<: *kafka-base
     container_name: 'kafka-3'
-    image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
-    init: true
-    build:
-      context: .
-      dockerfile: Dockerfile.kafka
-      args:
-        KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-        SCALA_VERSION: ${SCALA_VERSION:-2.13}
     healthcheck:
-      test:
-        [
-          'CMD',
-          '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh',
-          '--bootstrap-server',
-          'kafka-3:9091',
-        ]
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-3:9091']
       interval: 15s
       timeout: 15s
       retries: 10
       start_period: 360s
-    depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
-      - toxiproxy
-    restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-      KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
-      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29093'
-      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-3:9091,LISTENER_LOCAL://localhost:29093'
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'LISTENER_INTERNAL'
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'LISTENER_INTERNAL:PLAINTEXT,LISTENER_LOCAL:PLAINTEXT'
-      KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '2'
+      <<: *kafka-base-env
       KAFKA_CFG_BROKER_ID: '3'
+      KAFKA_CFG_NODE_ID: '3'
       KAFKA_CFG_BROKER_RACK: '3'
-      KAFKA_CFG_ZOOKEEPER_SESSION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_REPLICA_SELECTOR_CLASS: 'org.apache.kafka.common.replica.RackAwareReplicaSelector'
-      KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'false'
-      KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
+      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29093,CONTROLLER://:9093'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-3:9091,LISTENER_LOCAL://localhost:29093'
+
   kafka-4:
+    <<: *kafka-base
     container_name: 'kafka-4'
-    image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
-    init: true
-    build:
-      context: .
-      dockerfile: Dockerfile.kafka
-      args:
-        KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-        SCALA_VERSION: ${SCALA_VERSION:-2.13}
     healthcheck:
-      test:
-        [
-          'CMD',
-          '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh',
-          '--bootstrap-server',
-          'kafka-4:9091',
-        ]
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-4:9091']
       interval: 15s
       timeout: 15s
       retries: 10
       start_period: 360s
-    depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
-      - toxiproxy
-    restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-      KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
-      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29094'
-      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-4:9091,LISTENER_LOCAL://localhost:29094'
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'LISTENER_INTERNAL'
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'LISTENER_INTERNAL:PLAINTEXT,LISTENER_LOCAL:PLAINTEXT'
-      KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '2'
+      <<: *kafka-base-env
       KAFKA_CFG_BROKER_ID: '4'
+      KAFKA_CFG_NODE_ID: '4'
       KAFKA_CFG_BROKER_RACK: '4'
-      KAFKA_CFG_ZOOKEEPER_SESSION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_REPLICA_SELECTOR_CLASS: 'org.apache.kafka.common.replica.RackAwareReplicaSelector'
-      KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'false'
-      KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
+      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29094,CONTROLLER://:9093'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-4:9091,LISTENER_LOCAL://localhost:29094'
+
   kafka-5:
+    <<: *kafka-base
     container_name: 'kafka-5'
-    image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
-    init: true
-    build:
-      context: .
-      dockerfile: Dockerfile.kafka
-      args:
-        KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-        SCALA_VERSION: ${SCALA_VERSION:-2.13}
     healthcheck:
-      test:
-        [
-          'CMD',
-          '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh',
-          '--bootstrap-server',
-          'kafka-5:9091',
-        ]
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-5:9091']
       interval: 15s
       timeout: 15s
       retries: 10
       start_period: 360s
-    depends_on:
-      - zookeeper-1
-      - zookeeper-2
-      - zookeeper-3
-      - toxiproxy
-    restart: always
     environment:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
-      KAFKA_CFG_ZOOKEEPER_CONNECT: 'zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181'
-      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29095'
-      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-5:9091,LISTENER_LOCAL://localhost:29095'
-      KAFKA_CFG_INTER_BROKER_LISTENER_NAME: 'LISTENER_INTERNAL'
-      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: 'LISTENER_INTERNAL:PLAINTEXT,LISTENER_LOCAL:PLAINTEXT'
-      KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '2'
-      KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '2'
+      <<: *kafka-base-env
       KAFKA_CFG_BROKER_ID: '5'
+      KAFKA_CFG_NODE_ID: '5'
       KAFKA_CFG_BROKER_RACK: '5'
-      KAFKA_CFG_ZOOKEEPER_SESSION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_ZOOKEEPER_CONNECTION_TIMEOUT_MS: '6000'
-      KAFKA_CFG_REPLICA_SELECTOR_CLASS: 'org.apache.kafka.common.replica.RackAwareReplicaSelector'
-      KAFKA_CFG_DELETE_TOPIC_ENABLE: 'true'
-      KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE: 'false'
-      KAFKA_CFG_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_JVM_PERFORMANCE_OPTS: "-XX:+IgnoreUnrecognizedVMOptions"
+      KAFKA_CFG_LISTENERS: 'LISTENER_INTERNAL://:9091,LISTENER_LOCAL://:29095,CONTROLLER://:9093'
+      KAFKA_CFG_ADVERTISED_LISTENERS: 'LISTENER_INTERNAL://kafka-5:9091,LISTENER_LOCAL://localhost:29095'
+
   toxiproxy:
     container_name: 'toxiproxy'
     image: 'ghcr.io/shopify/toxiproxy:2.12.0'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,6 +26,21 @@ for var in "${!KAFKA_CFG_@}"; do
     echo "$key=$value" >>/tmp/server.properties
 done
 
+# use KRaft if KAFKA_VERSION is 4.0.0 or newer
+if printf "%s\n4.0.0" "$KAFKA_VERSION" | sort -V | head -n1 | grep -q "^4.0.0$"; then
+  # remove zookeeper-only options from server.properties and setup storage
+  sed -e '/zookeeper.connect/d' \
+      -i /tmp/server.properties
+  bin/kafka-storage.sh format -t "$KAFKA_CFG_CLUSTER_ID" -c /tmp/server.properties --ignore-formatted
+else
+  # remove KRaft-only options from server.properties
+  sed -e '/process.roles/d' \
+      -e '/controller.quorum.voters/d' \
+      -e '/controller.listener.names/d' \
+      -e '/cluster.id/d' \
+      -i /tmp/server.properties
+fi
+
 sort /tmp/server.properties
 
 exec bin/kafka-server-start.sh /tmp/server.properties


### PR DESCRIPTION
- make use of docker compose 'fragments' (yaml anchors) to reduce a lot of duplication in the docker-compose
- remove the pinned commit we were using to test Kafka 4.0 with ZooKeeper support and start testing against the release with KRaft enabled
- use the entrypoint.sh to remove the inappropriate broker properties if in zookeeper mode or kraft mode respectively
- don't start the zookeeper containers unless `--profile zookeeper` is passed, this saves on the resource at the cost of not necessarily being obvious to a casual user. It's a shame we can't selectively start them based on KAFKA_VERSION