### PR TITLE
chore: add 3.9.1 and 4.1.0 version constants and FVT

### DIFF
--- a/.github/workflows/fvt-main.yml
+++ b/.github/workflows/fvt-main.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [stable]
-        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.3, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 4.0.0]
+        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.3, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 4.0.0, 4.1.0]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
@@ -42,6 +42,8 @@ jobs:
         - kafka-version: 3.8.1
           scala-version: 2.13
         - kafka-version: 4.0.0
+          scala-version: 2.13
+        - kafka-version: 4.1.0
           scala-version: 2.13
     uses: ./.github/workflows/fvt.yml
     with:

--- a/.github/workflows/fvt-pr.yml
+++ b/.github/workflows/fvt-pr.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [stable]
-        kafka-version: [1.0.2, 2.6.3, 3.6.2, 3.8.1, 4.0.0]
+        kafka-version: [1.0.2, 2.6.3, 3.6.2, 3.9.1, 4.1.0]
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
@@ -28,7 +28,7 @@ jobs:
           scala-version: 2.12
         - kafka-version: 3.6.2
           scala-version: 2.13
-        - kafka-version: 3.8.1
+        - kafka-version: 3.9.1
           scala-version: 2.13
         - kafka-version: 4.0.0
           scala-version: 2.13

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -9,7 +9,7 @@ on:
       kafka-version:
         required: false
         type: string
-        default: "3.6.2"
+        default: "3.9.1"
       scala-version:
         required: false
         type: string

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -17,7 +17,7 @@ RUN cd /etc/java/java-17-openjdk/*/conf/security \
  && echo 'networkaddress.cache.negative.ttl=0' >> java.security
 
 ARG SCALA_VERSION="2.13"
-ARG KAFKA_VERSION="3.6.2"
+ARG KAFKA_VERSION="3.9.1"
 
 WORKDIR /tmp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,19 +13,19 @@ x-zookeeper-base: &zookeeper-base
     ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
 
 x-kafka-base: &kafka-base
-  image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.6.2}'
+  image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.9.1}'
   init: true
   build:
     context: .
     dockerfile: Dockerfile.kafka
     args:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
+      KAFKA_VERSION: ${KAFKA_VERSION:-3.9.1}
       SCALA_VERSION: ${SCALA_VERSION:-2.13}
   depends_on:
     - toxiproxy
   restart: always
   environment: &kafka-base-env
-    KAFKA_VERSION: ${KAFKA_VERSION:-3.6.2}
+    KAFKA_VERSION: ${KAFKA_VERSION:-3.9.1}
     KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: '2'
     KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '2'
     KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '2'
@@ -72,7 +72,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-1'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-1:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-1:9091']
       interval: 15s
       timeout: 15s
       retries: 10
@@ -89,7 +89,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-2'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-2:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-2:9091']
       interval: 15s
       timeout: 15s
       retries: 10
@@ -106,7 +106,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-3'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-3:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-3:9091']
       interval: 15s
       timeout: 15s
       retries: 10
@@ -123,7 +123,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-4'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-4:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-4:9091']
       interval: 15s
       timeout: 15s
       retries: 10
@@ -140,7 +140,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-5'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.6.2}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-5:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-5:9091']
       interval: 15s
       timeout: 15s
       retries: 10

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 set -eu
 set -o pipefail
 
-KAFKA_VERSION="${KAFKA_VERSION:-3.6.2}"
+KAFKA_VERSION="${KAFKA_VERSION:-3.9.1}"
 KAFKA_HOME="/opt/kafka-${KAFKA_VERSION}"
 
 if [ ! -d "${KAFKA_HOME}" ]; then

--- a/utils.go
+++ b/utils.go
@@ -214,7 +214,9 @@ var (
 	V3_8_0_0  = newKafkaVersion(3, 8, 0, 0)
 	V3_8_1_0  = newKafkaVersion(3, 8, 1, 0)
 	V3_9_0_0  = newKafkaVersion(3, 9, 0, 0)
+	V3_9_1_0  = newKafkaVersion(3, 9, 1, 0)
 	V4_0_0_0  = newKafkaVersion(4, 0, 0, 0)
+	V4_1_0_0  = newKafkaVersion(4, 1, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -287,10 +289,12 @@ var (
 		V3_8_0_0,
 		V3_8_1_0,
 		V3_9_0_0,
+		V3_9_1_0,
 		V4_0_0_0,
+		V4_1_0_0,
 	}
 	MinVersion     = V0_8_2_0
-	MaxVersion     = V4_0_0_0
+	MaxVersion     = V4_1_0_0
 	DefaultVersion = V2_1_0_0
 
 	// reduced set of protocol versions to matrix test


### PR DESCRIPTION
- add version constants to utils.go for latest releases
- add 4.1.0 to fvt-main
- tweak fvt-pr to drop 3.8.1 and 4.0.0 and replace them with 3.9.1 and 4.1.0
- update the "default" KAFKA_VERSION when running the FVT locally from 3.6.2 to 3.9.1