### PR TITLE
refactor: get/put for KError

### DIFF
--- a/acl_create_response.go
+++ b/acl_create_response.go
@@ -88,7 +88,7 @@ type AclCreationResponse struct {
 }
 
 func (a *AclCreationResponse) encode(pe packetEncoder) error {
-	pe.putInt16(int16(a.Err))
+	pe.putKError(a.Err)
 
 	if err := pe.putNullableString(a.ErrMsg); err != nil {
 		return err
@@ -98,11 +98,10 @@ func (a *AclCreationResponse) encode(pe packetEncoder) error {
 }
 
 func (a *AclCreationResponse) decode(pd packetDecoder, version int16) (err error) {
-	kerr, err := pd.getInt16()
+	a.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	a.Err = KError(kerr)
 
 	if a.ErrMsg, err = pd.getNullableString(); err != nil {
 		return err

--- a/acl_delete_response.go
+++ b/acl_delete_response.go
@@ -89,7 +89,7 @@ type FilterResponse struct {
 }
 
 func (f *FilterResponse) encode(pe packetEncoder, version int16) error {
-	pe.putInt16(int16(f.Err))
+	pe.putKError(f.Err)
 	if err := pe.putNullableString(f.ErrMsg); err != nil {
 		return err
 	}
@@ -107,11 +107,10 @@ func (f *FilterResponse) encode(pe packetEncoder, version int16) error {
 }
 
 func (f *FilterResponse) decode(pd packetDecoder, version int16) (err error) {
-	kerr, err := pd.getInt16()
+	f.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	f.Err = KError(kerr)
 
 	if f.ErrMsg, err = pd.getNullableString(); err != nil {
 		return err
@@ -141,7 +140,7 @@ type MatchingAcl struct {
 }
 
 func (m *MatchingAcl) encode(pe packetEncoder, version int16) error {
-	pe.putInt16(int16(m.Err))
+	pe.putKError(m.Err)
 	if err := pe.putNullableString(m.ErrMsg); err != nil {
 		return err
 	}
@@ -158,11 +157,10 @@ func (m *MatchingAcl) encode(pe packetEncoder, version int16) error {
 }
 
 func (m *MatchingAcl) decode(pd packetDecoder, version int16) (err error) {
-	kerr, err := pd.getInt16()
+	m.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	m.Err = KError(kerr)
 
 	if m.ErrMsg, err = pd.getNullableString(); err != nil {
 		return err

--- a/acl_describe_response.go
+++ b/acl_describe_response.go
@@ -17,7 +17,7 @@ func (d *DescribeAclsResponse) setVersion(v int16) {
 
 func (d *DescribeAclsResponse) encode(pe packetEncoder) error {
 	pe.putInt32(int32(d.ThrottleTime / time.Millisecond))
-	pe.putInt16(int16(d.Err))
+	pe.putKError(d.Err)
 
 	if err := pe.putNullableString(d.ErrMsg); err != nil {
 		return err
@@ -43,11 +43,10 @@ func (d *DescribeAclsResponse) decode(pd packetDecoder, version int16) (err erro
 	}
 	d.ThrottleTime = time.Duration(throttleTime) * time.Millisecond
 
-	kerr, err := pd.getInt16()
+	d.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	d.Err = KError(kerr)
 
 	errmsg, err := pd.getString()
 	if err != nil {

--- a/add_offsets_to_txn_response.go
+++ b/add_offsets_to_txn_response.go
@@ -17,7 +17,7 @@ func (a *AddOffsetsToTxnResponse) setVersion(v int16) {
 
 func (a *AddOffsetsToTxnResponse) encode(pe packetEncoder) error {
 	pe.putInt32(int32(a.ThrottleTime / time.Millisecond))
-	pe.putInt16(int16(a.Err))
+	pe.putKError(a.Err)
 	return nil
 }
 
@@ -28,11 +28,10 @@ func (a *AddOffsetsToTxnResponse) decode(pd packetDecoder, version int16) (err e
 	}
 	a.ThrottleTime = time.Duration(throttleTime) * time.Millisecond
 
-	kerr, err := pd.getInt16()
+	a.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	a.Err = KError(kerr)
 
 	return nil
 }

--- a/add_partitions_to_txn_response.go
+++ b/add_partitions_to_txn_response.go
@@ -116,7 +116,7 @@ type PartitionError struct {
 
 func (p *PartitionError) encode(pe packetEncoder) error {
 	pe.putInt32(p.Partition)
-	pe.putInt16(int16(p.Err))
+	pe.putKError(p.Err)
 	return nil
 }
 
@@ -125,11 +125,10 @@ func (p *PartitionError) decode(pd packetDecoder, version int16) (err error) {
 		return err
 	}
 
-	kerr, err := pd.getInt16()
+	p.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	p.Err = KError(kerr)
 
 	return nil
 }

--- a/alter_client_quotas_response.go
+++ b/alter_client_quotas_response.go
@@ -77,7 +77,7 @@ func (a *AlterClientQuotasResponse) decode(pd packetDecoder, version int16) erro
 
 func (a *AlterClientQuotasEntryResponse) encode(pe packetEncoder) error {
 	// ErrorCode
-	pe.putInt16(int16(a.ErrorCode))
+	pe.putKError(a.ErrorCode)
 
 	// ErrorMsg
 	if err := pe.putNullableString(a.ErrorMsg); err != nil {
@@ -97,13 +97,12 @@ func (a *AlterClientQuotasEntryResponse) encode(pe packetEncoder) error {
 	return nil
 }
 
-func (a *AlterClientQuotasEntryResponse) decode(pd packetDecoder, version int16) error {
+func (a *AlterClientQuotasEntryResponse) decode(pd packetDecoder, version int16) (err error) {
 	// ErrorCode
-	errCode, err := pd.getInt16()
+	a.ErrorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	a.ErrorCode = KError(errCode)
 
 	// ErrorMsg
 	errMsg, err := pd.getNullableString()

--- a/alter_partition_reassignments_response.go
+++ b/alter_partition_reassignments_response.go
@@ -8,7 +8,7 @@ type alterPartitionReassignmentsErrorBlock struct {
 }
 
 func (b *alterPartitionReassignmentsErrorBlock) encode(pe packetEncoder) error {
-	pe.putInt16(int16(b.errorCode))
+	pe.putKError(b.errorCode)
 	if err := pe.putNullableString(b.errorMessage); err != nil {
 		return err
 	}
@@ -18,11 +18,10 @@ func (b *alterPartitionReassignmentsErrorBlock) encode(pe packetEncoder) error {
 }
 
 func (b *alterPartitionReassignmentsErrorBlock) decode(pd packetDecoder) (err error) {
-	errorCode, err := pd.getInt16()
+	b.errorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	b.errorCode = KError(errorCode)
 	b.errorMessage, err = pd.getNullableString()
 	if err != nil {
 		return err
@@ -59,7 +58,7 @@ func (r *AlterPartitionReassignmentsResponse) AddError(topic string, partition i
 
 func (r *AlterPartitionReassignmentsResponse) encode(pe packetEncoder) error {
 	pe.putInt32(r.ThrottleTimeMs)
-	pe.putInt16(int16(r.ErrorCode))
+	pe.putKError(r.ErrorCode)
 	if err := pe.putNullableString(r.ErrorMessage); err != nil {
 		return err
 	}
@@ -95,12 +94,10 @@ func (r *AlterPartitionReassignmentsResponse) decode(pd packetDecoder, version i
 		return err
 	}
 
-	kerr, err := pd.getInt16()
+	r.ErrorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-
-	r.ErrorCode = KError(kerr)
 
 	if r.ErrorMessage, err = pd.getNullableString(); err != nil {
 		return err

--- a/alter_user_scram_credentials_response.go
+++ b/alter_user_scram_credentials_response.go
@@ -31,7 +31,7 @@ func (r *AlterUserScramCredentialsResponse) encode(pe packetEncoder) error {
 		if err := pe.putString(u.User); err != nil {
 			return err
 		}
-		pe.putInt16(int16(u.ErrorCode))
+		pe.putKError(u.ErrorCode)
 		if err := pe.putNullableString(u.ErrorMessage); err != nil {
 			return err
 		}
@@ -62,12 +62,11 @@ func (r *AlterUserScramCredentialsResponse) decode(pd packetDecoder, version int
 				return err
 			}
 
-			kerr, err := pd.getInt16()
+			r.Results[i].ErrorCode, err = pd.getKError()
 			if err != nil {
 				return err
 			}
 
-			r.Results[i].ErrorCode = KError(kerr)
 			if r.Results[i].ErrorMessage, err = pd.getNullableString(); err != nil {
 				return err
 			}

--- a/create_partitions_response.go
+++ b/create_partitions_response.go
@@ -109,7 +109,7 @@ func (t *TopicPartitionError) Unwrap() error {
 }
 
 func (t *TopicPartitionError) encode(pe packetEncoder) error {
-	pe.putInt16(int16(t.Err))
+	pe.putKError(t.Err)
 
 	if err := pe.putNullableString(t.ErrMsg); err != nil {
 		return err
@@ -119,11 +119,10 @@ func (t *TopicPartitionError) encode(pe packetEncoder) error {
 }
 
 func (t *TopicPartitionError) decode(pd packetDecoder, version int16) (err error) {
-	kerr, err := pd.getInt16()
+	t.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	t.Err = KError(kerr)
 
 	if t.ErrMsg, err = pd.getNullableString(); err != nil {
 		return err

--- a/create_topics_response.go
+++ b/create_topics_response.go
@@ -162,7 +162,7 @@ func (t *TopicError) Unwrap() error {
 }
 
 func (t *TopicError) encode(pe packetEncoder, version int16) error {
-	pe.putInt16(int16(t.Err))
+	pe.putKError(t.Err)
 
 	if version >= 1 {
 		if err := pe.putNullableString(t.ErrMsg); err != nil {
@@ -174,11 +174,10 @@ func (t *TopicError) encode(pe packetEncoder, version int16) error {
 }
 
 func (t *TopicError) decode(pd packetDecoder, version int16) (err error) {
-	kErr, err := pd.getInt16()
+	t.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	t.Err = KError(kErr)
 
 	if version >= 1 {
 		if t.ErrMsg, err = pd.getNullableString(); err != nil {
@@ -228,7 +227,7 @@ func (r *CreatableTopicResult) encode(pe packetEncoder, version int16) error {
 
 	pe.putUVarint(2) // value length
 
-	pe.putInt16(int16(r.TopicConfigErrorCode)) // tag value
+	pe.putKError(r.TopicConfigErrorCode) // tag value
 
 	return nil
 }
@@ -261,11 +260,10 @@ func (r *CreatableTopicResult) decode(pd packetDecoder, version int16) (err erro
 	}
 	err = pd.getTaggedFieldArray(taggedFieldDecoders{
 		0: func(pd packetDecoder) error {
-			kErr, err := pd.getInt16()
+			r.TopicConfigErrorCode, err = pd.getKError()
 			if err != nil {
 				return err
 			}
-			r.TopicConfigErrorCode = KError(kErr)
 			return nil
 		},
 	})

--- a/delete_groups_response.go
+++ b/delete_groups_response.go
@@ -24,7 +24,7 @@ func (r *DeleteGroupsResponse) encode(pe packetEncoder) error {
 		if err := pe.putString(groupID); err != nil {
 			return err
 		}
-		pe.putInt16(int16(errorCode))
+		pe.putKError(errorCode)
 		pe.putEmptyTaggedFieldArray()
 	}
 
@@ -54,12 +54,11 @@ func (r *DeleteGroupsResponse) decode(pd packetDecoder, version int16) error {
 		if err != nil {
 			return err
 		}
-		errorCode, err := pd.getInt16()
+		r.GroupErrorCodes[groupID], err = pd.getKError()
 		if err != nil {
 			return err
 		}
 
-		r.GroupErrorCodes[groupID] = KError(errorCode)
 		if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
 			return err
 		}

--- a/delete_offsets_response.go
+++ b/delete_offsets_response.go
@@ -30,7 +30,7 @@ func (r *DeleteOffsetsResponse) AddError(topic string, partition int32, errorCod
 }
 
 func (r *DeleteOffsetsResponse) encode(pe packetEncoder) error {
-	pe.putInt16(int16(r.ErrorCode))
+	pe.putKError(r.ErrorCode)
 	pe.putInt32(int32(r.ThrottleTime / time.Millisecond))
 
 	if err := pe.putArrayLength(len(r.Errors)); err != nil {
@@ -45,18 +45,17 @@ func (r *DeleteOffsetsResponse) encode(pe packetEncoder) error {
 		}
 		for partition, errorCode := range partitions {
 			pe.putInt32(partition)
-			pe.putInt16(int16(errorCode))
+			pe.putKError(errorCode)
 		}
 	}
 	return nil
 }
 
-func (r *DeleteOffsetsResponse) decode(pd packetDecoder, version int16) error {
-	tmpErr, err := pd.getInt16()
+func (r *DeleteOffsetsResponse) decode(pd packetDecoder, version int16) (err error) {
+	r.ErrorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	r.ErrorCode = KError(tmpErr)
 
 	throttleTime, err := pd.getInt32()
 	if err != nil {
@@ -89,11 +88,10 @@ func (r *DeleteOffsetsResponse) decode(pd packetDecoder, version int16) error {
 				return err
 			}
 
-			tmp, err := pd.getInt16()
+			r.Errors[name][id], err = pd.getKError()
 			if err != nil {
 				return err
 			}
-			r.Errors[name][id] = KError(tmp)
 		}
 	}
 

--- a/delete_records_response.go
+++ b/delete_records_response.go
@@ -159,7 +159,7 @@ type DeleteRecordsResponsePartition struct {
 
 func (t *DeleteRecordsResponsePartition) encode(pe packetEncoder) error {
 	pe.putInt64(t.LowWatermark)
-	pe.putInt16(int16(t.Err))
+	pe.putKError(t.Err)
 	return nil
 }
 
@@ -170,11 +170,10 @@ func (t *DeleteRecordsResponsePartition) decode(pd packetDecoder, version int16)
 	}
 	t.LowWatermark = lowWatermark
 
-	kErr, err := pd.getInt16()
+	t.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	t.Err = KError(kErr)
 
 	return nil
 }

--- a/delete_topics_response.go
+++ b/delete_topics_response.go
@@ -26,7 +26,7 @@ func (d *DeleteTopicsResponse) encode(pe packetEncoder) error {
 		if err := pe.putString(topic); err != nil {
 			return err
 		}
-		pe.putInt16(int16(errorCode))
+		pe.putKError(errorCode)
 		pe.putEmptyTaggedFieldArray()
 	}
 
@@ -57,12 +57,11 @@ func (d *DeleteTopicsResponse) decode(pd packetDecoder, version int16) (err erro
 		if err != nil {
 			return err
 		}
-		errorCode, err := pd.getInt16()
+		d.TopicErrorCodes[topic], err = pd.getKError()
 		if err != nil {
 			return err
 		}
 
-		d.TopicErrorCodes[topic] = KError(errorCode)
 		if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
 			return err
 		}

--- a/describe_client_quotas_response.go
+++ b/describe_client_quotas_response.go
@@ -44,7 +44,7 @@ func (d *DescribeClientQuotasResponse) encode(pe packetEncoder) error {
 	pe.putInt32(int32(d.ThrottleTime / time.Millisecond))
 
 	// ErrorCode
-	pe.putInt16(int16(d.ErrorCode))
+	pe.putKError(d.ErrorCode)
 
 	// ErrorMsg
 	if err := pe.putNullableString(d.ErrorMsg); err != nil {
@@ -73,11 +73,10 @@ func (d *DescribeClientQuotasResponse) decode(pd packetDecoder, version int16) e
 	d.ThrottleTime = time.Duration(throttleTime) * time.Millisecond
 
 	// ErrorCode
-	errCode, err := pd.getInt16()
+	d.ErrorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	d.ErrorCode = KError(errCode)
 
 	// ErrorMsg
 	errMsg, err := pd.getNullableString()

--- a/describe_log_dirs_response.go
+++ b/describe_log_dirs_response.go
@@ -22,7 +22,7 @@ func (r *DescribeLogDirsResponse) encode(pe packetEncoder) error {
 	pe.putInt32(int32(r.ThrottleTime / time.Millisecond))
 
 	if r.Version >= 3 {
-		pe.putInt16(int16(r.ErrorCode))
+		pe.putKError(r.ErrorCode)
 	}
 
 	if err := pe.putArrayLength(len(r.LogDirs)); err != nil {
@@ -47,11 +47,10 @@ func (r *DescribeLogDirsResponse) decode(pd packetDecoder, version int16) error 
 	r.ThrottleTime = time.Duration(throttleTime) * time.Millisecond
 
 	if version >= 3 {
-		errCode, err := pd.getInt16()
+		r.ErrorCode, err = pd.getKError()
 		if err != nil {
 			return err
 		}
-		r.ErrorCode = KError(errCode)
 	}
 
 	// Decode array of DescribeLogDirsResponseDirMetadata
@@ -131,7 +130,7 @@ type DescribeLogDirsResponseDirMetadata struct {
 }
 
 func (r *DescribeLogDirsResponseDirMetadata) encode(pe packetEncoder, version int16) error {
-	pe.putInt16(int16(r.ErrorCode))
+	pe.putKError(r.ErrorCode)
 
 	err := pe.putString(r.Path)
 	if err != nil {
@@ -156,12 +155,11 @@ func (r *DescribeLogDirsResponseDirMetadata) encode(pe packetEncoder, version in
 	return nil
 }
 
-func (r *DescribeLogDirsResponseDirMetadata) decode(pd packetDecoder, version int16) error {
-	errCode, err := pd.getInt16()
+func (r *DescribeLogDirsResponseDirMetadata) decode(pd packetDecoder, version int16) (err error) {
+	r.ErrorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	r.ErrorCode = KError(errCode)
 
 	path, err := pd.getString()
 	if err != nil {

--- a/describe_user_scram_credentials_response.go
+++ b/describe_user_scram_credentials_response.go
@@ -54,7 +54,7 @@ type UserScramCredentialsResponseInfo struct {
 func (r *DescribeUserScramCredentialsResponse) encode(pe packetEncoder) error {
 	pe.putInt32(int32(r.ThrottleTime / time.Millisecond))
 
-	pe.putInt16(int16(r.ErrorCode))
+	pe.putKError(r.ErrorCode)
 	if err := pe.putNullableString(r.ErrorMessage); err != nil {
 		return err
 	}
@@ -94,12 +94,11 @@ func (r *DescribeUserScramCredentialsResponse) decode(pd packetDecoder, version 
 	}
 	r.ThrottleTime = time.Duration(throttleTime) * time.Millisecond
 
-	kerr, err := pd.getInt16()
+	r.ErrorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
 
-	r.ErrorCode = KError(kerr)
 	if r.ErrorMessage, err = pd.getNullableString(); err != nil {
 		return err
 	}
@@ -117,11 +116,10 @@ func (r *DescribeUserScramCredentialsResponse) decode(pd packetDecoder, version 
 				return err
 			}
 
-			errorCode, err := pd.getInt16()
+			r.Results[i].ErrorCode, err = pd.getKError()
 			if err != nil {
 				return err
 			}
-			r.Results[i].ErrorCode = KError(errorCode)
 			if r.Results[i].ErrorMessage, err = pd.getNullableString(); err != nil {
 				return err
 			}

--- a/elect_leaders_response.go
+++ b/elect_leaders_response.go
@@ -8,7 +8,7 @@ type PartitionResult struct {
 }
 
 func (b *PartitionResult) encode(pe packetEncoder, version int16) error {
-	pe.putInt16(int16(b.ErrorCode))
+	pe.putKError(b.ErrorCode)
 	if err := pe.putNullableString(b.ErrorMessage); err != nil {
 		return err
 	}
@@ -17,11 +17,10 @@ func (b *PartitionResult) encode(pe packetEncoder, version int16) error {
 }
 
 func (b *PartitionResult) decode(pd packetDecoder, version int16) (err error) {
-	kerr, err := pd.getInt16()
+	b.ErrorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	b.ErrorCode = KError(kerr)
 	b.ErrorMessage, err = pd.getNullableString()
 	if err != nil {
 		return err
@@ -45,7 +44,7 @@ func (r *ElectLeadersResponse) encode(pe packetEncoder) error {
 	pe.putInt32(r.ThrottleTimeMs)
 
 	if r.Version > 0 {
-		pe.putInt16(int16(r.ErrorCode))
+		pe.putKError(r.ErrorCode)
 	}
 
 	if err := pe.putArrayLength(len(r.ReplicaElectionResults)); err != nil {
@@ -77,11 +76,10 @@ func (r *ElectLeadersResponse) decode(pd packetDecoder, version int16) (err erro
 		return err
 	}
 	if r.Version > 0 {
-		kerr, err := pd.getInt16()
+		r.ErrorCode, err = pd.getKError()
 		if err != nil {
 			return err
 		}
-		r.ErrorCode = KError(kerr)
 	}
 
 	numTopics, err := pd.getArrayLength()

--- a/end_txn_response.go
+++ b/end_txn_response.go
@@ -16,7 +16,7 @@ func (e *EndTxnResponse) setVersion(v int16) {
 
 func (e *EndTxnResponse) encode(pe packetEncoder) error {
 	pe.putInt32(int32(e.ThrottleTime / time.Millisecond))
-	pe.putInt16(int16(e.Err))
+	pe.putKError(e.Err)
 	return nil
 }
 
@@ -27,11 +27,10 @@ func (e *EndTxnResponse) decode(pd packetDecoder, version int16) (err error) {
 	}
 	e.ThrottleTime = time.Duration(throttleTime) * time.Millisecond
 
-	kerr, err := pd.getInt16()
+	e.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	e.Err = KError(kerr)
 
 	return nil
 }

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -74,11 +74,10 @@ func (b *FetchResponseBlock) decode(pd packetDecoder, version int16) (err error)
 		sizeMetric = getOrRegisterHistogram("consumer-fetch-response-size", metricRegistry)
 	}
 
-	tmp, err := pd.getInt16()
+	b.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	b.Err = KError(tmp)
 
 	b.HighWaterMarkOffset, err = pd.getInt64()
 	if err != nil {
@@ -217,7 +216,7 @@ func (b *FetchResponseBlock) isPartial() (bool, error) {
 }
 
 func (b *FetchResponseBlock) encode(pe packetEncoder, version int16) (err error) {
-	pe.putInt16(int16(b.Err))
+	pe.putKError(b.Err)
 
 	pe.putInt64(b.HighWaterMarkOffset)
 

--- a/find_coordinator_response.go
+++ b/find_coordinator_response.go
@@ -29,11 +29,10 @@ func (f *FindCoordinatorResponse) decode(pd packetDecoder, version int16) (err e
 		f.ThrottleTime = time.Duration(throttleTime) * time.Millisecond
 	}
 
-	tmp, err := pd.getInt16()
+	f.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	f.Err = KError(tmp)
 
 	if version >= 1 {
 		if f.ErrMsg, err = pd.getNullableString(); err != nil {
@@ -60,7 +59,7 @@ func (f *FindCoordinatorResponse) encode(pe packetEncoder) error {
 		pe.putInt32(int32(f.ThrottleTime / time.Millisecond))
 	}
 
-	pe.putInt16(int16(f.Err))
+	pe.putKError(f.Err)
 
 	if f.Version >= 1 {
 		if err := pe.putNullableString(f.ErrMsg); err != nil {

--- a/heartbeat_response.go
+++ b/heartbeat_response.go
@@ -16,7 +16,7 @@ func (r *HeartbeatResponse) encode(pe packetEncoder) error {
 	if r.Version >= 1 {
 		pe.putInt32(r.ThrottleTime)
 	}
-	pe.putInt16(int16(r.Err))
+	pe.putKError(r.Err)
 	return nil
 }
 
@@ -28,11 +28,10 @@ func (r *HeartbeatResponse) decode(pd packetDecoder, version int16) error {
 			return err
 		}
 	}
-	kerr, err := pd.getInt16()
+	r.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	r.Err = KError(kerr)
 
 	return nil
 }

--- a/init_producer_id_response.go
+++ b/init_producer_id_response.go
@@ -16,7 +16,7 @@ func (i *InitProducerIDResponse) setVersion(v int16) {
 
 func (i *InitProducerIDResponse) encode(pe packetEncoder) error {
 	pe.putInt32(int32(i.ThrottleTime / time.Millisecond))
-	pe.putInt16(int16(i.Err))
+	pe.putKError(i.Err)
 	pe.putInt64(i.ProducerID)
 	pe.putInt16(i.ProducerEpoch)
 	pe.putEmptyTaggedFieldArray()
@@ -31,11 +31,10 @@ func (i *InitProducerIDResponse) decode(pd packetDecoder, version int16) (err er
 	}
 	i.ThrottleTime = time.Duration(throttleTime) * time.Millisecond
 
-	kerr, err := pd.getInt16()
+	i.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	i.Err = KError(kerr)
 
 	if i.ProducerID, err = pd.getInt64(); err != nil {
 		return err

--- a/join_group_response.go
+++ b/join_group_response.go
@@ -52,7 +52,7 @@ func (r *JoinGroupResponse) encode(pe packetEncoder) error {
 	if r.Version >= 2 {
 		pe.putInt32(r.ThrottleTime)
 	}
-	pe.putInt16(int16(r.Err))
+	pe.putKError(r.Err)
 	pe.putInt32(r.GenerationId)
 
 	if err := pe.putString(r.GroupProtocol); err != nil {
@@ -95,12 +95,10 @@ func (r *JoinGroupResponse) decode(pd packetDecoder, version int16) (err error) 
 		}
 	}
 
-	kerr, err := pd.getInt16()
+	r.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-
-	r.Err = KError(kerr)
 
 	if r.GenerationId, err = pd.getInt32(); err != nil {
 		return

--- a/leave_group_response.go
+++ b/leave_group_response.go
@@ -22,7 +22,7 @@ func (r *LeaveGroupResponse) encode(pe packetEncoder) error {
 	if r.Version >= 1 {
 		pe.putInt32(r.ThrottleTime)
 	}
-	pe.putInt16(int16(r.Err))
+	pe.putKError(r.Err)
 	if r.Version >= 3 {
 		if err := pe.putArrayLength(len(r.Members)); err != nil {
 			return err
@@ -34,7 +34,7 @@ func (r *LeaveGroupResponse) encode(pe packetEncoder) error {
 			if err := pe.putNullableString(member.GroupInstanceId); err != nil {
 				return err
 			}
-			pe.putInt16(int16(member.Err))
+			pe.putKError(member.Err)
 		}
 	}
 	return nil
@@ -47,11 +47,10 @@ func (r *LeaveGroupResponse) decode(pd packetDecoder, version int16) (err error)
 			return err
 		}
 	}
-	kerr, err := pd.getInt16()
+	r.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	r.Err = KError(kerr)
 
 	if r.Version >= 3 {
 		membersLen, err := pd.getArrayLength()
@@ -66,10 +65,8 @@ func (r *LeaveGroupResponse) decode(pd packetDecoder, version int16) (err error)
 			if r.Members[i].GroupInstanceId, err = pd.getNullableString(); err != nil {
 				return err
 			}
-			if memberErr, err := pd.getInt16(); err != nil {
+			if r.Members[i].Err, err = pd.getKError(); err != nil {
 				return err
-			} else {
-				r.Members[i].Err = KError(memberErr)
 			}
 		}
 	}

--- a/list_groups_response.go
+++ b/list_groups_response.go
@@ -22,7 +22,7 @@ func (r *ListGroupsResponse) encode(pe packetEncoder) error {
 		pe.putInt32(r.ThrottleTime)
 	}
 
-	pe.putInt16(int16(r.Err))
+	pe.putKError(r.Err)
 
 	if err := pe.putArrayLength(len(r.Groups)); err != nil {
 		return err
@@ -54,21 +54,18 @@ func (r *ListGroupsResponse) encode(pe packetEncoder) error {
 	return nil
 }
 
-func (r *ListGroupsResponse) decode(pd packetDecoder, version int16) error {
+func (r *ListGroupsResponse) decode(pd packetDecoder, version int16) (err error) {
 	r.Version = version
 	if r.Version >= 1 {
-		var err error
 		if r.ThrottleTime, err = pd.getInt32(); err != nil {
 			return err
 		}
 	}
 
-	kerr, err := pd.getInt16()
+	r.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-
-	r.Err = KError(kerr)
 
 	n, err := pd.getArrayLength()
 	if err != nil {

--- a/list_partition_reassignments_response.go
+++ b/list_partition_reassignments_response.go
@@ -68,7 +68,7 @@ func (r *ListPartitionReassignmentsResponse) AddBlock(topic string, partition in
 
 func (r *ListPartitionReassignmentsResponse) encode(pe packetEncoder) error {
 	pe.putInt32(r.ThrottleTimeMs)
-	pe.putInt16(int16(r.ErrorCode))
+	pe.putKError(r.ErrorCode)
 	if err := pe.putNullableString(r.ErrorMessage); err != nil {
 		return err
 	}
@@ -105,12 +105,10 @@ func (r *ListPartitionReassignmentsResponse) decode(pd packetDecoder, version in
 		return err
 	}
 
-	kerr, err := pd.getInt16()
+	r.ErrorCode, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-
-	r.ErrorCode = KError(kerr)
 
 	if r.ErrorMessage, err = pd.getNullableString(); err != nil {
 		return err

--- a/metadata_response.go
+++ b/metadata_response.go
@@ -24,11 +24,10 @@ type PartitionMetadata struct {
 
 func (p *PartitionMetadata) decode(pd packetDecoder, version int16) (err error) {
 	p.Version = version
-	tmp, err := pd.getInt16()
+	p.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	p.Err = KError(tmp)
 
 	if p.ID, err = pd.getInt32(); err != nil {
 		return err
@@ -67,7 +66,7 @@ func (p *PartitionMetadata) decode(pd packetDecoder, version int16) (err error) 
 
 func (p *PartitionMetadata) encode(pe packetEncoder, version int16) (err error) {
 	p.Version = version
-	pe.putInt16(int16(p.Err))
+	pe.putKError(p.Err)
 
 	pe.putInt32(p.ID)
 
@@ -116,11 +115,10 @@ type TopicMetadata struct {
 
 func (t *TopicMetadata) decode(pd packetDecoder, version int16) (err error) {
 	t.Version = version
-	tmp, err := pd.getInt16()
+	t.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	t.Err = KError(tmp)
 
 	t.Name, err = pd.getString()
 	if err != nil {
@@ -171,7 +169,7 @@ func (t *TopicMetadata) decode(pd packetDecoder, version int16) (err error) {
 
 func (t *TopicMetadata) encode(pe packetEncoder, version int16) (err error) {
 	t.Version = version
-	pe.putInt16(int16(t.Err))
+	pe.putKError(t.Err)
 
 	err = pe.putString(t.Name)
 	if err != nil {

--- a/offset_commit_response.go
+++ b/offset_commit_response.go
@@ -40,7 +40,7 @@ func (r *OffsetCommitResponse) encode(pe packetEncoder) error {
 		}
 		for partition, kerror := range partitions {
 			pe.putInt32(partition)
-			pe.putInt16(int16(kerror))
+			pe.putKError(kerror)
 		}
 	}
 	return nil
@@ -81,11 +81,10 @@ func (r *OffsetCommitResponse) decode(pd packetDecoder, version int16) (err erro
 				return err
 			}
 
-			tmp, err := pd.getInt16()
+			r.Errors[name][id], err = pd.getKError()
 			if err != nil {
 				return err
 			}
-			r.Errors[name][id] = KError(tmp)
 		}
 	}
 

--- a/offset_fetch_response.go
+++ b/offset_fetch_response.go
@@ -29,11 +29,10 @@ func (b *OffsetFetchResponseBlock) decode(pd packetDecoder, version int16) (err 
 		return err
 	}
 
-	tmp, err := pd.getInt16()
+	b.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	b.Err = KError(tmp)
 
 	_, err = pd.getEmptyTaggedFieldArray()
 	return err
@@ -50,7 +49,7 @@ func (b *OffsetFetchResponseBlock) encode(pe packetEncoder, version int16) (err 
 		return err
 	}
 
-	pe.putInt16(int16(b.Err))
+	pe.putKError(b.Err)
 
 	pe.putEmptyTaggedFieldArray()
 	return nil
@@ -95,7 +94,7 @@ func (r *OffsetFetchResponse) encode(pe packetEncoder) (err error) {
 		pe.putEmptyTaggedFieldArray()
 	}
 	if r.Version >= 2 {
-		pe.putInt16(int16(r.Err))
+		pe.putKError(r.Err)
 	}
 	pe.putEmptyTaggedFieldArray()
 	return nil
@@ -155,11 +154,10 @@ func (r *OffsetFetchResponse) decode(pd packetDecoder, version int16) (err error
 	}
 
 	if version >= 2 {
-		kerr, err := pd.getInt16()
+		r.Err, err = pd.getKError()
 		if err != nil {
 			return err
 		}
-		r.Err = KError(kerr)
 	}
 
 	_, err = pd.getEmptyTaggedFieldArray()

--- a/offset_response.go
+++ b/offset_response.go
@@ -15,11 +15,10 @@ type OffsetResponseBlock struct {
 }
 
 func (b *OffsetResponseBlock) decode(pd packetDecoder, version int16) (err error) {
-	tmp, err := pd.getInt16()
+	b.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	b.Err = KError(tmp)
 
 	if version == 0 {
 		b.Offsets, err = pd.getInt64Array()
@@ -51,7 +50,7 @@ func (b *OffsetResponseBlock) decode(pd packetDecoder, version int16) (err error
 }
 
 func (b *OffsetResponseBlock) encode(pe packetEncoder, version int16) (err error) {
-	pe.putInt16(int16(b.Err))
+	pe.putKError(b.Err)
 
 	if version == 0 {
 		return pe.putInt64Array(b.Offsets)

--- a/packet_decoder.go
+++ b/packet_decoder.go
@@ -19,6 +19,7 @@ type packetDecoder interface {
 	getFloat64() (float64, error)
 	getArrayLength() (int, error)
 	getBool() (bool, error)
+	getKError() (KError, error)
 	getEmptyTaggedFieldArray() (int, error)
 	getTaggedFieldArray(taggedFieldDecoders) error
 

--- a/packet_encoder.go
+++ b/packet_encoder.go
@@ -16,6 +16,7 @@ type packetEncoder interface {
 	putFloat64(in float64)
 	putArrayLength(in int) error
 	putBool(in bool)
+	putKError(in KError)
 
 	// Collections
 	putBytes(in []byte) error

--- a/prep_encoder.go
+++ b/prep_encoder.go
@@ -62,6 +62,10 @@ func (pe *prepEncoder) putBool(in bool) {
 	pe.length++
 }
 
+func (pe *prepEncoder) putKError(in KError) {
+	pe.length += 2
+}
+
 // arrays
 
 func (pe *prepEncoder) putBytes(in []byte) error {

--- a/produce_response.go
+++ b/produce_response.go
@@ -29,11 +29,10 @@ type ProduceResponseBlock struct {
 }
 
 func (b *ProduceResponseBlock) decode(pd packetDecoder, version int16) (err error) {
-	tmp, err := pd.getInt16()
+	b.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-	b.Err = KError(tmp)
 
 	b.Offset, err = pd.getInt64()
 	if err != nil {
@@ -59,7 +58,7 @@ func (b *ProduceResponseBlock) decode(pd packetDecoder, version int16) (err erro
 }
 
 func (b *ProduceResponseBlock) encode(pe packetEncoder, version int16) (err error) {
-	pe.putInt16(int16(b.Err))
+	pe.putKError(b.Err)
 	pe.putInt64(b.Offset)
 
 	if version >= 2 {

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -138,6 +138,11 @@ func (rd *realDecoder) getBool() (bool, error) {
 	return true, nil
 }
 
+func (rd *realDecoder) getKError() (KError, error) {
+	i, err := rd.getInt16()
+	return KError(i), err
+}
+
 func (rd *realDecoder) getTaggedFieldArray(decoders taggedFieldDecoders) error {
 	return PacketDecodingError{"tagged fields used in non-flexible context"}
 }

--- a/real_encoder.go
+++ b/real_encoder.go
@@ -67,6 +67,10 @@ func (re *realEncoder) putBool(in bool) {
 	re.putInt8(0)
 }
 
+func (re *realEncoder) putKError(in KError) {
+	re.putInt16(int16(in))
+}
+
 // collection
 
 func (re *realEncoder) putRawBytes(in []byte) error {

--- a/sasl_authenticate_response.go
+++ b/sasl_authenticate_response.go
@@ -14,7 +14,7 @@ func (r *SaslAuthenticateResponse) setVersion(v int16) {
 }
 
 func (r *SaslAuthenticateResponse) encode(pe packetEncoder) error {
-	pe.putInt16(int16(r.Err))
+	pe.putKError(r.Err)
 	if err := pe.putNullableString(r.ErrorMessage); err != nil {
 		return err
 	}
@@ -27,14 +27,12 @@ func (r *SaslAuthenticateResponse) encode(pe packetEncoder) error {
 	return nil
 }
 
-func (r *SaslAuthenticateResponse) decode(pd packetDecoder, version int16) error {
+func (r *SaslAuthenticateResponse) decode(pd packetDecoder, version int16) (err error) {
 	r.Version = version
-	kerr, err := pd.getInt16()
+	r.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-
-	r.Err = KError(kerr)
 
 	if r.ErrorMessage, err = pd.getNullableString(); err != nil {
 		return err

--- a/sasl_handshake_response.go
+++ b/sasl_handshake_response.go
@@ -11,17 +11,15 @@ func (r *SaslHandshakeResponse) setVersion(v int16) {
 }
 
 func (r *SaslHandshakeResponse) encode(pe packetEncoder) error {
-	pe.putInt16(int16(r.Err))
+	pe.putKError(r.Err)
 	return pe.putStringArray(r.EnabledMechanisms)
 }
 
-func (r *SaslHandshakeResponse) decode(pd packetDecoder, version int16) error {
-	kerr, err := pd.getInt16()
+func (r *SaslHandshakeResponse) decode(pd packetDecoder, version int16) (err error) {
+	r.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-
-	r.Err = KError(kerr)
 
 	if r.EnabledMechanisms, err = pd.getStringArray(); err != nil {
 		return err

--- a/sync_group_response.go
+++ b/sync_group_response.go
@@ -29,7 +29,7 @@ func (r *SyncGroupResponse) encode(pe packetEncoder) error {
 	if r.Version >= 1 {
 		pe.putInt32(r.ThrottleTime)
 	}
-	pe.putInt16(int16(r.Err))
+	pe.putKError(r.Err)
 	return pe.putBytes(r.MemberAssignment)
 }
 
@@ -40,12 +40,10 @@ func (r *SyncGroupResponse) decode(pd packetDecoder, version int16) (err error) 
 			return err
 		}
 	}
-	kerr, err := pd.getInt16()
+	r.Err, err = pd.getKError()
 	if err != nil {
 		return err
 	}
-
-	r.Err = KError(kerr)
 
 	r.MemberAssignment, err = pd.getBytes()
 	return


### PR DESCRIPTION
Refactor to handle this common case more concisely.

For v2, it might be cleaner to handle the common pattern of ErrorCode followed by ErrorMessage in a more idiomatic go manner.
