### PR TITLE
test: relax flaky producer metrics assertions

### DIFF
--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -1154,19 +1154,23 @@ func validateProducerMetrics(t *testing.T, client Client) {
 		}
 		metricValidators.registerForGlobalAndTopic("test_1", maxValHistogramValidator("compression-ratio", 1000))
 	} else {
-		// We record compression ratios of 1.00 (100 with a histogram) for every TestBatchSize record
+		// We record compression ratios of 1.00 (100 with a histogram) for every sent batch.
 		if client.Config().Version.IsAtLeast(V0_11_0_0) {
-			// records will be grouped in batchSet rather than msgSet
-			metricValidators.registerForGlobalAndTopic("test_1", minCountHistogramValidator("compression-ratio", 3))
+			// Records will be grouped in RecordBatch rather than MessageSet. The number of
+			// batches is scheduler-dependent when the async producer keeps accepting input
+			// while a previous batch is waiting to be flushed.
+			metricValidators.registerForGlobalAndTopic("test_1", minCountHistogramValidator("compression-ratio", 1))
 		} else {
+			// MessageSet metrics are recorded per message.
 			metricValidators.registerForGlobalAndTopic("test_1", countHistogramValidator("compression-ratio", TestBatchSize))
 		}
 		metricValidators.registerForGlobalAndTopic("test_1", minValHistogramValidator("compression-ratio", 100))
 		metricValidators.registerForGlobalAndTopic("test_1", maxValHistogramValidator("compression-ratio", 100))
 	}
 
-	// We send exactly TestBatchSize messages
-	metricValidators.registerForGlobalAndTopic("test_1", countMeterValidator("record-send-rate", TestBatchSize))
+	// We successfully deliver TestBatchSize messages, but retried produce requests can
+	// make the send-attempt metric higher than the final delivered message count.
+	metricValidators.registerForGlobalAndTopic("test_1", minCountMeterValidator("record-send-rate", TestBatchSize))
 	// We send at least one record per request
 	metricValidators.registerForGlobalAndTopic("test_1", minCountHistogramValidator("records-per-request", 1))
 	metricValidators.registerForGlobalAndTopic("test_1", minValHistogramValidator("records-per-request", 1))


### PR DESCRIPTION
## Why

- `TestFuncProducingFlushing` can fail intermittently because producer metrics count send attempts and encoded batches, not only final delivered messages.
- Fixes #3496.

## What

- Relax the uncompressed RecordBatch `compression-ratio` assertion to require at least one recorded batch.
- Treat `record-send-rate` as a minimum send-attempt count so retried produce requests do not fail the test after all messages are delivered.

## Validation

- `go test -c -tags=functional -o /tmp/sarama-functional.test .`
- `go test ./...`

## Notes

- I could not run the full functional Kafka matrix locally because the local Docker socket was unavailable for the FVT environment.
