### PR TITLE
perf: cache topic batch-size metric lookup

### DIFF
--- a/produce_request.go
+++ b/produce_request.go
@@ -102,8 +102,10 @@ func (r *ProduceRequest) encode(pe packetEncoder) error {
 		}
 		topicRecordCount := int64(0)
 		var topicCompressionRatioMetric metrics.Histogram
+		var topicBatchSizeMetric metrics.Histogram
 		if metricRegistry != nil {
 			topicCompressionRatioMetric = getOrRegisterTopicHistogram("compression-ratio", topic, metricRegistry)
+			topicBatchSizeMetric = getOrRegisterTopicHistogram("batch-size", topic, metricRegistry)
 		}
 		for id, records := range partitions {
 			startOffset := pe.offset()
@@ -125,7 +127,7 @@ func (r *ProduceRequest) encode(pe packetEncoder) error {
 				}
 				batchSize := int64(pe.offset() - startOffset)
 				batchSizeMetric.Update(batchSize)
-				getOrRegisterTopicHistogram("batch-size", topic, metricRegistry).Update(batchSize)
+				topicBatchSizeMetric.Update(batchSize)
 			}
 		}
 		if topicRecordCount > 0 {

--- a/produce_request_test.go
+++ b/produce_request_test.go
@@ -109,3 +109,45 @@ func TestProduceRequest(t *testing.T) {
 	batch.compressedRecords = nil
 	testRequestDecode(t, "one record", request, packet)
 }
+
+func benchmarkProduceRequestEncodeMetrics(b *testing.B, partitions int) {
+	b.Helper()
+
+	produceReq := &ProduceRequest{
+		RequiredAcks: WaitForLocal,
+		Timeout:      1_000,
+	}
+	for partition := range partitions {
+		produceReq.AddMessage("bench.topic", int32(partition), &Message{
+			Codec: CompressionNone,
+			Value: []byte("payload"),
+		})
+	}
+
+	req := &request{
+		correlationID: 1,
+		clientID:      "bench",
+		body:          produceReq,
+	}
+	metricRegistry := NewConfig().MetricRegistry
+
+	b.ReportAllocs()
+
+	for b.Loop() {
+		if _, err := encode(req, metricRegistry); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkProduceRequestEncodeMetrics1Partition(b *testing.B) {
+	benchmarkProduceRequestEncodeMetrics(b, 1)
+}
+
+func BenchmarkProduceRequestEncodeMetrics32Partitions(b *testing.B) {
+	benchmarkProduceRequestEncodeMetrics(b, 32)
+}
+
+func BenchmarkProduceRequestEncodeMetrics128Partitions(b *testing.B) {
+	benchmarkProduceRequestEncodeMetrics(b, 128)
+}


### PR DESCRIPTION
# Overview

Optimize `ProduceRequest.encode` by caching the topic-level `batch-size` histogram once per topic, instead of looking it up for every partition.

# Changes

- Cache `topicBatchSizeMetric` once per topic in `ProduceRequest.encode`.
- Reuse cached metric in the partition loop.
- Add focused benchmarks:
  - `BenchmarkProduceRequestEncodeMetrics1Partition`
  - `BenchmarkProduceRequestEncodeMetrics32Partitions`
  - `BenchmarkProduceRequestEncodeMetrics128Partitions`

## Benchmark
```text
goos: darwin
goarch: arm64
cpu: Apple M1

name                                        old ns/op   new ns/op   delta
ProduceRequestEncodeMetrics1Partition       1977        2040        +3.2%
ProduceRequestEncodeMetrics32Partitions     26250       24600       -6.3%
ProduceRequestEncodeMetrics128Partitions    100070      92300       -7.8%
```

# Testing

- `go test -run 'TestProduceRequest|TestAllocateBodyProtocolVersions' .`
- `go test -run '^$' -bench 'BenchmarkProduceRequestEncodeMetrics(1Partition|32Partitions|128Partitions)$' -benchmem -count=8 .`