### PR TITLE
fix: retry ListTopics on transient transport errors

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -224,6 +224,21 @@ func isRetriableGroupCoordinatorError(err error) bool {
 	return errors.Is(err, ErrNotCoordinatorForConsumer) || errors.Is(err, ErrConsumerCoordinatorNotAvailable) || errors.Is(err, io.EOF)
 }
 
+// isRetriableListTopicsError returns true for controller errors and transient
+// transport failures where reconnecting and retrying can succeed.
+func isRetriableListTopicsError(err error) bool {
+	if isRetriableControllerError(err) || shouldCloseBrokerConn(err) {
+		return true
+	}
+
+	return isRetriableListTopicsTimeoutError(err)
+}
+
+func isRetriableListTopicsTimeoutError(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
+}
+
 // retryOnError will repeatedly call the given (error-returning) func in the
 // case that its response is non-nil and retryable (as determined by the
 // provided retryable func) up to the maximum number of tries permitted by
@@ -420,76 +435,89 @@ func (ca *clusterAdmin) ListTopics() (map[string]TopicDetail, error) {
 	// DescribeConfigsRequest request. To avoid sending many requests to the
 	// broker, we use a single DescribeConfigsRequest.
 
-	// Send the all-topic MetadataRequest
-	b, err := ca.findAnyBroker()
-	if err != nil {
-		return nil, err
-	}
-	_ = b.Open(ca.client.Config())
+	var topicsDetailsMap map[string]TopicDetail
 
-	metadataReq := NewMetadataRequest(ca.conf.Version, nil)
-	metadataResp, err := b.GetMetadata(metadataReq)
-	if err != nil {
-		return nil, err
-	}
-
-	topicsDetailsMap := make(map[string]TopicDetail, len(metadataResp.Topics))
-
-	var describeConfigsResources []*ConfigResource
-
-	for _, topic := range metadataResp.Topics {
-		topicDetails := TopicDetail{
-			NumPartitions: int32(len(topic.Partitions)),
+	if err := ca.retryOnError(isRetriableListTopicsError, func() error {
+		// Send the all-topic MetadataRequest
+		b, err := ca.findAnyBroker()
+		if err != nil {
+			return err
 		}
-		if len(topic.Partitions) > 0 {
-			topicDetails.ReplicaAssignment = make(map[int32][]int32, len(topic.Partitions))
-			for _, partition := range topic.Partitions {
-				topicDetails.ReplicaAssignment[partition.ID] = partition.Replicas
+		_ = b.Open(ca.client.Config())
+
+		metadataReq := NewMetadataRequest(ca.conf.Version, nil)
+		metadataResp, err := b.GetMetadata(metadataReq)
+		if err != nil {
+			if isRetriableListTopicsTimeoutError(err) {
+				_ = b.Close()
 			}
-			topicDetails.ReplicationFactor = int16(len(topic.Partitions[0].Replicas))
+			return err
 		}
-		topicsDetailsMap[topic.Name] = topicDetails
 
-		// we populate the resources we want to describe from the MetadataResponse
-		topicResource := ConfigResource{
-			Type: TopicResource,
-			Name: topic.Name,
-		}
-		describeConfigsResources = append(describeConfigsResources, &topicResource)
-	}
+		currentTopicsDetailsMap := make(map[string]TopicDetail, len(metadataResp.Topics))
+		describeConfigsResources := make([]*ConfigResource, 0, len(metadataResp.Topics))
 
-	// Send the DescribeConfigsRequest
-	describeConfigsReq := &DescribeConfigsRequest{
-		Resources: describeConfigsResources,
-	}
-
-	if ca.conf.Version.IsAtLeast(V1_1_0_0) {
-		describeConfigsReq.Version = 1
-	}
-
-	if ca.conf.Version.IsAtLeast(V2_0_0_0) {
-		describeConfigsReq.Version = 2
-	}
-
-	describeConfigsResp, err := b.DescribeConfigs(describeConfigsReq)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, resource := range describeConfigsResp.Resources {
-		topicDetails := topicsDetailsMap[resource.Name]
-		topicDetails.ConfigEntries = make(map[string]*string)
-
-		for _, entry := range resource.Configs {
-			// only include non-default non-sensitive config
-			// (don't actually think topic config will ever be sensitive)
-			if entry.Default || entry.Sensitive {
-				continue
+		for _, topic := range metadataResp.Topics {
+			topicDetails := TopicDetail{
+				NumPartitions: int32(len(topic.Partitions)),
 			}
-			topicDetails.ConfigEntries[entry.Name] = &entry.Value
+			if len(topic.Partitions) > 0 {
+				topicDetails.ReplicaAssignment = make(map[int32][]int32, len(topic.Partitions))
+				for _, partition := range topic.Partitions {
+					topicDetails.ReplicaAssignment[partition.ID] = partition.Replicas
+				}
+				topicDetails.ReplicationFactor = int16(len(topic.Partitions[0].Replicas))
+			}
+			currentTopicsDetailsMap[topic.Name] = topicDetails
+
+			// we populate the resources we want to describe from the MetadataResponse
+			describeConfigsResources = append(describeConfigsResources, &ConfigResource{
+				Type: TopicResource,
+				Name: topic.Name,
+			})
 		}
 
-		topicsDetailsMap[resource.Name] = topicDetails
+		// Send the DescribeConfigsRequest
+		describeConfigsReq := &DescribeConfigsRequest{
+			Resources: describeConfigsResources,
+		}
+
+		if ca.conf.Version.IsAtLeast(V1_1_0_0) {
+			describeConfigsReq.Version = 1
+		}
+
+		if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+			describeConfigsReq.Version = 2
+		}
+
+		describeConfigsResp, err := b.DescribeConfigs(describeConfigsReq)
+		if err != nil {
+			if isRetriableListTopicsTimeoutError(err) {
+				_ = b.Close()
+			}
+			return err
+		}
+
+		for _, resource := range describeConfigsResp.Resources {
+			topicDetails := currentTopicsDetailsMap[resource.Name]
+			topicDetails.ConfigEntries = make(map[string]*string)
+
+			for _, entry := range resource.Configs {
+				// only include non-default non-sensitive config
+				// (don't actually think topic config will ever be sensitive)
+				if entry.Default || entry.Sensitive {
+					continue
+				}
+				topicDetails.ConfigEntries[entry.Name] = &entry.Value
+			}
+
+			currentTopicsDetailsMap[resource.Name] = topicDetails
+		}
+
+		topicsDetailsMap = currentTopicsDetailsMap
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return topicsDetailsMap, nil

--- a/admin_test.go
+++ b/admin_test.go
@@ -5,6 +5,7 @@ package sarama
 import (
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -167,20 +168,20 @@ func TestClusterAdminListTopics(t *testing.T) {
 	}
 
 	if len(entries) == 0 {
-		t.Fatal(errors.New("no resource present"))
+		t.Fatal("no resource present")
 	}
 
 	topic, found := entries["my_topic"]
 	if !found {
-		t.Fatal(errors.New("topic not found in response"))
+		t.Fatal("topic not found in response")
 	}
 	_, found = topic.ConfigEntries["max.message.bytes"]
 	if found {
-		t.Fatal(errors.New("default topic config entry incorrectly found in response"))
+		t.Fatal("default topic config entry incorrectly found in response")
 	}
 	value := topic.ConfigEntries["retention.ms"]
 	if value == nil || *value != "5000" {
-		t.Fatal(errors.New("non-default topic config entry not found in response"))
+		t.Fatal("non-default topic config entry not found in response")
 	}
 
 	err = admin.Close()
@@ -188,8 +189,154 @@ func TestClusterAdminListTopics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if topic.ReplicaAssignment == nil || topic.ReplicaAssignment[0][0] != 1 {
-		t.Fatal(errors.New("replica assignment not found in response"))
+	assignment, found := topic.ReplicaAssignment[0]
+	if !found {
+		t.Fatal("replica assignment for partition 0 not found in response")
+	}
+	if len(assignment) == 0 {
+		t.Fatal("replica assignment for partition 0 was empty")
+	}
+	if assignment[0] != 1 {
+		t.Fatal("replica assignment not found in response")
+	}
+}
+
+func TestClusterAdminListTopicsRetriesOnTransientConnectionError(t *testing.T) {
+	seedBroker := NewMockBroker(t, 1)
+	defer seedBroker.Close()
+
+	metadataResponse := NewMockMetadataResponse(t).
+		SetController(seedBroker.BrokerID()).
+		SetBroker(seedBroker.Addr(), seedBroker.BrokerID()).
+		SetLeader("my_topic", 0, seedBroker.BrokerID())
+
+	var stateMu sync.Mutex
+	var injectTimeout, injected bool
+	var metadataAttempts int
+
+	seedBroker.SetHandlerFuncByMap(map[string]requestHandlerFunc{
+		"MetadataRequest": func(req *request) encoderWithHeader {
+			stateMu.Lock()
+			metadataAttempts++
+			shouldInject := injectTimeout && !injected
+			if shouldInject {
+				injected = true
+			}
+			stateMu.Unlock()
+			if shouldInject {
+				return nil
+			}
+			return metadataResponse.For(req.body)
+		},
+		"DescribeConfigsRequest": func(req *request) encoderWithHeader {
+			return NewMockDescribeConfigsResponse(t).For(req.body)
+		},
+	})
+
+	config := NewTestConfig()
+	config.Version = V1_1_0_0
+	config.Net.ReadTimeout = 100 * time.Millisecond
+	config.Admin.Retry.Max = 3
+	config.Admin.Retry.Backoff = 10 * time.Millisecond
+
+	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer safeClose(t, admin)
+
+	stateMu.Lock()
+	injectTimeout = true
+	metadataAttemptsBeforeList := metadataAttempts
+	stateMu.Unlock()
+
+	entries, err := admin.ListTopics()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stateMu.Lock()
+	gotInjected := injected
+	gotMetadataAttempts := metadataAttempts
+	stateMu.Unlock()
+	if !gotInjected {
+		t.Fatal("expected metadata timeout to be injected during ListTopics")
+	}
+	if gotMetadataAttempts < metadataAttemptsBeforeList+2 {
+		t.Fatal("expected ListTopics to retry metadata after transient timeout")
+	}
+	if len(entries) == 0 {
+		t.Fatal("no resource present")
+	}
+}
+
+func TestClusterAdminListTopicsRetriesOnDescribeConfigsTimeout(t *testing.T) {
+	seedBroker := NewMockBroker(t, 1)
+	defer seedBroker.Close()
+
+	metadataResponse := NewMockMetadataResponse(t).
+		SetController(seedBroker.BrokerID()).
+		SetBroker(seedBroker.Addr(), seedBroker.BrokerID()).
+		SetLeader("my_topic", 0, seedBroker.BrokerID())
+
+	var stateMu sync.Mutex
+	var injectTimeout, injected bool
+	var describeConfigsAttempts int
+	describeConfigsResponse := NewMockDescribeConfigsResponse(t)
+
+	seedBroker.SetHandlerFuncByMap(map[string]requestHandlerFunc{
+		"MetadataRequest": func(req *request) encoderWithHeader {
+			return metadataResponse.For(req.body)
+		},
+		"DescribeConfigsRequest": func(req *request) encoderWithHeader {
+			stateMu.Lock()
+			describeConfigsAttempts++
+			shouldInject := injectTimeout && !injected
+			if shouldInject {
+				injected = true
+			}
+			stateMu.Unlock()
+			if shouldInject {
+				return nil
+			}
+			return describeConfigsResponse.For(req.body)
+		},
+	})
+
+	config := NewTestConfig()
+	config.Version = V1_1_0_0
+	config.Net.ReadTimeout = 100 * time.Millisecond
+	config.Admin.Retry.Max = 3
+	config.Admin.Retry.Backoff = 10 * time.Millisecond
+
+	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer safeClose(t, admin)
+
+	stateMu.Lock()
+	injectTimeout = true
+	describeConfigsAttemptsBeforeList := describeConfigsAttempts
+	stateMu.Unlock()
+
+	entries, err := admin.ListTopics()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stateMu.Lock()
+	gotInjected := injected
+	gotDescribeConfigsAttempts := describeConfigsAttempts
+	stateMu.Unlock()
+	if !gotInjected {
+		t.Fatal("expected DescribeConfigs timeout to be injected during ListTopics")
+	}
+	if gotDescribeConfigsAttempts < describeConfigsAttemptsBeforeList+2 {
+		t.Fatal("expected ListTopics to retry DescribeConfigs after transient timeout")
+	}
+	if len(entries) == 0 {
+		t.Fatal("no resource present")
 	}
 }
 


### PR DESCRIPTION
## Summary

`ClusterAdmin.ListTopics()` currently fails fast on transient connection failures (for example `EOF`, `broken pipe`, timeout) and does not retry like other admin paths.

This change adds retry behavior for `ListTopics` so temporary transport failures can recover automatically.

## Root Cause

`ListTopics` performs two sequential RPCs (`Metadata` then `DescribeConfigs`) but was not wrapped in `retryOnError`, so any transient network failure aborted the whole call immediately.

## Fix

- Wrap the full `ListTopics` flow in `retryOnError` (retry from the start).
- Add a retriable predicate for:
  - existing controller-retriable errors
  - transport-close errors
  - timeout network errors
- Add a regression test that forces one transient metadata request failure, then verifies `ListTopics` retries and succeeds.

## Why This Is Safe

- No behavior change on healthy paths.
- Scope is limited to `ListTopics`.
- Retrying the full flow keeps metadata/config data consistent per attempt.

## Testing

- `go test -run 'TestClusterAdminListTopics|TestClusterAdminListTopicsRetriesOnTransientConnectionError' -count=10 ./...`
- `go test -run TestClusterAdminListTopicsRetriesOnTransientConnectionError -count=20 ./...`
- `go test -run ClusterAdmin -count=1 ./...`

## Issue

Fixes #3125
