### PR TITLE
fix: close broken tcp connections

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -157,6 +157,27 @@ func NewBroker(addr string) *Broker {
 	return &Broker{id: -1, addr: addr}
 }
 
+func (b *Broker) getSockError() error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	if b.conn == nil {
+		return nil
+	}
+
+	conn := b.conn
+	if c, ok := conn.(*bufConn); ok {
+		conn = c.Conn
+	}
+	if c, ok := conn.(*tls.Conn); ok {
+		conn = c.NetConn()
+	}
+	if c, ok := conn.(*net.TCPConn); ok {
+		return getTCPConnSockError(c)
+	}
+	return nil
+}
+
 // Open tries to connect to the Broker if it is not already connected or connecting, but does not block
 // waiting for the connection to complete. This means that any subsequent operations on the broker will
 // block waiting for the connection to succeed or fail. To get the effect of a fully synchronous Open call,

--- a/broker.go
+++ b/broker.go
@@ -158,7 +158,10 @@ func NewBroker(addr string) *Broker {
 }
 
 func (b *Broker) getSockError() error {
-	b.lock.Lock()
+	// skip socket health checks while another operation owns broker state
+	if !b.lock.TryLock() {
+		return nil
+	}
 	defer b.lock.Unlock()
 
 	if b.conn == nil {
@@ -308,18 +311,12 @@ func (b *Broker) Open(conf *Config) error {
 		if conf.Net.SASL.Enable && !useSaslV0 {
 			b.connErr = b.authenticateViaSASLv1()
 			if b.connErr != nil {
-				close(b.responses)
-				<-b.done
-				b.responses = nil
-				b.done = nil
-				err = b.conn.Close()
+				err = b.closeLocked()
 				if err == nil {
 					DebugLogger.Printf("Closed connection to broker %s due to SASL v1 auth error: %s\n", b.addr, b.connErr)
 				} else {
 					Logger.Printf("Error while closing connection to broker %s (due to SASL v1 auth error: %s): %s\n", b.addr, b.connErr, err)
 				}
-				b.conn = nil
-				b.opened.Store(false)
 				return
 			}
 		}
@@ -398,11 +395,11 @@ func (b *Broker) closeLocked() error {
 	if b.responses != nil {
 		close(b.responses)
 	}
+	// close the socket before waiting so in-flight reads can exit
+	err := b.conn.Close()
 	if b.done != nil {
 		<-b.done
 	}
-
-	err := b.conn.Close()
 
 	b.conn = nil
 	b.responses = nil

--- a/broker_test.go
+++ b/broker_test.go
@@ -197,6 +197,52 @@ func TestBrokerFailedRequest(t *testing.T) {
 	}
 }
 
+func TestBrokerClose(t *testing.T) {
+	t.Run("interrupts active async response reads", func(t *testing.T) {
+		mockBroker := NewMockBroker(t, 0)
+		defer mockBroker.Close()
+
+		broker := NewBroker(mockBroker.Addr())
+		conf := NewTestConfig()
+		conf.ApiVersionsRequest = false
+		conf.Net.ReadTimeout = 30 * time.Second
+
+		require.NoError(t, broker.Open(conf))
+
+		request := ProduceRequest{}
+		request.RequiredAcks = WaitForLocal
+
+		responseErrs := make(chan error, 1)
+		err := broker.AsyncProduce(&request, func(_ *ProduceResponse, err error) {
+			responseErrs <- err
+		})
+		require.NoError(t, err)
+
+		closeErrs := make(chan error, 1)
+		go func() {
+			closeErrs <- broker.Close()
+		}()
+
+		select {
+		case err := <-closeErrs:
+			require.NoError(t, err)
+		case <-time.After(250 * time.Millisecond):
+			require.FailNow(t, "Close blocked with an active async response read")
+		}
+
+		select {
+		case err := <-responseErrs:
+			require.Error(t, err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "timed out waiting for the async produce callback")
+		}
+
+		connected, err := broker.Connected()
+		require.NoError(t, err)
+		require.False(t, connected)
+	})
+}
+
 // closeImmediatelyDialer is a test dialer that returns a net.Conn whose peer is
 // already closed. This reliably triggers a transport-level failure (e.g. EOF)
 // during ApiVersions negotiation in Broker.Open.

--- a/client.go
+++ b/client.go
@@ -684,9 +684,9 @@ func (client *client) randomizeSeedBrokers(addrs []string) {
 	}
 }
 
-func (client *client) checkSeedBrokersHealth(brokers []*Broker) []*Broker {
+func (client *client) checkSeedBrokersHealth(brokers []*Broker) {
 	if len(brokers) == 0 {
-		return nil
+		return
 	}
 
 	for _, broker := range brokers {
@@ -695,8 +695,6 @@ func (client *client) checkSeedBrokersHealth(brokers []*Broker) []*Broker {
 			safeAsyncClose(broker)
 		}
 	}
-
-	return brokers
 }
 
 func (client *client) checkBrokersHealth() {
@@ -708,8 +706,8 @@ func (client *client) checkBrokersHealth() {
 		}
 	}
 
-	client.seedBrokers = client.checkSeedBrokersHealth(client.seedBrokers)
-	client.deadSeeds = client.checkSeedBrokersHealth(client.deadSeeds)
+	client.checkSeedBrokersHealth(client.seedBrokers)
+	client.checkSeedBrokersHealth(client.deadSeeds)
 }
 
 func (client *client) updateBroker(brokers []*Broker) {

--- a/client.go
+++ b/client.go
@@ -689,18 +689,14 @@ func (client *client) checkSeedBrokersHealth(brokers []*Broker) []*Broker {
 		return nil
 	}
 
-	healthyBrokers := make([]*Broker, 0, len(brokers))
 	for _, broker := range brokers {
 		if err := broker.getSockError(); err != nil {
 			Logger.Printf("client/seedbrokers close seed broker #%d at %s due to socket error: %v", broker.ID(), broker.Addr(), err)
 			safeAsyncClose(broker)
-			continue
 		}
-
-		healthyBrokers = append(healthyBrokers, broker)
 	}
 
-	return healthyBrokers
+	return brokers
 }
 
 func (client *client) checkBrokersHealth() {

--- a/client_test.go
+++ b/client_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -744,6 +745,121 @@ func TestClientResurrectDeadSeeds(t *testing.T) {
 
 	seed2.Close()
 	safeClose(t, c)
+}
+
+func TestClientCheckBrokersHealth(t *testing.T) {
+	newConnectedBroker := func(t *testing.T) (*Broker, *net.TCPConn, func()) {
+		t.Helper()
+
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+
+		accepted := make(chan *net.TCPConn, 1)
+		acceptErr := make(chan error, 1)
+		go func() {
+			conn, err := listener.Accept()
+			if err != nil {
+				acceptErr <- err
+				return
+			}
+			accepted <- conn.(*net.TCPConn)
+		}()
+
+		conn, err := net.Dial("tcp", listener.Addr().String())
+		require.NoError(t, err)
+
+		var serverConn *net.TCPConn
+		select {
+		case serverConn = <-accepted:
+		case err := <-acceptErr:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "timed out waiting for test broker connection")
+		}
+
+		broker := NewBroker(listener.Addr().String())
+		broker.conn = conn.(*net.TCPConn)
+		broker.metricRegistry = metrics.NewRegistry()
+		broker.opened.Store(true)
+
+		cleanup := func() {
+			_ = listener.Close()
+			_ = serverConn.Close()
+			_ = broker.Close()
+		}
+
+		return broker, serverConn, cleanup
+	}
+
+	t.Run("does not wait for brokers that are opening", func(t *testing.T) {
+		broker := &Broker{id: 1, addr: "127.0.0.1:9092"}
+		broker.lock.Lock()
+		defer broker.lock.Unlock()
+
+		client := &client{
+			brokers: map[int32]*Broker{broker.ID(): broker},
+		}
+
+		done := make(chan struct{})
+		go func() {
+			client.checkBrokersHealth()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(100 * time.Millisecond):
+			require.FailNow(t, "checkBrokersHealth blocked on a broker that was still opening")
+		}
+	})
+
+	t.Run("keeps unhealthy live seed brokers available for reopening", func(t *testing.T) {
+		broker, serverConn, cleanup := newConnectedBroker(t)
+		defer cleanup()
+
+		client := &client{
+			brokers:     map[int32]*Broker{},
+			seedBrokers: []*Broker{broker},
+		}
+
+		require.NoError(t, serverConn.SetLinger(0))
+		require.NoError(t, serverConn.Close())
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			client.checkBrokersHealth()
+
+			assert.Len(c, client.seedBrokers, 1)
+			assert.Same(c, broker, client.seedBrokers[0])
+
+			connected, err := broker.Connected()
+			assert.NoError(c, err)
+			assert.False(c, connected)
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("keeps unhealthy dead seed brokers available for reopening", func(t *testing.T) {
+		broker, serverConn, cleanup := newConnectedBroker(t)
+		defer cleanup()
+
+		client := &client{
+			brokers:   map[int32]*Broker{},
+			deadSeeds: []*Broker{broker},
+		}
+
+		require.NoError(t, serverConn.SetLinger(0))
+		require.NoError(t, serverConn.Close())
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			client.checkBrokersHealth()
+
+			assert.Len(c, client.deadSeeds, 1)
+			assert.Same(c, broker, client.deadSeeds[0])
+
+			connected, err := broker.Connected()
+			assert.NoError(c, err)
+			assert.False(c, connected)
+		}, time.Second, 10*time.Millisecond)
+	})
 }
 
 //nolint:paralleltest

--- a/client_test.go
+++ b/client_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -17,6 +18,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func socketErrorProbeAvailable() bool {
+	switch runtime.GOOS {
+	case "aix", "darwin", "dragonfly", "freebsd", "linux", "netbsd", "openbsd", "solaris":
+		return true
+	default:
+		return false
+	}
+}
 
 func TestSimpleClient(t *testing.T) {
 	seedBroker := NewMockBroker(t, 1)
@@ -814,6 +824,10 @@ func TestClientCheckBrokersHealth(t *testing.T) {
 	})
 
 	t.Run("keeps unhealthy live seed brokers available for reopening", func(t *testing.T) {
+		if !socketErrorProbeAvailable() {
+			t.Skip("socket error probing is unavailable on this platform")
+		}
+
 		broker, serverConn, cleanup := newConnectedBroker(t)
 		defer cleanup()
 
@@ -838,6 +852,10 @@ func TestClientCheckBrokersHealth(t *testing.T) {
 	})
 
 	t.Run("keeps unhealthy dead seed brokers available for reopening", func(t *testing.T) {
+		if !socketErrorProbeAvailable() {
+			t.Skip("socket error probing is unavailable on this platform")
+		}
+
 		broker, serverConn, cleanup := newConnectedBroker(t)
 		defer cleanup()
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	golang.org/x/net v0.53.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,6 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/klauspost/compress v1.18.4 h1:RPhnKRAQ4Fh8zU2FY/6ZFDwTVTxgJ/EMydqSTzE9a2c=
-github.com/klauspost/compress v1.18.4/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -58,8 +56,6 @@ go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
-golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
 golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -69,8 +65,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
-golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
 golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -83,6 +77,8 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=

--- a/sockopt_other.go
+++ b/sockopt_other.go
@@ -1,0 +1,9 @@
+//go:build !unix || android || illumos || ios || hurd
+
+package sarama
+
+import "net"
+
+func getTCPConnSockError(_ *net.TCPConn) error {
+	return nil
+}

--- a/sockopt_posix.go
+++ b/sockopt_posix.go
@@ -1,0 +1,36 @@
+//go:build unix && !android && !illumos && !ios && !hurd
+
+// build on aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+
+package sarama
+
+import (
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func getTCPConnSockError(conn *net.TCPConn) error {
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("failed to get raw connection: %w", err)
+	}
+
+	var sockErr int
+	var opErr error
+
+	err = rawConn.Control(func(fd uintptr) {
+		sockErr, opErr = unix.GetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_ERROR)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to control raw connection: %w", err)
+	}
+	if opErr != nil {
+		return fmt.Errorf("failed to get socket error: %w", opErr)
+	}
+	if sockErr != 0 {
+		return unix.Errno(sockErr)
+	}
+	return nil
+}


### PR DESCRIPTION
Prevent TCP connection leaks that error occurred to kernel space's socket. Previously, when errors occurred on TCP sockets, connections would remain in TCP_CLOSE state indefinitely without being properly freed.

The leaked connections caused a cascade of kernel-level issues:
- TCP sockets remain in TCP_CLOSE state indefinitely
- Their sk_receive_queues retain FINACK skb packets
- These skbs hold pages allocated from page_pool
- page_pool_release_retry() stalls because pages cannot be freed while still referenced by the TCP stack

The fix ensures that TCP connections are properly closed when socket errors occur, preventing resource leaks at both the application and kernel levels.