### PR TITLE
chore(fvt): improve testFuncConsumerGroupMember

### DIFF
--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -172,8 +172,8 @@ func TestFuncTxnProduce(t *testing.T) {
 	defer consumer.Close()
 
 	pc, err := consumer.ConsumePartition("test.1", 0, OffsetNewest)
-	msgChannel := pc.Messages()
 	require.NoError(t, err)
+	msgChannel := pc.Messages()
 	defer pc.Close()
 
 	nonTransactionalProducer, err := NewAsyncProducer(FunctionalTestEnv.KafkaBrokerAddrs, NewFunctionalTestConfig())


### PR DESCRIPTION
- ensure ConsumeClaim returns when it should
- use require.EventuallyWithT
- add a bunch of t.Logf so it's clearer what state each consumer reaches

Contributes-to: #3310