### PR TITLE
fix: stabilise TestFuncTxnProduceAndCommitOffset flakes

### DIFF
--- a/client.go
+++ b/client.go
@@ -977,7 +977,7 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 	}
 	retry := func(err error) error {
 		if attemptsRemaining > 0 {
-			backoff := client.computeBackoff(attemptsRemaining)
+			backoff := computeMetadataBackoff(client.conf, attemptsRemaining)
 			if pastDeadline(backoff) {
 				Logger.Println("client/metadata skipping last retries as we would go past the metadata timeout")
 				return err
@@ -1171,19 +1171,19 @@ func (client *client) cachedController() *Broker {
 	return client.brokers[client.controllerID]
 }
 
-func (client *client) computeBackoff(attemptsRemaining int) time.Duration {
-	if client.conf.Metadata.Retry.BackoffFunc != nil {
-		maxRetries := client.conf.Metadata.Retry.Max
+func computeMetadataBackoff(conf *Config, attemptsRemaining int) time.Duration {
+	if conf.Metadata.Retry.BackoffFunc != nil {
+		maxRetries := conf.Metadata.Retry.Max
 		retries := maxRetries - attemptsRemaining
-		return client.conf.Metadata.Retry.BackoffFunc(retries, maxRetries)
+		return conf.Metadata.Retry.BackoffFunc(retries, maxRetries)
 	}
-	return client.conf.Metadata.Retry.Backoff
+	return conf.Metadata.Retry.Backoff
 }
 
 func (client *client) findCoordinator(coordinatorKey string, coordinatorType CoordinatorType, attemptsRemaining int) (*FindCoordinatorResponse, error) {
 	retry := func(err error) (*FindCoordinatorResponse, error) {
 		if attemptsRemaining > 0 {
-			backoff := client.computeBackoff(attemptsRemaining)
+			backoff := computeMetadataBackoff(client.conf, attemptsRemaining)
 			attemptsRemaining--
 			Logger.Printf("client/coordinator retrying after %dms... (%d attempts remaining)\n", backoff/time.Millisecond, attemptsRemaining)
 			time.Sleep(backoff)

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -946,9 +946,9 @@ func (s *consumerGroupSession) newClaimWithRetry(topic string, partition int32, 
 		if retries <= 0 || !isRetriableClaimError(err) {
 			return nil, err
 		}
-		backoff := computeMetadataBackoff(s.parent.config, retries)
 		retries--
 
+		backoff := computeMetadataBackoff(s.parent.config, retries)
 		Logger.Printf(
 			"consumer-group/claim %s/%d retrying after %dms... (%d attempts remaining): %v\n",
 			topic, partition, backoff/time.Millisecond, retries, err)

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -933,6 +933,50 @@ func (s *consumerGroupSession) Context() context.Context {
 	return s.ctx
 }
 
+// newClaimWithRetry calls newConsumerGroupClaim, retrying transient errors so
+// that brief leader/metadata desync around a rebalance doesn't leave a
+// partition permanently unclaimed for the lifetime of this session
+func (s *consumerGroupSession) newClaimWithRetry(topic string, partition int32, offset int64) (*consumerGroupClaim, error) {
+	retries := s.parent.config.Metadata.Retry.Max
+	for {
+		claim, err := newConsumerGroupClaim(s, topic, partition, offset)
+		if err == nil {
+			return claim, nil
+		}
+		if retries <= 0 || !isRetriableClaimError(err) {
+			return nil, err
+		}
+		backoff := computeMetadataBackoff(s.parent.config, retries)
+		retries--
+
+		Logger.Printf(
+			"consumer-group/claim %s/%d retrying after %dms... (%d attempts remaining): %v\n",
+			topic, partition, backoff/time.Millisecond, retries, err)
+
+		select {
+		case <-s.ctx.Done():
+			return nil, err
+		case <-s.parent.closed:
+			return nil, err
+		case <-time.After(backoff):
+		}
+
+		// refresh leader/broker info before retrying
+		_ = s.parent.client.RefreshMetadata(topic)
+	}
+}
+
+// isRetriableClaimError reports whether err from newConsumerGroupClaim is
+// a transient condition worth retrying after a metadata refresh
+func isRetriableClaimError(err error) bool {
+	return errors.Is(err, ErrNotConnected) ||
+		errors.Is(err, ErrLeaderNotAvailable) ||
+		errors.Is(err, ErrNotLeaderForPartition) ||
+		errors.Is(err, ErrFencedLeaderEpoch) ||
+		errors.Is(err, ErrUnknownLeaderEpoch) ||
+		errors.Is(err, ErrReplicaNotAvailable)
+}
+
 func (s *consumerGroupSession) consume(topic string, partition int32) {
 	// quick exit if rebalance is due
 	select {
@@ -950,7 +994,7 @@ func (s *consumerGroupSession) consume(topic string, partition int32) {
 	}
 
 	// create new claim
-	claim, err := newConsumerGroupClaim(s, topic, partition, offset)
+	claim, err := s.newClaimWithRetry(topic, partition, offset)
 	if err != nil {
 		s.parent.handleError(err, topic, partition)
 		return

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -364,14 +364,16 @@ func TestFuncInitProducerId3(t *testing.T) {
 
 type messageHandler struct {
 	*testing.T
-	h       func(*ConsumerMessage)
-	started sync.WaitGroup
+	h         func(*ConsumerMessage)
+	started   chan struct{}
+	startOnce sync.Once
 }
 
 func (h *messageHandler) Setup(s ConsumerGroupSession) error   { return nil }
 func (h *messageHandler) Cleanup(s ConsumerGroupSession) error { return nil }
 func (h *messageHandler) ConsumeClaim(sess ConsumerGroupSession, claim ConsumerGroupClaim) error {
-	h.started.Done()
+	// signal once on the first claim received
+	h.startOnce.Do(func() { close(h.started) })
 
 	for msg := range claim.Messages() {
 		h.Logf("consumed msg %v", msg)
@@ -416,7 +418,7 @@ func TestFuncTxnProduceAndCommitOffset(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	handler := &messageHandler{}
+	handler := &messageHandler{started: make(chan struct{})}
 	handler.T = t
 	handler.h = func(msg *ConsumerMessage) {
 		err := producer.BeginTxn()
@@ -428,13 +430,12 @@ func TestFuncTxnProduceAndCommitOffset(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	handler.started.Add(4)
 	go func() {
 		err = cg.Consume(ctx, []string{"test.4"}, handler)
 		require.NoError(t, err)
 	}()
 
-	handler.started.Wait()
+	<-handler.started
 
 	nonTransactionalProducer, err := NewAsyncProducer(FunctionalTestEnv.KafkaBrokerAddrs, NewFunctionalTestConfig())
 	require.NoError(t, err)

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/rcrowley/go-metrics"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/IBM/sarama/internal/toxiproxy"
@@ -432,7 +433,7 @@ func TestFuncTxnProduceAndCommitOffset(t *testing.T) {
 
 	go func() {
 		err = cg.Consume(ctx, []string{"test.4"}, handler)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 
 	<-handler.started


### PR DESCRIPTION
Trying to resolve the flaky failures in `TestFuncTxnProduceAndCommitOffset` tracked in #3502. Interestingly it actually looks like it caught a genuine issue!

Two independent issues seemed to be contributing:

1. When the consumer group rebalances at session start, `newConsumerGroupClaim` can return a transient leader/metadata error (`ErrNotLeaderForPartition`, `ErrFencedLeaderEpoch`, `ErrLeaderNotAvailable`, etc.) before metadata has caught up. That error went straight to `handleError` and the partition stayed unclaimed for the rest of the session, which in the test manifested as the consumer never seeing the produced message.

2. The handler used `started.Add(4)` and called `Done()` from `ConsumeClaim`, but `ConsumeClaim` can fire more than four times when a rebalance re-invokes it for the same partition, pushing the counter negative and panicking.

With this PR, `consumerGroupSession.consume` now calls a small retry wrapper that backs off, refreshes metadata, and retries up to `Metadata.Retry.Max` times before giving up, and the test uses a simple `chan struct{}` closed once via `sync.Once` on the first claim.