### PR TITLE
fix: return correct error when encoding

### DIFF
--- a/join_group_request.go
+++ b/join_group_request.go
@@ -80,7 +80,7 @@ func (r *JoinGroupRequest) encode(pe packetEncoder) error {
 
 	if len(r.GroupProtocols) > 0 {
 		if len(r.OrderedGroupProtocols) > 0 {
-			return PacketDecodingError{"cannot specify both GroupProtocols and OrderedGroupProtocols on JoinGroupRequest"}
+			return PacketEncodingError{"cannot specify both GroupProtocols and OrderedGroupProtocols on JoinGroupRequest"}
 		}
 
 		if err := pe.putArrayLength(len(r.GroupProtocols)); err != nil {


### PR DESCRIPTION
The `encode` method failure should probably be an encoding error not decoding one.
