### PR TITLE
fix: Make InitialOffset available also in PartitionConsumer

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -116,6 +116,7 @@ func NewConsumer(addrs []string, config *Config) (Consumer, error) {
 	}
 	c, err := newConsumer(client)
 	if err != nil {
+		// Return nil rather than a Consumer interface with a nil value
 		return nil, err
 	}
 
@@ -130,6 +131,7 @@ func NewConsumerFromClient(client Client) (Consumer, error) {
 	cli := &nopCloserClient{client}
 	c, err := newConsumer(cli)
 	if err != nil {
+		// Return nil rather than a Consumer interface with a nil value
 		return nil, err
 	}
 
@@ -169,12 +171,14 @@ func (c *consumer) Partitions(topic string) ([]int32, error) {
 func (c *consumer) ConsumePartition(topic string, partition int32, offset int64) (PartitionConsumer, error) {
 	pc, err := c.consumePartition(topic, partition, offset)
 	if err != nil {
+		// Return nil rather than a PartitionConsumer interface with a nil value
 		return nil, err
 	}
 
 	return pc, nil
 }
 
+// consumePartition returns the concrete partitionConsumer struct used internally in the ConsumerGroup implementation
 func (c *consumer) consumePartition(topic string, partition int32, offset int64) (*partitionConsumer, error) {
 	child := &partitionConsumer{
 		consumer:             c,

--- a/consumer.go
+++ b/consumer.go
@@ -114,7 +114,12 @@ func NewConsumer(addrs []string, config *Config) (Consumer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newConsumer(client)
+	c, err := newConsumer(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
 // NewConsumerFromClient creates a new consumer using the given client. It is still
@@ -123,10 +128,15 @@ func NewConsumerFromClient(client Client) (Consumer, error) {
 	// For clients passed in by the client, ensure we don't
 	// call Close() on it.
 	cli := &nopCloserClient{client}
-	return newConsumer(cli)
+	c, err := newConsumer(cli)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
-func newConsumer(client Client) (Consumer, error) {
+func newConsumer(client Client) (*consumer, error) {
 	// Check that we are not dealing with a closed Client before processing any other arguments
 	if client.Closed() {
 		return nil, ErrClosedClient
@@ -157,6 +167,15 @@ func (c *consumer) Partitions(topic string) ([]int32, error) {
 }
 
 func (c *consumer) ConsumePartition(topic string, partition int32, offset int64) (PartitionConsumer, error) {
+	pc, err := c.consumePartition(topic, partition, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	return pc, nil
+}
+
+func (c *consumer) consumePartition(topic string, partition int32, offset int64) (*partitionConsumer, error) {
 	child := &partitionConsumer{
 		consumer:             c,
 		conf:                 c.conf,
@@ -380,10 +399,6 @@ type PartitionConsumer interface {
 	// Consumer.Return.Errors setting to true, and read from this channel.
 	Errors() <-chan *ConsumerError
 
-	// InitialOffset returns the initial offset that was used as a starting
-	// point for this partition.
-	InitialOffset() int64
-
 	// HighWaterMarkOffset returns the high water mark offset of the partition,
 	// i.e. the offset that will be used for the next message that will be produced.
 	// You can use this to determine how far behind the processing is.
@@ -402,6 +417,16 @@ type PartitionConsumer interface {
 
 	// IsPaused indicates if this partition consumer is paused or not
 	IsPaused() bool
+}
+
+// InitialOffsetPartitionConsumer is an extension of PartitionConsumer that adds InitialOffset. The object returned
+// from the default Consumer.ConsumePartition implements this interface.
+type InitialOffsetPartitionConsumer interface {
+	PartitionConsumer
+
+	// InitialOffset returns the initial offset that was used as a starting
+	// point for this partition.
+	InitialOffset() int64
 }
 
 type partitionConsumerResponse struct {
@@ -452,7 +477,7 @@ type partitionConsumer struct {
 	responseResult     error
 	fetchSize          int32
 	offset             int64
-	initialOffset	   int64
+	initialOffset      int64
 	retries            atomic.Int32
 
 	paused atomic.Bool // accessed atomically, 0 = not paused, 1 = paused

--- a/consumer.go
+++ b/consumer.go
@@ -380,6 +380,10 @@ type PartitionConsumer interface {
 	// Consumer.Return.Errors setting to true, and read from this channel.
 	Errors() <-chan *ConsumerError
 
+	// InitialOffset returns the initial offset that was used as a starting
+	// point for this partition.
+	InitialOffset() int64
+
 	// HighWaterMarkOffset returns the high water mark offset of the partition,
 	// i.e. the offset that will be used for the next message that will be produced.
 	// You can use this to determine how far behind the processing is.
@@ -448,6 +452,7 @@ type partitionConsumer struct {
 	responseResult     error
 	fetchSize          int32
 	offset             int64
+	initialOffset	   int64
 	retries            atomic.Int32
 
 	paused atomic.Bool // accessed atomically, 0 = not paused, 1 = paused
@@ -648,6 +653,8 @@ func (child *partitionConsumer) chooseStartingOffset(offset int64) error {
 		return ErrOffsetOutOfRange
 	}
 
+	child.initialOffset = child.offset
+
 	return nil
 }
 
@@ -679,6 +686,10 @@ func (child *partitionConsumer) Close() error {
 		return consumerErrors
 	}
 	return nil
+}
+
+func (child *partitionConsumer) InitialOffset() int64 {
+	return child.initialOffset
 }
 
 func (child *partitionConsumer) HighWaterMarkOffset() int64 {

--- a/consumer.go
+++ b/consumer.go
@@ -116,7 +116,7 @@ func NewConsumer(addrs []string, config *Config) (Consumer, error) {
 	}
 	c, err := newConsumer(client)
 	if err != nil {
-		// Return nil rather than a Consumer interface with a nil value
+		// Return untyped nil rather than a Consumer interface with a typed nil pointer
 		return nil, err
 	}
 
@@ -131,7 +131,7 @@ func NewConsumerFromClient(client Client) (Consumer, error) {
 	cli := &nopCloserClient{client}
 	c, err := newConsumer(cli)
 	if err != nil {
-		// Return nil rather than a Consumer interface with a nil value
+		// Return untyped nil rather than a Consumer interface with a typed nil pointer
 		return nil, err
 	}
 
@@ -171,7 +171,7 @@ func (c *consumer) Partitions(topic string) ([]int32, error) {
 func (c *consumer) ConsumePartition(topic string, partition int32, offset int64) (PartitionConsumer, error) {
 	pc, err := c.consumePartition(topic, partition, offset)
 	if err != nil {
-		// Return nil rather than a PartitionConsumer interface with a nil value
+		// Return untyped nil rather than a PartitionConsumer interface with a typed nil pointer
 		return nil, err
 	}
 

--- a/consumer.go
+++ b/consumer.go
@@ -118,7 +118,12 @@ func NewConsumer(addrs []string, config *Config) (Consumer, error) {
 	if err != nil {
 		return nil, err
 	}
-	return newConsumer(client)
+	c, err := newConsumer(client)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
 // NewConsumerFromClient creates a new consumer using the given client. It is still
@@ -127,10 +132,15 @@ func NewConsumerFromClient(client Client) (Consumer, error) {
 	// For clients passed in by the client, ensure we don't
 	// call Close() on it.
 	cli := &nopCloserClient{client}
-	return newConsumer(cli)
+	c, err := newConsumer(cli)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
-func newConsumer(client Client) (Consumer, error) {
+func newConsumer(client Client) (*consumer, error) {
 	// Check that we are not dealing with a closed Client before processing any other arguments
 	if client.Closed() {
 		return nil, ErrClosedClient
@@ -162,6 +172,15 @@ func (c *consumer) Partitions(topic string) ([]int32, error) {
 }
 
 func (c *consumer) ConsumePartition(topic string, partition int32, offset int64) (PartitionConsumer, error) {
+	pc, err := c.consumePartition(topic, partition, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	return pc, nil
+}
+
+func (c *consumer) consumePartition(topic string, partition int32, offset int64) (*partitionConsumer, error) {
 	child := &partitionConsumer{
 		consumer:             c,
 		conf:                 c.conf,
@@ -404,10 +423,6 @@ type PartitionConsumer interface {
 	// Consumer.Return.Errors setting to true, and read from this channel.
 	Errors() <-chan *ConsumerError
 
-	// InitialOffset returns the initial offset that was used as a starting
-	// point for this partition.
-	InitialOffset() int64
-
 	// HighWaterMarkOffset returns the high water mark offset of the partition,
 	// i.e. the offset that will be used for the next message that will be produced.
 	// You can use this to determine how far behind the processing is.
@@ -426,6 +441,16 @@ type PartitionConsumer interface {
 
 	// IsPaused indicates if this partition consumer is paused or not
 	IsPaused() bool
+}
+
+// InitialOffsetPartitionConsumer is an extension of PartitionConsumer that adds InitialOffset. The object returned
+// from the default Consumer.ConsumePartition implements this interface.
+type InitialOffsetPartitionConsumer interface {
+	PartitionConsumer
+
+	// InitialOffset returns the initial offset that was used as a starting
+	// point for this partition.
+	InitialOffset() int64
 }
 
 type partitionConsumerResponse struct {
@@ -477,7 +502,7 @@ type partitionConsumer struct {
 	responseResult     error
 	fetchSize          int32
 	offset             int64
-	initialOffset	   int64
+	initialOffset      int64
 	retries            atomic.Int32
 
 	paused atomic.Bool // accessed atomically, 0 = not paused, 1 = paused

--- a/consumer.go
+++ b/consumer.go
@@ -120,7 +120,7 @@ func NewConsumer(addrs []string, config *Config) (Consumer, error) {
 	}
 	c, err := newConsumer(client)
 	if err != nil {
-		// Return nil rather than a Consumer interface with a nil value
+		// Return untyped nil rather than a Consumer interface with a typed nil pointer
 		return nil, err
 	}
 
@@ -135,7 +135,7 @@ func NewConsumerFromClient(client Client) (Consumer, error) {
 	cli := &nopCloserClient{client}
 	c, err := newConsumer(cli)
 	if err != nil {
-		// Return nil rather than a Consumer interface with a nil value
+		// Return untyped nil rather than a Consumer interface with a typed nil pointer
 		return nil, err
 	}
 
@@ -176,7 +176,7 @@ func (c *consumer) Partitions(topic string) ([]int32, error) {
 func (c *consumer) ConsumePartition(topic string, partition int32, offset int64) (PartitionConsumer, error) {
 	pc, err := c.consumePartition(topic, partition, offset)
 	if err != nil {
-		// Return nil rather than a PartitionConsumer interface with a nil value
+		// Return untyped nil rather than a PartitionConsumer interface with a typed nil pointer
 		return nil, err
 	}
 

--- a/consumer.go
+++ b/consumer.go
@@ -404,6 +404,10 @@ type PartitionConsumer interface {
 	// Consumer.Return.Errors setting to true, and read from this channel.
 	Errors() <-chan *ConsumerError
 
+	// InitialOffset returns the initial offset that was used as a starting
+	// point for this partition.
+	InitialOffset() int64
+
 	// HighWaterMarkOffset returns the high water mark offset of the partition,
 	// i.e. the offset that will be used for the next message that will be produced.
 	// You can use this to determine how far behind the processing is.
@@ -473,6 +477,7 @@ type partitionConsumer struct {
 	responseResult     error
 	fetchSize          int32
 	offset             int64
+	initialOffset	   int64
 	retries            atomic.Int32
 
 	paused atomic.Bool // accessed atomically, 0 = not paused, 1 = paused
@@ -707,6 +712,8 @@ func (child *partitionConsumer) chooseStartingOffset(offset int64) error {
 		return ErrOffsetOutOfRange
 	}
 
+	child.initialOffset = child.offset
+
 	return nil
 }
 
@@ -738,6 +745,10 @@ func (child *partitionConsumer) Close() error {
 		return consumerErrors
 	}
 	return nil
+}
+
+func (child *partitionConsumer) InitialOffset() int64 {
+	return child.initialOffset
 }
 
 func (child *partitionConsumer) HighWaterMarkOffset() int64 {

--- a/consumer.go
+++ b/consumer.go
@@ -120,6 +120,7 @@ func NewConsumer(addrs []string, config *Config) (Consumer, error) {
 	}
 	c, err := newConsumer(client)
 	if err != nil {
+		// Return nil rather than a Consumer interface with a nil value
 		return nil, err
 	}
 
@@ -134,6 +135,7 @@ func NewConsumerFromClient(client Client) (Consumer, error) {
 	cli := &nopCloserClient{client}
 	c, err := newConsumer(cli)
 	if err != nil {
+		// Return nil rather than a Consumer interface with a nil value
 		return nil, err
 	}
 
@@ -174,12 +176,14 @@ func (c *consumer) Partitions(topic string) ([]int32, error) {
 func (c *consumer) ConsumePartition(topic string, partition int32, offset int64) (PartitionConsumer, error) {
 	pc, err := c.consumePartition(topic, partition, offset)
 	if err != nil {
+		// Return nil rather than a PartitionConsumer interface with a nil value
 		return nil, err
 	}
 
 	return pc, nil
 }
 
+// consumePartition returns the concrete partitionConsumer struct used internally in the ConsumerGroup implementation
 func (c *consumer) consumePartition(topic string, partition int32, offset int64) (*partitionConsumer, error) {
 	child := &partitionConsumer{
 		consumer:             c,

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -1172,9 +1172,9 @@ type ConsumerGroupClaim interface {
 }
 
 type consumerGroupClaim struct {
+	*partitionConsumer
 	topic     string
 	partition int32
-	*partitionConsumer
 }
 
 func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition int32, offset int64) (*consumerGroupClaim, error) {
@@ -1195,9 +1195,9 @@ func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition i
 	}()
 
 	return &consumerGroupClaim{
+		partitionConsumer: pcm,
 		topic:             topic,
 		partition:         partition,
-		partitionConsumer: pcm,
 	}, nil
 }
 

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -80,7 +80,7 @@ type consumerGroup struct {
 	client Client
 
 	config          *Config
-	consumer        Consumer
+	consumer        *consumer
 	groupID         string
 	groupInstanceId *string
 	memberID        string
@@ -1174,15 +1174,15 @@ type ConsumerGroupClaim interface {
 type consumerGroupClaim struct {
 	topic     string
 	partition int32
-	PartitionConsumer
+	*partitionConsumer
 }
 
 func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition int32, offset int64) (*consumerGroupClaim, error) {
-	pcm, err := sess.parent.consumer.ConsumePartition(topic, partition, offset)
+	pcm, err := sess.parent.consumer.consumePartition(topic, partition, offset)
 
 	if errors.Is(err, ErrOffsetOutOfRange) && sess.parent.config.Consumer.Group.ResetInvalidOffsets {
 		offset = sess.parent.config.Consumer.Offsets.Initial
-		pcm, err = sess.parent.consumer.ConsumePartition(topic, partition, offset)
+		pcm, err = sess.parent.consumer.consumePartition(topic, partition, offset)
 	}
 	if err != nil {
 		return nil, err
@@ -1197,12 +1197,12 @@ func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition i
 	return &consumerGroupClaim{
 		topic:             topic,
 		partition:         partition,
-		PartitionConsumer: pcm,
+		partitionConsumer: pcm,
 	}, nil
 }
 
-func (c *consumerGroupClaim) Topic() string        { return c.topic }
-func (c *consumerGroupClaim) Partition() int32     { return c.partition }
+func (c *consumerGroupClaim) Topic() string    { return c.topic }
+func (c *consumerGroupClaim) Partition() int32 { return c.partition }
 
 // Drains messages and errors, ensures the claim is fully closed.
 func (c *consumerGroupClaim) waitClosed() (errs ConsumerErrors) {

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -1174,7 +1174,6 @@ type ConsumerGroupClaim interface {
 type consumerGroupClaim struct {
 	topic     string
 	partition int32
-	offset    int64
 	PartitionConsumer
 }
 
@@ -1198,14 +1197,12 @@ func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition i
 	return &consumerGroupClaim{
 		topic:             topic,
 		partition:         partition,
-		offset:            offset,
 		PartitionConsumer: pcm,
 	}, nil
 }
 
 func (c *consumerGroupClaim) Topic() string        { return c.topic }
 func (c *consumerGroupClaim) Partition() int32     { return c.partition }
-func (c *consumerGroupClaim) InitialOffset() int64 { return c.offset }
 
 // Drains messages and errors, ensures the claim is fully closed.
 func (c *consumerGroupClaim) waitClosed() (errs ConsumerErrors) {

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -95,7 +95,7 @@ type consumerGroup struct {
 	client Client
 
 	config           *Config
-	consumer         Consumer
+	consumer         *consumer
 	groupID          string
 	groupInstanceId  *string
 	memberID         string

--- a/consumer_group_session.go
+++ b/consumer_group_session.go
@@ -448,9 +448,9 @@ type ConsumerGroupClaim interface {
 }
 
 type consumerGroupClaim struct {
+	*partitionConsumer
 	topic     string
 	partition int32
-	*partitionConsumer
 }
 
 func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition int32, offset int64) (*consumerGroupClaim, error) {
@@ -471,9 +471,9 @@ func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition i
 	}()
 
 	return &consumerGroupClaim{
+		partitionConsumer: pcm,
 		topic:             topic,
 		partition:         partition,
-		partitionConsumer: pcm,
 	}, nil
 }
 

--- a/consumer_group_session.go
+++ b/consumer_group_session.go
@@ -450,15 +450,15 @@ type ConsumerGroupClaim interface {
 type consumerGroupClaim struct {
 	topic     string
 	partition int32
-	PartitionConsumer
+	*partitionConsumer
 }
 
 func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition int32, offset int64) (*consumerGroupClaim, error) {
-	pcm, err := sess.parent.consumer.ConsumePartition(topic, partition, offset)
+	pcm, err := sess.parent.consumer.consumePartition(topic, partition, offset)
 
 	if errors.Is(err, ErrOffsetOutOfRange) && sess.parent.config.Consumer.Group.ResetInvalidOffsets {
 		offset = sess.parent.config.Consumer.Offsets.Initial
-		pcm, err = sess.parent.consumer.ConsumePartition(topic, partition, offset)
+		pcm, err = sess.parent.consumer.consumePartition(topic, partition, offset)
 	}
 	if err != nil {
 		return nil, err
@@ -473,12 +473,12 @@ func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition i
 	return &consumerGroupClaim{
 		topic:             topic,
 		partition:         partition,
-		PartitionConsumer: pcm,
+		partitionConsumer: pcm,
 	}, nil
 }
 
-func (c *consumerGroupClaim) Topic() string        { return c.topic }
-func (c *consumerGroupClaim) Partition() int32     { return c.partition }
+func (c *consumerGroupClaim) Topic() string    { return c.topic }
+func (c *consumerGroupClaim) Partition() int32 { return c.partition }
 
 // Drains messages and errors, ensures the claim is fully closed.
 func (c *consumerGroupClaim) waitClosed() (errs ConsumerErrors) {

--- a/consumer_group_session.go
+++ b/consumer_group_session.go
@@ -450,7 +450,6 @@ type ConsumerGroupClaim interface {
 type consumerGroupClaim struct {
 	topic     string
 	partition int32
-	offset    int64
 	PartitionConsumer
 }
 
@@ -474,14 +473,12 @@ func newConsumerGroupClaim(sess *consumerGroupSession, topic string, partition i
 	return &consumerGroupClaim{
 		topic:             topic,
 		partition:         partition,
-		offset:            offset,
 		PartitionConsumer: pcm,
 	}, nil
 }
 
 func (c *consumerGroupClaim) Topic() string        { return c.topic }
 func (c *consumerGroupClaim) Partition() int32     { return c.partition }
-func (c *consumerGroupClaim) InitialOffset() int64 { return c.offset }
 
 // Drains messages and errors, ensures the claim is fully closed.
 func (c *consumerGroupClaim) waitClosed() (errs ConsumerErrors) {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -68,6 +68,9 @@ func TestConsumerOffsetManual(t *testing.T) {
 	}
 
 	// Then
+	if io := consumer.InitialOffset(); io != manualOffset {
+		t.Errorf("Expected initial offset %d, found %d", manualOffset, io)
+	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
 	}
@@ -241,6 +244,7 @@ func TestPauseResumeConsumption(t *testing.T) {
 func TestConsumerOffsetNewest(t *testing.T) {
 	// Given
 	offsetNewest := int64(10)
+	offsetOldest := int64(7)
 	offsetNewestAfterFetchRequest := int64(50)
 	broker0 := NewMockBroker(t, 0)
 	broker0.SetHandlerByMap(map[string]MockResponse{
@@ -249,7 +253,7 @@ func TestConsumerOffsetNewest(t *testing.T) {
 			SetLeader("my_topic", 0, broker0.BrokerID()),
 		"OffsetRequest": NewMockOffsetResponse(t).
 			SetOffset("my_topic", 0, OffsetNewest, offsetNewest).
-			SetOffset("my_topic", 0, OffsetOldest, 7),
+			SetOffset("my_topic", 0, OffsetOldest, offsetOldest),
 		"FetchRequest": NewMockFetchResponse(t, 1).
 			SetMessage("my_topic", 0, 9, testMsg). // skipped because parseRecords(): offset < child.offset
 			SetMessage("my_topic", 0, 10, testMsg).
@@ -269,6 +273,9 @@ func TestConsumerOffsetNewest(t *testing.T) {
 	}
 
 	// Then
+	if io := consumer.InitialOffset(); io != offsetNewest {
+		t.Errorf("Expected initial offset %d, found %d", offsetNewest, io)
+	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
 	}
@@ -287,6 +294,7 @@ func TestConsumerOffsetNewest(t *testing.T) {
 func TestConsumerOffsetOldest(t *testing.T) {
 	// Given
 	offsetNewest := int64(10)
+	offsetOldest := int64(7)
 	broker0 := NewMockBroker(t, 0)
 	broker0.SetHandlerByMap(map[string]MockResponse{
 		"MetadataRequest": NewMockMetadataResponse(t).
@@ -294,7 +302,7 @@ func TestConsumerOffsetOldest(t *testing.T) {
 			SetLeader("my_topic", 0, broker0.BrokerID()),
 		"OffsetRequest": NewMockOffsetResponse(t).
 			SetOffset("my_topic", 0, OffsetNewest, offsetNewest).
-			SetOffset("my_topic", 0, OffsetOldest, 7),
+			SetOffset("my_topic", 0, OffsetOldest, offsetOldest),
 		"FetchRequest": NewMockFetchResponse(t, 1).
 			// skipped because parseRecords(): offset < child.offset
 			SetMessage("my_topic", 0, 6, testMsg).
@@ -317,6 +325,9 @@ func TestConsumerOffsetOldest(t *testing.T) {
 	}
 
 	// Then
+	if io := consumer.InitialOffset(); io != offsetOldest {
+		t.Errorf("Expected initial offset %d, found %d", offsetOldest, io)
+	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
 	}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -68,8 +68,8 @@ func TestConsumerOffsetManual(t *testing.T) {
 	}
 
 	// Then
-	if io := consumer.InitialOffset(); io != manualOffset {
-		t.Errorf("Expected initial offset %d, found %d", manualOffset, io)
+	if initialOffset := consumer.InitialOffset(); initialOffset != manualOffset {
+		t.Errorf("Expected initial offset %d, found %d", manualOffset, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
@@ -273,8 +273,8 @@ func TestConsumerOffsetNewest(t *testing.T) {
 	}
 
 	// Then
-	if io := consumer.InitialOffset(); io != offsetNewest {
-		t.Errorf("Expected initial offset %d, found %d", offsetNewest, io)
+	if initialOffset := consumer.InitialOffset(); initialOffset != offsetNewest {
+		t.Errorf("Expected initial offset %d, found %d", offsetNewest, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
@@ -325,8 +325,8 @@ func TestConsumerOffsetOldest(t *testing.T) {
 	}
 
 	// Then
-	if io := consumer.InitialOffset(); io != offsetOldest {
-		t.Errorf("Expected initial offset %d, found %d", offsetOldest, io)
+	if initialOffset := consumer.InitialOffset(); initialOffset != offsetOldest {
+		t.Errorf("Expected initial offset %d, found %d", offsetOldest, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -68,7 +68,7 @@ func TestConsumerOffsetManual(t *testing.T) {
 	}
 
 	// Then
-	if initialOffset := consumer.InitialOffset(); initialOffset != manualOffset {
+	if initialOffset := consumer.(InitialOffsetPartitionConsumer).InitialOffset(); initialOffset != manualOffset {
 		t.Errorf("Expected initial offset %d, found %d", manualOffset, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
@@ -273,7 +273,7 @@ func TestConsumerOffsetNewest(t *testing.T) {
 	}
 
 	// Then
-	if initialOffset := consumer.InitialOffset(); initialOffset != offsetNewest {
+	if initialOffset := consumer.(InitialOffsetPartitionConsumer).InitialOffset(); initialOffset != offsetNewest {
 		t.Errorf("Expected initial offset %d, found %d", offsetNewest, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
@@ -325,7 +325,7 @@ func TestConsumerOffsetOldest(t *testing.T) {
 	}
 
 	// Then
-	if initialOffset := consumer.InitialOffset(); initialOffset != offsetOldest {
+	if initialOffset := consumer.(InitialOffsetPartitionConsumer).InitialOffset(); initialOffset != offsetOldest {
 		t.Errorf("Expected initial offset %d, found %d", offsetOldest, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -69,8 +69,8 @@ func TestConsumerOffsetManual(t *testing.T) {
 	}
 
 	// Then
-	if io := consumer.InitialOffset(); io != manualOffset {
-		t.Errorf("Expected initial offset %d, found %d", manualOffset, io)
+	if initialOffset := consumer.InitialOffset(); initialOffset != manualOffset {
+		t.Errorf("Expected initial offset %d, found %d", manualOffset, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
@@ -274,8 +274,8 @@ func TestConsumerOffsetNewest(t *testing.T) {
 	}
 
 	// Then
-	if io := consumer.InitialOffset(); io != offsetNewest {
-		t.Errorf("Expected initial offset %d, found %d", offsetNewest, io)
+	if initialOffset := consumer.InitialOffset(); initialOffset != offsetNewest {
+		t.Errorf("Expected initial offset %d, found %d", offsetNewest, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
@@ -326,8 +326,8 @@ func TestConsumerOffsetOldest(t *testing.T) {
 	}
 
 	// Then
-	if io := consumer.InitialOffset(); io != offsetOldest {
-		t.Errorf("Expected initial offset %d, found %d", offsetOldest, io)
+	if initialOffset := consumer.InitialOffset(); initialOffset != offsetOldest {
+		t.Errorf("Expected initial offset %d, found %d", offsetOldest, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -69,7 +69,7 @@ func TestConsumerOffsetManual(t *testing.T) {
 	}
 
 	// Then
-	if initialOffset := consumer.InitialOffset(); initialOffset != manualOffset {
+	if initialOffset := consumer.(InitialOffsetPartitionConsumer).InitialOffset(); initialOffset != manualOffset {
 		t.Errorf("Expected initial offset %d, found %d", manualOffset, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
@@ -274,7 +274,7 @@ func TestConsumerOffsetNewest(t *testing.T) {
 	}
 
 	// Then
-	if initialOffset := consumer.InitialOffset(); initialOffset != offsetNewest {
+	if initialOffset := consumer.(InitialOffsetPartitionConsumer).InitialOffset(); initialOffset != offsetNewest {
 		t.Errorf("Expected initial offset %d, found %d", offsetNewest, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
@@ -326,7 +326,7 @@ func TestConsumerOffsetOldest(t *testing.T) {
 	}
 
 	// Then
-	if initialOffset := consumer.InitialOffset(); initialOffset != offsetOldest {
+	if initialOffset := consumer.(InitialOffsetPartitionConsumer).InitialOffset(); initialOffset != offsetOldest {
 		t.Errorf("Expected initial offset %d, found %d", offsetOldest, initialOffset)
 	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -69,6 +69,9 @@ func TestConsumerOffsetManual(t *testing.T) {
 	}
 
 	// Then
+	if io := consumer.InitialOffset(); io != manualOffset {
+		t.Errorf("Expected initial offset %d, found %d", manualOffset, io)
+	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
 	}
@@ -242,6 +245,7 @@ func TestPauseResumeConsumption(t *testing.T) {
 func TestConsumerOffsetNewest(t *testing.T) {
 	// Given
 	offsetNewest := int64(10)
+	offsetOldest := int64(7)
 	offsetNewestAfterFetchRequest := int64(50)
 	broker0 := NewMockBroker(t, 0)
 	broker0.SetHandlerByMap(map[string]MockResponse{
@@ -250,7 +254,7 @@ func TestConsumerOffsetNewest(t *testing.T) {
 			SetLeader("my_topic", 0, broker0.BrokerID()),
 		"OffsetRequest": NewMockOffsetResponse(t).
 			SetOffset("my_topic", 0, OffsetNewest, offsetNewest).
-			SetOffset("my_topic", 0, OffsetOldest, 7),
+			SetOffset("my_topic", 0, OffsetOldest, offsetOldest),
 		"FetchRequest": NewMockFetchResponse(t, 1).
 			SetMessage("my_topic", 0, 9, testMsg). // skipped because parseRecords(): offset < child.offset
 			SetMessage("my_topic", 0, 10, testMsg).
@@ -270,6 +274,9 @@ func TestConsumerOffsetNewest(t *testing.T) {
 	}
 
 	// Then
+	if io := consumer.InitialOffset(); io != offsetNewest {
+		t.Errorf("Expected initial offset %d, found %d", offsetNewest, io)
+	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
 	}
@@ -288,6 +295,7 @@ func TestConsumerOffsetNewest(t *testing.T) {
 func TestConsumerOffsetOldest(t *testing.T) {
 	// Given
 	offsetNewest := int64(10)
+	offsetOldest := int64(7)
 	broker0 := NewMockBroker(t, 0)
 	broker0.SetHandlerByMap(map[string]MockResponse{
 		"MetadataRequest": NewMockMetadataResponse(t).
@@ -295,7 +303,7 @@ func TestConsumerOffsetOldest(t *testing.T) {
 			SetLeader("my_topic", 0, broker0.BrokerID()),
 		"OffsetRequest": NewMockOffsetResponse(t).
 			SetOffset("my_topic", 0, OffsetNewest, offsetNewest).
-			SetOffset("my_topic", 0, OffsetOldest, 7),
+			SetOffset("my_topic", 0, OffsetOldest, offsetOldest),
 		"FetchRequest": NewMockFetchResponse(t, 1).
 			// skipped because parseRecords(): offset < child.offset
 			SetMessage("my_topic", 0, 6, testMsg).
@@ -318,6 +326,9 @@ func TestConsumerOffsetOldest(t *testing.T) {
 	}
 
 	// Then
+	if io := consumer.InitialOffset(); io != offsetOldest {
+		t.Errorf("Expected initial offset %d, found %d", offsetOldest, io)
+	}
 	if hwmo := consumer.HighWaterMarkOffset(); hwmo != offsetNewest {
 		t.Errorf("Expected high water mark offset %d, found %d", offsetNewest, hwmo)
 	}

--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -227,6 +227,7 @@ func (c *Consumer) ExpectConsumePartition(topic string, partition int32, offset 
 			topic:              topic,
 			partition:          partition,
 			offset:             offset,
+			initialOffset:      highWatermarkOffset,
 			messages:           make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
 			suppressedMessages: make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
 			errors:             make(chan *sarama.ConsumerError, c.config.ChannelBufferSize),
@@ -255,6 +256,7 @@ type PartitionConsumer struct {
 	topic                         string
 	partition                     int32
 	offset                        int64
+	initialOffset                 int64
 	messages                      chan *sarama.ConsumerMessage
 	suppressedMessages            chan *sarama.ConsumerMessage
 	errors                        chan *sarama.ConsumerError
@@ -343,6 +345,10 @@ func (pc *PartitionConsumer) Errors() <-chan *sarama.ConsumerError {
 // Messages implements the Messages method from the sarama.PartitionConsumer interface.
 func (pc *PartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
 	return pc.messages
+}
+
+func (pc *PartitionConsumer) InitialOffset() int64 {
+	return pc.initialOffset
 }
 
 func (pc *PartitionConsumer) HighWaterMarkOffset() int64 {

--- a/mocks/consumer.go
+++ b/mocks/consumer.go
@@ -227,6 +227,7 @@ func (c *Consumer) ExpectConsumePartition(topic string, partition int32, offset 
 			topic:              topic,
 			partition:          partition,
 			offset:             offset,
+			initialOffset:      highWatermarkOffset,
 			messages:           make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
 			suppressedMessages: make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
 			errors:             make(chan *sarama.ConsumerError, c.config.ChannelBufferSize),
@@ -255,6 +256,7 @@ type PartitionConsumer struct {
 	topic                         string
 	partition                     int32
 	offset                        int64
+	initialOffset                 int64
 	messages                      chan *sarama.ConsumerMessage
 	suppressedMessages            chan *sarama.ConsumerMessage
 	errors                        chan *sarama.ConsumerError
@@ -336,6 +338,10 @@ func (pc *PartitionConsumer) Errors() <-chan *sarama.ConsumerError {
 // Messages implements the Messages method from the sarama.PartitionConsumer interface.
 func (pc *PartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
 	return pc.messages
+}
+
+func (pc *PartitionConsumer) InitialOffset() int64 {
+	return pc.initialOffset
 }
 
 func (pc *PartitionConsumer) HighWaterMarkOffset() int64 {


### PR DESCRIPTION
Store the initial offset in the `partitionConsumer`
and make it available via the `InitialOffset`
method. The same method is then also reused when
embedded in a `consumerGroupClaim`.

I also added tests for the `InitialOffset` method since it did not exist before.

This change will align the `ConsumerGroupClaim` and `PartitionConsumer` interfaces, and will also make it possible to implement a proper end of partition detection that is not timer based or has to access internal fields, something that has been requested several times (https://github.com/IBM/sarama/issues/628, https://github.com/IBM/sarama/issues/848, https://github.com/IBM/sarama/issues/2116).