### PR TITLE
fix: stop dispatcher for dying children in brokerConsumer.abort()

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -1171,12 +1171,22 @@ func (bc *brokerConsumer) abort(err error) {
 	_ = bc.broker.Close() // we don't care about the error this might return, we already have one
 
 	for child := range bc.subscriptions {
-		child.notifyError(err)
+		select {
+		case <-child.dying:
+			child.stopDispatcher()
+		default:
+			child.notifyError(err)
+		}
 	}
 
 	for newSubscriptions := range bc.newSubscriptions {
 		for _, child := range newSubscriptions {
-			child.notifyError(err)
+			select {
+			case <-child.dying:
+				child.stopDispatcher()
+			default:
+				child.notifyError(err)
+			}
 		}
 	}
 }

--- a/consumer.go
+++ b/consumer.go
@@ -1177,12 +1177,22 @@ func (bc *brokerConsumer) abort(err error) {
 	_ = bc.broker.Close() // we don't care about the error this might return, we already have one
 
 	for child := range bc.subscriptions {
-		child.notifyError(err)
+		select {
+		case <-child.dying:
+			child.stopDispatcher()
+		default:
+			child.notifyError(err)
+		}
 	}
 
 	for newSubscriptions := range bc.newSubscriptions {
 		for _, child := range newSubscriptions {
-			child.notifyError(err)
+			select {
+			case <-child.dying:
+				child.stopDispatcher()
+			default:
+				child.notifyError(err)
+			}
 		}
 	}
 }

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -2328,6 +2328,34 @@ func TestConsumerAbortNoGoroutineLeak(t *testing.T) {
 		runAbort(t, newBrokerConsumer(child))
 	})
 
+	t.Run("stops dispatcher for dying child", func(t *testing.T) {
+		child := newChild(config.ChannelBufferSize)
+		child.consumer = &consumer{
+			client:          client,
+			conf:            config,
+			children:        make(map[string]map[int32]*partitionConsumer),
+			brokerConsumers: make(map[*Broker]*brokerConsumer),
+			metricRegistry:  newCleanupRegistry(config.MetricRegistry),
+		}
+
+		// Start the dispatcher goroutine (it will block on <-child.trigger).
+		go child.dispatcher()
+
+		// Mark the child as dying (simulates AsyncClose during rebalance).
+		close(child.dying)
+
+		bc := newBrokerConsumer(child)
+		runAbort(t, bc)
+
+		// The dispatcher should have exited via stopDispatcher, closing feeder.
+		select {
+		case _, ok := <-child.feeder:
+			require.False(t, ok, "feeder channel should be closed after dispatcher exits")
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "dispatcher did not exit after abort() on dying child")
+		}
+	})
+
 	t.Run("returns when redispatch is already pending", func(t *testing.T) {
 		child := newChild(config.ChannelBufferSize)
 		child.trigger <- none{}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -2253,6 +2253,34 @@ func TestConsumerAbortNoGoroutineLeak(t *testing.T) {
 		runAbort(t, newBrokerConsumer(child))
 	})
 
+	t.Run("stops dispatcher for dying child", func(t *testing.T) {
+		child := newChild(config.ChannelBufferSize)
+		child.consumer = &consumer{
+			client:          client,
+			conf:            config,
+			children:        make(map[string]map[int32]*partitionConsumer),
+			brokerConsumers: make(map[*Broker]*brokerConsumer),
+			metricRegistry:  newCleanupRegistry(config.MetricRegistry),
+		}
+
+		// Start the dispatcher goroutine (it will block on <-child.trigger).
+		go child.dispatcher()
+
+		// Mark the child as dying (simulates AsyncClose during rebalance).
+		close(child.dying)
+
+		bc := newBrokerConsumer(child)
+		runAbort(t, bc)
+
+		// The dispatcher should have exited via stopDispatcher, closing feeder.
+		select {
+		case _, ok := <-child.feeder:
+			require.False(t, ok, "feeder channel should be closed after dispatcher exits")
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "dispatcher did not exit after abort() on dying child")
+		}
+	})
+
 	t.Run("returns when redispatch is already pending", func(t *testing.T) {
 		child := newChild(config.ChannelBufferSize)
 		child.trigger <- none{}


### PR DESCRIPTION
## Summary

- Fix dispatcher livelock when `brokerConsumer.abort()` is called while partition consumers are dying (e.g. during rebalance)
- Call `stopDispatcher()` for dying children in `abort()`, matching the pattern used in every other subscription iteration (`subscriptionConsumer`, `updateSubscriptions`, `handleResponses`, `fetchNewMessages`)
- Add test verifying the dispatcher actually exits when abort runs on a dying child

Fixes #3491

## Test plan

- [x] `go test -race -run TestConsumerAbortNoGoroutineLeak -v -count=1` passes (all 5 subtests including new `stops_dispatcher_for_dying_child`)
- [x] `go vet ./...` clean
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)