### PR TITLE
feat(admin): add KIP-396 list/alter offsets APIs

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -115,6 +115,20 @@ type ClusterAdmin interface {
 	// List the consumer group offsets available in the cluster.
 	ListConsumerGroupOffsets(group string, topicPartitions map[string][]int32) (*OffsetFetchResponse, error)
 
+	// ListOffsets lists offsets for the specified topic partitions.
+	// Each value is OffsetNewest, OffsetOldest, or a timestamp in milliseconds.
+	// Results are keyed by topic/partition and include per-partition errors.
+	//
+	// For oldest/newest requests, Kafka may return a valid offset while timestamp is -1.
+	// To get the exact message timestamp, fetch the record at that offset.
+	// This operation is supported by brokers with version 0.10.1.0 or higher.
+	ListOffsets(partitions map[string]map[int32]int64, options *ListOffsetsOptions) (map[string]map[int32]*OffsetResult, error)
+
+	// AlterConsumerGroupOffsets alters offsets for the specified group by committing the provided offsets and metadata.
+	// The request targets the group's coordinator and returns per-partition results in the response.
+	// This operation is not transactional so it may succeed for some partitions while fail for others.
+	AlterConsumerGroupOffsets(group string, offsets map[string]map[int32]OffsetAndMetadata, options *AlterConsumerGroupOffsetsOptions) (*OffsetCommitResponse, error)
+
 	// Deletes a consumer group offset
 	DeleteConsumerGroupOffset(group string, topic string, partition int32) error
 
@@ -235,6 +249,17 @@ func isRetriableListTopicsError(err error) bool {
 }
 
 func isRetriableListTopicsTimeoutError(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
+// isRetriableBrokerError returns `true` if the given error is a retryable
+// transport error or a timeout.
+func isRetriableBrokerError(err error) bool {
+	return errors.Is(err, ErrNotConnected) || shouldCloseBrokerConn(err) || isTimeoutError(err)
+}
+
+func isTimeoutError(err error) bool {
 	var netErr net.Error
 	return errors.As(err, &netErr) && netErr.Timeout()
 }

--- a/admin.go
+++ b/admin.go
@@ -245,12 +245,7 @@ func isRetriableListTopicsError(err error) bool {
 		return true
 	}
 
-	return isRetriableListTopicsTimeoutError(err)
-}
-
-func isRetriableListTopicsTimeoutError(err error) bool {
-	var netErr net.Error
-	return errors.As(err, &netErr) && netErr.Timeout()
+	return isTimeoutError(err)
 }
 
 // isRetriableBrokerError returns `true` if the given error is a retryable
@@ -473,7 +468,7 @@ func (ca *clusterAdmin) ListTopics() (map[string]TopicDetail, error) {
 		metadataReq := NewMetadataRequest(ca.conf.Version, nil)
 		metadataResp, err := b.GetMetadata(metadataReq)
 		if err != nil {
-			if isRetriableListTopicsTimeoutError(err) {
+			if isTimeoutError(err) {
 				_ = b.Close()
 			}
 			return err
@@ -517,7 +512,7 @@ func (ca *clusterAdmin) ListTopics() (map[string]TopicDetail, error) {
 
 		describeConfigsResp, err := b.DescribeConfigs(describeConfigsReq)
 		if err != nil {
-			if isRetriableListTopicsTimeoutError(err) {
+			if isTimeoutError(err) {
 				_ = b.Close()
 			}
 			return err

--- a/admin_offsets.go
+++ b/admin_offsets.go
@@ -1,0 +1,182 @@
+package sarama
+
+import (
+	"errors"
+	"sync"
+)
+
+// ListOffsetsOptions configures how offsets are fetched.
+type ListOffsetsOptions struct {
+	IsolationLevel IsolationLevel
+}
+
+// OffsetResult contains the response for a single topic partition.
+type OffsetResult struct {
+	Offset      int64
+	Timestamp   int64
+	LeaderEpoch int32
+	Err         error
+}
+
+// OffsetAndMetadata describes the offset commit for a single partition.
+type OffsetAndMetadata struct {
+	Offset   int64
+	Metadata string
+	// LeaderEpoch contains the leader epoch of the last consumed record.
+	// It is used by the broker to fence stale commits after leader changes.
+	// Use the epoch returned by offset fetch/list APIs, or -1 to omit.
+	LeaderEpoch int32
+}
+
+// AlterConsumerGroupOffsetsOptions configures how offsets are committed.
+// It is currently empty and reserved for future Kafka protocol options.
+type AlterConsumerGroupOffsetsOptions struct{}
+
+func (ca *clusterAdmin) ListOffsets(partitions map[string]map[int32]int64, options *ListOffsetsOptions) (map[string]map[int32]*OffsetResult, error) {
+	type topicPartition struct {
+		topic     string
+		partition int32
+	}
+
+	type brokerOffsetRequest struct {
+		request    *OffsetRequest
+		partitions []topicPartition
+	}
+
+	type brokerOffsetResult struct {
+		result map[topicPartition]*OffsetResult
+		err    error
+	}
+
+	if len(partitions) == 0 {
+		return nil, ConfigurationError("no partitions provided")
+	}
+
+	if options == nil {
+		options = &ListOffsetsOptions{}
+	}
+
+	requests := make(map[*Broker]*brokerOffsetRequest)
+	for topic, topicOffsets := range partitions {
+		for partition, offsetQuery := range topicOffsets {
+			broker, _, err := ca.client.LeaderAndEpoch(topic, partition)
+			if err != nil {
+				return nil, err
+			}
+
+			req := requests[broker]
+			if req == nil {
+				req = &brokerOffsetRequest{
+					request: NewOffsetRequest(ca.conf.Version),
+				}
+				req.request.IsolationLevel = options.IsolationLevel
+				requests[broker] = req
+			}
+			req.request.AddBlock(topic, partition, offsetQuery, 1)
+			req.partitions = append(req.partitions, topicPartition{topic: topic, partition: partition})
+		}
+	}
+
+	results := make(chan brokerOffsetResult)
+	var wg sync.WaitGroup
+
+	for broker, req := range requests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			var resp *OffsetResponse
+			err := ca.retryOnError(isRetriableBrokerError, func() error {
+				var err error
+				_ = broker.Open(ca.client.Config())
+				resp, err = broker.GetAvailableOffsets(req.request)
+				return err
+			})
+			if err != nil {
+				results <- brokerOffsetResult{err: err}
+				return
+			}
+			broker.handleThrottledResponse(resp)
+
+			partitionResults := make(map[topicPartition]*OffsetResult, len(req.partitions))
+			for _, tp := range req.partitions {
+				block := resp.GetBlock(tp.topic, tp.partition)
+				if block == nil {
+					partitionResults[tp] = &OffsetResult{Err: ErrIncompleteResponse}
+					continue
+				}
+				partitionResults[tp] = &OffsetResult{
+					Offset:      block.Offset,
+					Timestamp:   block.Timestamp,
+					LeaderEpoch: block.LeaderEpoch,
+					Err:         block.Err,
+				}
+			}
+
+			results <- brokerOffsetResult{result: partitionResults}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	allResults := make(map[string]map[int32]*OffsetResult, len(partitions))
+	var errs []error
+	for res := range results {
+		if res.err != nil {
+			errs = append(errs, res.err)
+		}
+		for tp, info := range res.result {
+			if allResults[tp.topic] == nil {
+				allResults[tp.topic] = make(map[int32]*OffsetResult)
+			}
+			allResults[tp.topic][tp.partition] = info
+		}
+	}
+
+	return allResults, errors.Join(errs...)
+}
+
+func (ca *clusterAdmin) AlterConsumerGroupOffsets(group string, offsets map[string]map[int32]OffsetAndMetadata, _ *AlterConsumerGroupOffsetsOptions) (*OffsetCommitResponse, error) {
+	if len(offsets) == 0 {
+		return nil, ConfigurationError("no offsets provided")
+	}
+
+	var response *OffsetCommitResponse
+	request := NewOffsetCommitRequest(ca.conf, group)
+
+	var commitTimestamp int64
+	if request.Version == 1 {
+		commitTimestamp = ReceiveTime
+	}
+
+	for topic, topicOffsets := range offsets {
+		for partition, offset := range topicOffsets {
+			request.AddBlockWithLeaderEpoch(topic, partition, offset.Offset, offset.LeaderEpoch, commitTimestamp, offset.Metadata)
+		}
+	}
+
+	err := ca.retryOnError(isRetriableGroupCoordinatorError, func() (err error) {
+		defer func() {
+			if err != nil && isRetriableGroupCoordinatorError(err) {
+				_ = ca.client.RefreshCoordinator(group)
+			}
+		}()
+
+		coordinator, err := ca.client.Coordinator(group)
+		if err != nil {
+			return err
+		}
+
+		response, err = coordinator.CommitOffset(request)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return response, err
+}

--- a/admin_offsets.go
+++ b/admin_offsets.go
@@ -7,6 +7,8 @@ import (
 
 // ListOffsetsOptions configures how offsets are fetched.
 type ListOffsetsOptions struct {
+	// IsolationLevel selects between ReadUncommitted (default) and ReadCommitted
+	// when fetching the latest offset. Only honored by brokers running v0.11+.
 	IsolationLevel IsolationLevel
 }
 
@@ -29,9 +31,14 @@ type OffsetAndMetadata struct {
 }
 
 // AlterConsumerGroupOffsetsOptions configures how offsets are committed.
-// It is currently empty and reserved for future Kafka protocol options.
+// It is currently empty and reserved for future Kafka protocol options
 type AlterConsumerGroupOffsetsOptions struct{}
 
+// ListOffsets fans out across the partition leaders to fetch offsets in parallel.
+// Per-partition results may carry their own Err (e.g. NotLeaderForPartition,
+// UnknownTopicOrPartition) when metadata is stale; the caller can refresh
+// metadata via the underlying client and retry those partitions if needed. The
+// retry loop here only covers transport-level failures.
 func (ca *clusterAdmin) ListOffsets(partitions map[string]map[int32]int64, options *ListOffsetsOptions) (map[string]map[int32]*OffsetResult, error) {
 	type topicPartition struct {
 		topic     string
@@ -56,12 +63,21 @@ func (ca *clusterAdmin) ListOffsets(partitions map[string]map[int32]int64, optio
 		options = &ListOffsetsOptions{}
 	}
 
+	allResults := make(map[string]map[int32]*OffsetResult, len(partitions))
+	setResult := func(topic string, partition int32, result *OffsetResult) {
+		if allResults[topic] == nil {
+			allResults[topic] = make(map[int32]*OffsetResult)
+		}
+		allResults[topic][partition] = result
+	}
+
 	requests := make(map[*Broker]*brokerOffsetRequest)
 	for topic, topicOffsets := range partitions {
 		for partition, offsetQuery := range topicOffsets {
 			broker, _, err := ca.client.LeaderAndEpoch(topic, partition)
 			if err != nil {
-				return nil, err
+				setResult(topic, partition, &OffsetResult{Err: err})
+				continue
 			}
 
 			req := requests[broker]
@@ -77,7 +93,11 @@ func (ca *clusterAdmin) ListOffsets(partitions map[string]map[int32]int64, optio
 		}
 	}
 
-	results := make(chan brokerOffsetResult)
+	if len(requests) == 0 {
+		return allResults, nil
+	}
+
+	results := make(chan brokerOffsetResult, len(requests))
 	var wg sync.WaitGroup
 
 	for broker, req := range requests {
@@ -122,23 +142,24 @@ func (ca *clusterAdmin) ListOffsets(partitions map[string]map[int32]int64, optio
 		close(results)
 	}()
 
-	allResults := make(map[string]map[int32]*OffsetResult, len(partitions))
 	var errs []error
 	for res := range results {
 		if res.err != nil {
 			errs = append(errs, res.err)
 		}
 		for tp, info := range res.result {
-			if allResults[tp.topic] == nil {
-				allResults[tp.topic] = make(map[int32]*OffsetResult)
-			}
-			allResults[tp.topic][tp.partition] = info
+			setResult(tp.topic, tp.partition, info)
 		}
 	}
 
 	return allResults, errors.Join(errs...)
 }
 
+// AlterConsumerGroupOffsets retries on transport-level errors and on
+// per-partition coordinator errors (NOT_COORDINATOR,
+// COORDINATOR_NOT_AVAILABLE, EOF). Other per-partition errors
+// (e.g. UNKNOWN_TOPIC_OR_PARTITION) are returned to the caller in
+// OffsetCommitResponse.Errors without retry.
 func (ca *clusterAdmin) AlterConsumerGroupOffsets(group string, offsets map[string]map[int32]OffsetAndMetadata, _ *AlterConsumerGroupOffsetsOptions) (*OffsetCommitResponse, error) {
 	if len(offsets) == 0 {
 		return nil, ConfigurationError("no offsets provided")
@@ -173,6 +194,14 @@ func (ca *clusterAdmin) AlterConsumerGroupOffsets(group string, offsets map[stri
 		response, err = coordinator.CommitOffset(request)
 		if err != nil {
 			return err
+		}
+
+		for _, topicErrors := range response.Errors {
+			for _, partErr := range topicErrors {
+				if isRetriableGroupCoordinatorError(partErr) {
+					return partErr
+				}
+			}
 		}
 
 		return nil

--- a/admin_test.go
+++ b/admin_test.go
@@ -1791,6 +1791,91 @@ func TestListConsumerGroupOffsets(t *testing.T) {
 	}
 }
 
+func TestListOffsets(t *testing.T) {
+	seedBroker := NewMockBroker(t, 1)
+	defer seedBroker.Close()
+
+	topic := "my-topic"
+	partition := int32(0)
+	timestamp := int64(1690000000000)
+	expectedOffset := int64(42)
+
+	seedBroker.SetHandlerByMap(map[string]MockResponse{
+		"OffsetRequest": NewMockOffsetResponse(t).SetOffset(topic, partition, timestamp, expectedOffset),
+		"MetadataRequest": NewMockMetadataResponse(t).
+			SetController(seedBroker.BrokerID()).
+			SetBroker(seedBroker.Addr(), seedBroker.BrokerID()).
+			SetLeader(topic, partition, seedBroker.BrokerID()),
+	})
+
+	config := NewTestConfig()
+	config.Version = V2_1_0_0
+
+	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+
+	result, err := admin.ListOffsets(map[string]map[int32]int64{
+		topic: {partition: timestamp},
+	}, nil)
+	if err != nil {
+		t.Fatalf("ListOffsets failed with error %v", err)
+	}
+
+	info := result[topic][partition]
+	if info == nil {
+		t.Fatalf("Expected result for topic %v and partition %v to exist, but it doesn't", topic, partition)
+	}
+	if info.Err != ErrNoError {
+		t.Fatalf("Expected ErrNoError, got %v", info.Err)
+	}
+	if info.Offset != expectedOffset {
+		t.Fatalf("Expected offset %v, got %v", expectedOffset, info.Offset)
+	}
+}
+
+func TestAlterConsumerGroupOffsets(t *testing.T) {
+	seedBroker := NewMockBroker(t, 1)
+	defer seedBroker.Close()
+
+	group := "my-group"
+	topic := "my-topic"
+	partition := int32(0)
+
+	seedBroker.SetHandlerByMap(map[string]MockResponse{
+		"OffsetCommitRequest": NewMockOffsetCommitResponse(t).SetError(group, topic, partition, ErrNoError),
+		"MetadataRequest": NewMockMetadataResponse(t).
+			SetController(seedBroker.BrokerID()).
+			SetBroker(seedBroker.Addr(), seedBroker.BrokerID()),
+		"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).SetCoordinator(CoordinatorGroup, group, seedBroker),
+	})
+
+	config := NewTestConfig()
+	config.Version = V2_1_0_0
+
+	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer admin.Close()
+
+	response, err := admin.AlterConsumerGroupOffsets(group, map[string]map[int32]OffsetAndMetadata{
+		topic: {partition: {
+			Offset:      100,
+			LeaderEpoch: -1,
+		}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("AlterConsumerGroupOffsets failed with error %v", err)
+	}
+
+	if response.Errors[topic][partition] != ErrNoError {
+		t.Fatalf("Expected ErrNoError, got %v", response.Errors[topic][partition])
+	}
+}
+
 func TestDeleteConsumerGroup(t *testing.T) {
 	seedBroker := NewMockBroker(t, 1)
 	defer seedBroker.Close()

--- a/admin_test.go
+++ b/admin_test.go
@@ -6,8 +6,12 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClusterAdmin(t *testing.T) {
@@ -1791,89 +1795,204 @@ func TestListConsumerGroupOffsets(t *testing.T) {
 	}
 }
 
-func TestListOffsets(t *testing.T) {
-	seedBroker := NewMockBroker(t, 1)
-	defer seedBroker.Close()
+// newMockBroker spins up a MockBroker with auto-cleanup.
+func newMockBroker(t *testing.T, id int32) *MockBroker {
+	t.Helper()
+	b := NewMockBroker(t, id)
+	t.Cleanup(func() { b.Close() })
+	return b
+}
 
-	topic := "my-topic"
-	partition := int32(0)
-	timestamp := int64(1690000000000)
-	expectedOffset := int64(42)
-
-	seedBroker.SetHandlerByMap(map[string]MockResponse{
-		"OffsetRequest": NewMockOffsetResponse(t).SetOffset(topic, partition, timestamp, expectedOffset),
-		"MetadataRequest": NewMockMetadataResponse(t).
-			SetController(seedBroker.BrokerID()).
-			SetBroker(seedBroker.Addr(), seedBroker.BrokerID()).
-			SetLeader(topic, partition, seedBroker.BrokerID()),
-	})
-
+// newTestAdmin builds a V2.1 ClusterAdmin against the given seed broker with
+// retry backoff disabled and auto-cleanup.
+func newTestAdmin(t *testing.T, seed *MockBroker) ClusterAdmin {
+	t.Helper()
 	config := NewTestConfig()
 	config.Version = V2_1_0_0
+	config.Admin.Retry.Backoff = 0
+	admin, err := NewClusterAdmin([]string{seed.Addr()}, config)
+	require.NoError(t, err)
+	t.Cleanup(func() { admin.Close() })
+	return admin
+}
 
-	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
-	if err != nil {
-		t.Fatal(err)
+// mockMetadataFor builds a MockMetadataResponse with controller and brokers
+// populated. Callers chain .SetLeader as needed.
+func mockMetadataFor(t *testing.T, controller *MockBroker, brokers ...*MockBroker) *MockMetadataResponse {
+	t.Helper()
+	m := NewMockMetadataResponse(t).
+		SetController(controller.BrokerID()).
+		SetBroker(controller.Addr(), controller.BrokerID())
+	for _, b := range brokers {
+		m.SetBroker(b.Addr(), b.BrokerID())
 	}
-	defer admin.Close()
+	return m
+}
 
-	result, err := admin.ListOffsets(map[string]map[int32]int64{
-		topic: {partition: timestamp},
-	}, nil)
-	if err != nil {
-		t.Fatalf("ListOffsets failed with error %v", err)
-	}
+func TestListOffsets(t *testing.T) {
+	const topic = "my-topic"
 
-	info := result[topic][partition]
-	if info == nil {
-		t.Fatalf("Expected result for topic %v and partition %v to exist, but it doesn't", topic, partition)
-	}
-	if info.Err != ErrNoError {
-		t.Fatalf("Expected ErrNoError, got %v", info.Err)
-	}
-	if info.Offset != expectedOffset {
-		t.Fatalf("Expected offset %v, got %v", expectedOffset, info.Offset)
-	}
+	t.Run("returns offsets from a single broker", func(t *testing.T) {
+		const partition = int32(0)
+		const timestamp = int64(1690000000000)
+		const expectedOffset = int64(42)
+
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"OffsetRequest":   NewMockOffsetResponse(t).SetOffset(topic, partition, timestamp, expectedOffset),
+			"MetadataRequest": mockMetadataFor(t, broker).SetLeader(topic, partition, broker.BrokerID()),
+		})
+
+		result, err := newTestAdmin(t, broker).ListOffsets(map[string]map[int32]int64{
+			topic: {partition: timestamp},
+		}, nil)
+		require.NoError(t, err)
+
+		info := result[topic][partition]
+		require.NotNil(t, info)
+		assert.Equal(t, ErrNoError, info.Err)
+		assert.Equal(t, expectedOffset, info.Offset)
+	})
+
+	t.Run("fans out across partition leaders", func(t *testing.T) {
+		const offset1 = int64(100)
+		const offset2 = int64(200)
+
+		leader1 := newMockBroker(t, 1)
+		leader2 := newMockBroker(t, 2)
+		metadata := mockMetadataFor(t, leader1, leader2).
+			SetLeader(topic, 0, leader1.BrokerID()).
+			SetLeader(topic, 1, leader2.BrokerID())
+
+		leader1.SetHandlerByMap(map[string]MockResponse{
+			"MetadataRequest": metadata,
+			"OffsetRequest":   NewMockOffsetResponse(t).SetOffset(topic, 0, OffsetNewest, offset1),
+		})
+		leader2.SetHandlerByMap(map[string]MockResponse{
+			"MetadataRequest": metadata,
+			"OffsetRequest":   NewMockOffsetResponse(t).SetOffset(topic, 1, OffsetNewest, offset2),
+		})
+
+		result, err := newTestAdmin(t, leader1).ListOffsets(map[string]map[int32]int64{
+			topic: {0: OffsetNewest, 1: OffsetNewest},
+		}, nil)
+		require.NoError(t, err)
+		require.Contains(t, result, topic)
+		assert.Equal(t, offset1, result[topic][0].Offset)
+		assert.Equal(t, offset2, result[topic][1].Offset)
+	})
+
+	t.Run("propagates IsolationLevel to the broker request", func(t *testing.T) {
+		const partition = int32(0)
+
+		broker := newMockBroker(t, 1)
+		metadata := mockMetadataFor(t, broker).SetLeader(topic, partition, broker.BrokerID())
+		offsets := NewMockOffsetResponse(t).SetOffset(topic, partition, OffsetNewest, 42)
+
+		var captured atomic.Int32
+		captured.Store(-1)
+		broker.SetHandlerFuncByMap(map[string]requestHandlerFunc{
+			"MetadataRequest": func(r *request) encoderWithHeader { return metadata.For(r.body) },
+			"OffsetRequest": func(r *request) encoderWithHeader {
+				captured.Store(int32(r.body.(*OffsetRequest).IsolationLevel))
+				return offsets.For(r.body)
+			},
+		})
+
+		_, err := newTestAdmin(t, broker).ListOffsets(map[string]map[int32]int64{
+			topic: {partition: OffsetNewest},
+		}, &ListOffsetsOptions{IsolationLevel: ReadCommitted})
+		require.NoError(t, err)
+		assert.Equal(t, int32(ReadCommitted), captured.Load())
+	})
+
+	t.Run("returns ConfigurationError when no partitions provided", func(t *testing.T) {
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{"MetadataRequest": mockMetadataFor(t, broker)})
+
+		result, err := newTestAdmin(t, broker).ListOffsets(nil, nil)
+		assert.Nil(t, result)
+
+		var cfgErr ConfigurationError
+		require.ErrorAs(t, err, &cfgErr)
+	})
+
+	t.Run("records metadata-resolve failure as a per-partition error", func(t *testing.T) {
+		const knownPartition = int32(0)
+		const missingPartition = int32(1)
+		const expectedOffset = int64(7)
+
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"OffsetRequest":   NewMockOffsetResponse(t).SetOffset(topic, knownPartition, OffsetNewest, expectedOffset),
+			"MetadataRequest": mockMetadataFor(t, broker).SetLeader(topic, knownPartition, broker.BrokerID()),
+		})
+
+		result, err := newTestAdmin(t, broker).ListOffsets(map[string]map[int32]int64{
+			topic: {knownPartition: OffsetNewest, missingPartition: OffsetNewest},
+		}, nil)
+		require.NoError(t, err)
+
+		known := result[topic][knownPartition]
+		require.NotNil(t, known)
+		assert.Equal(t, ErrNoError, known.Err)
+		assert.Equal(t, expectedOffset, known.Offset)
+
+		missing := result[topic][missingPartition]
+		require.NotNil(t, missing)
+		assert.ErrorIs(t, missing.Err, ErrUnknownTopicOrPartition)
+	})
 }
 
 func TestAlterConsumerGroupOffsets(t *testing.T) {
-	seedBroker := NewMockBroker(t, 1)
-	defer seedBroker.Close()
+	const (
+		group     = "my-group"
+		topic     = "my-topic"
+		partition = int32(0)
+	)
+	offsets := map[string]map[int32]OffsetAndMetadata{
+		topic: {partition: {Offset: 100, LeaderEpoch: -1}},
+	}
 
-	group := "my-group"
-	topic := "my-topic"
-	partition := int32(0)
+	t.Run("commits offsets via the group coordinator", func(t *testing.T) {
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"OffsetCommitRequest":    NewMockOffsetCommitResponse(t).SetError(group, topic, partition, ErrNoError),
+			"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).SetCoordinator(CoordinatorGroup, group, broker),
+			"MetadataRequest":        mockMetadataFor(t, broker),
+		})
 
-	seedBroker.SetHandlerByMap(map[string]MockResponse{
-		"OffsetCommitRequest": NewMockOffsetCommitResponse(t).SetError(group, topic, partition, ErrNoError),
-		"MetadataRequest": NewMockMetadataResponse(t).
-			SetController(seedBroker.BrokerID()).
-			SetBroker(seedBroker.Addr(), seedBroker.BrokerID()),
-		"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).SetCoordinator(CoordinatorGroup, group, seedBroker),
+		response, err := newTestAdmin(t, broker).AlterConsumerGroupOffsets(group, offsets, nil)
+		require.NoError(t, err)
+		assert.Equal(t, ErrNoError, response.Errors[topic][partition])
 	})
 
-	config := NewTestConfig()
-	config.Version = V2_1_0_0
+	t.Run("returns ConfigurationError when no offsets provided", func(t *testing.T) {
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{"MetadataRequest": mockMetadataFor(t, broker)})
 
-	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer admin.Close()
+		response, err := newTestAdmin(t, broker).AlterConsumerGroupOffsets(group, nil, nil)
+		assert.Nil(t, response)
 
-	response, err := admin.AlterConsumerGroupOffsets(group, map[string]map[int32]OffsetAndMetadata{
-		topic: {partition: {
-			Offset:      100,
-			LeaderEpoch: -1,
-		}},
-	}, nil)
-	if err != nil {
-		t.Fatalf("AlterConsumerGroupOffsets failed with error %v", err)
-	}
+		var cfgErr ConfigurationError
+		require.ErrorAs(t, err, &cfgErr)
+	})
 
-	if response.Errors[topic][partition] != ErrNoError {
-		t.Fatalf("Expected ErrNoError, got %v", response.Errors[topic][partition])
-	}
+	t.Run("retries on per-partition NOT_COORDINATOR", func(t *testing.T) {
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"OffsetCommitRequest": NewMockSequence(
+				NewMockOffsetCommitResponse(t).SetError(group, topic, partition, ErrNotCoordinatorForConsumer),
+				NewMockOffsetCommitResponse(t).SetError(group, topic, partition, ErrNoError),
+			),
+			"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).SetCoordinator(CoordinatorGroup, group, broker),
+			"MetadataRequest":        mockMetadataFor(t, broker),
+		})
+
+		response, err := newTestAdmin(t, broker).AlterConsumerGroupOffsets(group, offsets, nil)
+		require.NoError(t, err)
+		assert.Equal(t, ErrNoError, response.Errors[topic][partition])
+	})
 }
 
 func TestDeleteConsumerGroup(t *testing.T) {

--- a/offset_commit_request.go
+++ b/offset_commit_request.go
@@ -76,6 +76,9 @@ func (r *OffsetCommitRequest) setVersion(v int16) {
 }
 
 // NewOffsetCommitRequest creates an OffsetCommitRequest initialized for admin use.
+//
+// The version-mapping logic mirrors offsetManager.constructRequest in
+// offset_manager.go; protocol bumps must be applied to both call sites.
 func NewOffsetCommitRequest(conf *Config, group string) *OffsetCommitRequest {
 	request := &OffsetCommitRequest{
 		ConsumerGroup:           group,


### PR DESCRIPTION
## Summary

- Add Admin APIs for KIP-396 `ListOffsets` and `AlterConsumerGroupOffsets` to support bulk offset queries and group offset commits.
- Provide Go types aligned with KIP-396 semantics (`OffsetAndMetadata`).

## Key changes

- Add `ListOffsets` and `AlterConsumerGroupOffsets` to `ClusterAdmin` and wire protocol requests.
- Add result structs with leader epoch support and commit metadata for admin offset commits.
- Implement broker fan-out for list offsets and coordinator commit path for alter offsets.
- Add functional tests covering timestamp list offsets and admin offset commits.

## Constraints / tradeoffs

- `ListOffsets` currently accepts `int64` queries (earliest/latest/timestamp) to stay consistent with existing offset conventions; we can introduce an explicit spec type in a follow-up if needed.

## Notes

- Spec reference: [KIP-396](https://cwiki.apache.org/confluence/display/KAFKA/KIP-396%3A+Add+Offset+Management+APIs+to+AdminClient)
- Closes [#1669](https://github.com/IBM/sarama/issues/1669)
