### PR TITLE
fix: add Unwrap() to DescribeConfigError and AlterConfigError

### DIFF
--- a/alter_configs_response.go
+++ b/alter_configs_response.go
@@ -29,6 +29,10 @@ func (c *AlterConfigError) Error() string {
 	return text
 }
 
+func (c *AlterConfigError) Unwrap() error {
+	return c.Err
+}
+
 // AlterConfigsResourceResponse is a response type for alter config resource
 type AlterConfigsResourceResponse struct {
 	ErrorCode int16

--- a/alter_configs_response_test.go
+++ b/alter_configs_response_test.go
@@ -3,6 +3,7 @@
 package sarama
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -44,4 +45,35 @@ func TestAlterConfigsResponse(t *testing.T) {
 		},
 	}
 	testResponse(t, "response with error", response, alterResponsePopulated)
+}
+
+func TestAlterConfigError(t *testing.T) {
+	// Assert that AlterConfigError satisfies error interface
+	var err error = &AlterConfigError{
+		Err: ErrInvalidConfig,
+	}
+
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("expected errors.Is to match ErrInvalidConfig")
+	}
+
+	got := err.Error()
+	want := ErrInvalidConfig.Error()
+	if got != want {
+		t.Errorf("AlterConfigError.Error() = %v; want %v", got, want)
+	}
+
+	err = &AlterConfigError{
+		Err:    ErrInvalidConfig,
+		ErrMsg: "invalid config value",
+	}
+	got = err.Error()
+	want = ErrInvalidConfig.Error() + " - invalid config value"
+	if got != want {
+		t.Errorf("AlterConfigError.Error() = %v; want %v", got, want)
+	}
+
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("expected errors.Is to match ErrInvalidConfig with ErrMsg set")
+	}
 }

--- a/describe_configs_response.go
+++ b/describe_configs_response.go
@@ -47,6 +47,10 @@ func (c *DescribeConfigError) Error() string {
 	return text
 }
 
+func (c *DescribeConfigError) Unwrap() error {
+	return c.Err
+}
+
 type DescribeConfigsResponse struct {
 	Version      int16
 	ThrottleTime time.Duration

--- a/describe_configs_response_test.go
+++ b/describe_configs_response_test.go
@@ -3,6 +3,7 @@
 package sarama
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -274,4 +275,35 @@ func TestDescribeConfigsResponseWithDefaultv1(t *testing.T) {
 		},
 	}
 	testResponse(t, "response with error", response, describeConfigsResponseWithDefaultv1)
+}
+
+func TestDescribeConfigError(t *testing.T) {
+	// Assert that DescribeConfigError satisfies error interface
+	var err error = &DescribeConfigError{
+		Err: ErrInvalidConfig,
+	}
+
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("expected errors.Is to match ErrInvalidConfig")
+	}
+
+	got := err.Error()
+	want := ErrInvalidConfig.Error()
+	if got != want {
+		t.Errorf("DescribeConfigError.Error() = %v; want %v", got, want)
+	}
+
+	err = &DescribeConfigError{
+		Err:    ErrInvalidConfig,
+		ErrMsg: "invalid config value",
+	}
+	got = err.Error()
+	want = ErrInvalidConfig.Error() + " - invalid config value"
+	if got != want {
+		t.Errorf("DescribeConfigError.Error() = %v; want %v", got, want)
+	}
+
+	if !errors.Is(err, ErrInvalidConfig) {
+		t.Errorf("expected errors.Is to match ErrInvalidConfig with ErrMsg set")
+	}
 }


### PR DESCRIPTION
## Summary
`TopicError` and `TopicPartitionError` implement `Unwrap()` returning their `KError` field, enabling `errors.Is`/`errors.As` to traverse the error chain. However, `DescribeConfigError` and `AlterConfigError` have the same structure (`Err KError` + `ErrMsg`) but were missing `Unwrap()`, making `errors.Is`/`errors.As` unable to match the underlying `KError`.

This adds the missing `Unwrap()` methods for consistency, allowing callers to use `errors.Is(err, sarama.ErrInvalidConfig)` instead of type-asserting to extract the error code.

## Changes
- Add `Unwrap() error` to `*DescribeConfigError` (`describe_configs_response.go`)
- Add `Unwrap() error` to `*AlterConfigError` (`alter_configs_response.go`)
- Add tests for both, following the existing `TestTopicError` pattern

## Test plan
- [x] `go test -run 'TestDescribeConfigError|TestAlterConfigError|TestTopicError'` — all pass
- [x] `go vet ./...` — clean