### PR TITLE
perf(zstd): scale idle zstd encoder cap to GOMAXPROCS

### DIFF
--- a/zstd.go
+++ b/zstd.go
@@ -6,10 +6,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-// zstdMaxBufferedEncoders maximum number of not-in-use zstd encoders
-// If the pool of encoders is exhausted then new encoders will be created on the fly
-const zstdMaxBufferedEncoders = 1
-
 type ZstdEncoderParams struct {
 	Level int
 }
@@ -20,35 +16,35 @@ var zstdDecMap sync.Map
 
 var zstdAvailableEncoders sync.Map
 
-func getZstdEncoderChannel(params ZstdEncoderParams) chan *zstd.Encoder {
+func getZstdEncoderPool(params ZstdEncoderParams) *sync.Pool {
 	if c, ok := zstdAvailableEncoders.Load(params); ok {
-		return c.(chan *zstd.Encoder)
+		return c.(*sync.Pool)
 	}
-	c, _ := zstdAvailableEncoders.LoadOrStore(params, make(chan *zstd.Encoder, zstdMaxBufferedEncoders))
-	return c.(chan *zstd.Encoder)
+
+	encoderLevel := zstd.SpeedDefault
+	if params.Level != CompressionLevelDefault {
+		encoderLevel = zstd.EncoderLevelFromZstd(params.Level)
+	}
+
+	pool := &sync.Pool{
+		New: func() any {
+			enc, _ := zstd.NewWriter(nil, zstd.WithZeroFrames(true),
+				zstd.WithEncoderLevel(encoderLevel),
+				zstd.WithEncoderConcurrency(1))
+			return enc
+		},
+	}
+
+	c, _ := zstdAvailableEncoders.LoadOrStore(params, pool)
+	return c.(*sync.Pool)
 }
 
 func getZstdEncoder(params ZstdEncoderParams) *zstd.Encoder {
-	select {
-	case enc := <-getZstdEncoderChannel(params):
-		return enc
-	default:
-		encoderLevel := zstd.SpeedDefault
-		if params.Level != CompressionLevelDefault {
-			encoderLevel = zstd.EncoderLevelFromZstd(params.Level)
-		}
-		zstdEnc, _ := zstd.NewWriter(nil, zstd.WithZeroFrames(true),
-			zstd.WithEncoderLevel(encoderLevel),
-			zstd.WithEncoderConcurrency(1))
-		return zstdEnc
-	}
+	return getZstdEncoderPool(params).Get().(*zstd.Encoder)
 }
 
 func releaseEncoder(params ZstdEncoderParams, enc *zstd.Encoder) {
-	select {
-	case getZstdEncoderChannel(params) <- enc:
-	default:
-	}
+	getZstdEncoderPool(params).Put(enc)
 }
 
 func getDecoder(params ZstdDecoderParams) *zstd.Decoder {

--- a/zstd.go
+++ b/zstd.go
@@ -1,10 +1,24 @@
 package sarama
 
 import (
+	"runtime"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
 )
+
+// ZstdMaxBufferedEncoders bounds the number of idle zstd encoders Sarama
+// retains per ZstdEncoderParams. The previous bound of 1 forced any
+// concurrent caller after the first to allocate (and discard) a fresh
+// encoder per batch; defaulting to runtime.GOMAXPROCS lets steady-state
+// per-CPU concurrency reuse encoders while still bounding per-level memory
+// on high-core hosts. Each retained encoder is constructed with
+// WithEncoderConcurrency(1) to keep its own memory footprint small.
+//
+// The value is read on first use of each ZstdEncoderParams; changes after
+// that point only affect compression levels not yet seen. To override the
+// default, set this variable before any zstd compression takes place.
+var ZstdMaxBufferedEncoders = max(runtime.GOMAXPROCS(0), 1)
 
 type ZstdEncoderParams struct {
 	Level int
@@ -14,37 +28,64 @@ type ZstdDecoderParams struct {
 
 var zstdDecMap sync.Map
 
-var zstdAvailableEncoders sync.Map
+var (
+	zstdAvailableEncoders sync.Map
+	zstdEncoderInitMu     sync.Mutex
+)
 
-func getZstdEncoderPool(params ZstdEncoderParams) *sync.Pool {
+// getZstdEncoderChannel returns the buffered channel that retains idle zstd
+// encoders for the given params. The slow path holds a single global mutex
+// and re-checks the sync.Map under the lock so that a stampede of goroutines
+// arriving for the same not-yet-seen ZstdEncoderParams cannot create
+// multiple competing channels.
+func getZstdEncoderChannel(params ZstdEncoderParams) chan *zstd.Encoder {
 	if c, ok := zstdAvailableEncoders.Load(params); ok {
-		return c.(*sync.Pool)
+		return c.(chan *zstd.Encoder)
 	}
 
+	zstdEncoderInitMu.Lock()
+	defer zstdEncoderInitMu.Unlock()
+
+	if c, ok := zstdAvailableEncoders.Load(params); ok {
+		return c.(chan *zstd.Encoder)
+	}
+
+	size := ZstdMaxBufferedEncoders
+	if size < 1 {
+		size = 1
+	}
+	ch := make(chan *zstd.Encoder, size)
+	zstdAvailableEncoders.Store(params, ch)
+	return ch
+}
+
+func newZstdEncoder(params ZstdEncoderParams) *zstd.Encoder {
 	encoderLevel := zstd.SpeedDefault
 	if params.Level != CompressionLevelDefault {
 		encoderLevel = zstd.EncoderLevelFromZstd(params.Level)
 	}
-
-	pool := &sync.Pool{
-		New: func() any {
-			enc, _ := zstd.NewWriter(nil, zstd.WithZeroFrames(true),
-				zstd.WithEncoderLevel(encoderLevel),
-				zstd.WithEncoderConcurrency(1))
-			return enc
-		},
-	}
-
-	c, _ := zstdAvailableEncoders.LoadOrStore(params, pool)
-	return c.(*sync.Pool)
+	enc, _ := zstd.NewWriter(nil,
+		zstd.WithZeroFrames(true),
+		zstd.WithEncoderLevel(encoderLevel),
+		zstd.WithEncoderConcurrency(1))
+	return enc
 }
 
 func getZstdEncoder(params ZstdEncoderParams) *zstd.Encoder {
-	return getZstdEncoderPool(params).Get().(*zstd.Encoder)
+	select {
+	case enc := <-getZstdEncoderChannel(params):
+		return enc
+	default:
+		return newZstdEncoder(params)
+	}
 }
 
 func releaseEncoder(params ZstdEncoderParams, enc *zstd.Encoder) {
-	getZstdEncoderPool(params).Put(enc)
+	select {
+	case getZstdEncoderChannel(params) <- enc:
+	default:
+		// pool is at capacity; let the encoder be garbage collected.
+	}
 }
 
 func getDecoder(params ZstdDecoderParams) *zstd.Decoder {

--- a/zstd.go
+++ b/zstd.go
@@ -7,19 +7,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 )
 
-// ZstdMaxBufferedEncoders bounds the number of idle zstd encoders Sarama
-// retains per ZstdEncoderParams. The previous bound of 1 forced any
-// concurrent caller after the first to allocate (and discard) a fresh
-// encoder per batch; defaulting to runtime.GOMAXPROCS lets steady-state
-// per-CPU concurrency reuse encoders while still bounding per-level memory
-// on high-core hosts. Each retained encoder is constructed with
-// WithEncoderConcurrency(1) to keep its own memory footprint small.
-//
-// The value is read on first use of each ZstdEncoderParams; changes after
-// that point only affect compression levels not yet seen. To override the
-// default, set this variable before any zstd compression takes place.
-var ZstdMaxBufferedEncoders = max(runtime.GOMAXPROCS(0), 1)
-
 type ZstdEncoderParams struct {
 	Level int
 }
@@ -37,7 +24,9 @@ var (
 // encoders for the given params. The slow path holds a single global mutex
 // and re-checks the sync.Map under the lock so that a stampede of goroutines
 // arriving for the same not-yet-seen ZstdEncoderParams cannot create
-// multiple competing channels.
+// multiple competing channels. The channel is sized to GOMAXPROCS so that
+// the previous size-1 cap can no longer force concurrent callers to
+// allocate a fresh encoder per batch.
 func getZstdEncoderChannel(params ZstdEncoderParams) chan *zstd.Encoder {
 	if c, ok := zstdAvailableEncoders.Load(params); ok {
 		return c.(chan *zstd.Encoder)
@@ -50,11 +39,7 @@ func getZstdEncoderChannel(params ZstdEncoderParams) chan *zstd.Encoder {
 		return c.(chan *zstd.Encoder)
 	}
 
-	size := ZstdMaxBufferedEncoders
-	if size < 1 {
-		size = 1
-	}
-	ch := make(chan *zstd.Encoder, size)
+	ch := make(chan *zstd.Encoder, max(runtime.GOMAXPROCS(0), 1))
 	zstdAvailableEncoders.Store(params, ch)
 	return ch
 }

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -16,16 +16,39 @@ func BenchmarkZstdMemoryConsumption(b *testing.B) {
 
 	cpus := 96
 
-	gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
-	b.ReportAllocs()
-	for b.Loop() {
-		for j := 0; j < 2*cpus; j++ {
+	b.Run("no_drain", func(b *testing.B) {
+		b.ReportAllocs()
+
+		gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
+		for b.Loop() {
 			_, _ = zstdCompress(params, nil, buf)
 		}
-		// drain the buffered encoder
-		getZstdEncoder(params)
-		// previously this would be achieved with
-		// zstdEncMap.Delete(params)
-	}
-	runtime.GOMAXPROCS(gomaxprocsBackup)
+		runtime.GOMAXPROCS(gomaxprocsBackup)
+	})
+
+	// Drops the buffered encoder so we can measure cold-start allocation
+	b.Run("with_drain", func(b *testing.B) {
+		b.ReportAllocs()
+
+		gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
+		for b.Loop() {
+			_, _ = zstdCompress(params, nil, buf)
+			_ = getZstdEncoder(params)
+		}
+		runtime.GOMAXPROCS(gomaxprocsBackup)
+
+	})
+
+	// Concurrent encodes, which historically would allocate excessively
+	b.Run("concurrent", func(b *testing.B) {
+		b.ReportAllocs()
+
+		gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_, _ = zstdCompress(params, nil, buf)
+			}
+		})
+		runtime.GOMAXPROCS(gomaxprocsBackup)
+	})
 }

--- a/zstd_test.go
+++ b/zstd_test.go
@@ -3,7 +3,6 @@
 package sarama
 
 import (
-	"runtime"
 	"testing"
 )
 
@@ -14,41 +13,33 @@ func BenchmarkZstdMemoryConsumption(b *testing.B) {
 		buf[i] = byte((i / 256) + (i * 257))
 	}
 
-	cpus := 96
-
 	b.Run("no_drain", func(b *testing.B) {
 		b.ReportAllocs()
-
-		gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
 		for b.Loop() {
 			_, _ = zstdCompress(params, nil, buf)
 		}
-		runtime.GOMAXPROCS(gomaxprocsBackup)
 	})
 
-	// Drops the buffered encoder so we can measure cold-start allocation
+	// Drops the buffered encoder so we can measure cold-start allocation.
 	b.Run("with_drain", func(b *testing.B) {
 		b.ReportAllocs()
-
-		gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
 		for b.Loop() {
 			_, _ = zstdCompress(params, nil, buf)
 			_ = getZstdEncoder(params)
 		}
-		runtime.GOMAXPROCS(gomaxprocsBackup)
-
 	})
 
-	// Concurrent encodes, which historically would allocate excessively
+	// Concurrent encodes, which historically allocated a fresh encoder per
+	// batch for every concurrent caller beyond the first. RunParallel uses
+	// GOMAXPROCS goroutines by default; SetParallelism scales that ratio for
+	// hosts where exercising more concurrency than CPUs is interesting.
 	b.Run("concurrent", func(b *testing.B) {
 		b.ReportAllocs()
-
-		gomaxprocsBackup := runtime.GOMAXPROCS(cpus)
+		b.SetParallelism(2)
 		b.RunParallel(func(pb *testing.PB) {
 			for pb.Next() {
 				_, _ = zstdCompress(params, nil, buf)
 			}
 		})
-		runtime.GOMAXPROCS(gomaxprocsBackup)
 	})
 }


### PR DESCRIPTION
## Summary

Raise the per-`CompressionLevel` encoder cache size from 1 to GOMAXPROCS, and lazy-init each channel under a mutex. Under concurrent producer load this eliminates a hot path where any goroutine that arrived while the one cached encoder was checked out would allocate (and immediately discard) a fresh encoder on every batch.

## Motivation

`getZstdEncoder` previously read from a buffered channel of capacity 1 (`zstdMaxBufferedEncoders = 1`) per `ZstdEncoderParams`. When two or more goroutines compressed at the same level concurrently, the channel was empty for the second arrival, the `default` branch fired, and a new `zstd.Writer` was constructed for every batch. Encoder construction is non-trivial (it allocates internal buffers and starts goroutines for parallel encoding), so under steady contention the cache effectively did nothing for all but the first goroutine in flight.

Sizing the channel to GOMAXPROCS lets steady-state per-CPU concurrency reuse encoders, while still bounding per-level memory on high-core hosts. Each retained encoder is constructed with `WithEncoderConcurrency(1)` (unchanged) so its own footprint stays small.

## Changes

- `zstd.go`: raise the `chan *zstd.Encoder` capacity to `max(runtime.GOMAXPROCS(0), 1)`, and serialize lazy channel creation behind a mutex with a double-checked `sync.Map` load so a stampede of goroutines cannot create multiple competing channels for the same params.
- `zstd_test.go`: update existing benchmarks and add a `RunParallel` benchmark to demonstrate the contention case the size-1 cache could not handle.

Public API and wire format are unchanged.

## Test plan

- [x] `go test ./...` passes
- [x] Existing zstd round-trip tests pass
- [x] `go test -race -run TestZstd ./...` passes
- [ ] Reviewers: please run benchmarks locally to confirm the parallel case improves on your hardware: `go test -run=^$ -bench=BenchmarkZstd -benchmem ./...`

## DCO
Co-author has authorized me (committer) to sign off on their behalf; the work is Honeycomb-copyrighted.