### PR TITLE
fix: prevent race during partition consumer close

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -192,10 +192,12 @@ func (c *consumer) ConsumePartition(topic string, partition int32, offset int64)
 	child.leaderEpoch = epoch
 	for {
 		child.broker = c.refBrokerConsumer(leader)
-		if child.broker.queueSubscription(child) {
+		child.brokerSubscription = newBrokerSubscription(child)
+		if child.broker.queueSubscription(child.brokerSubscription) {
 			break
 		}
 
+		child.brokerSubscription.release()
 		c.unrefBrokerConsumer(child.broker)
 	}
 
@@ -399,19 +401,40 @@ type PartitionConsumer interface {
 }
 
 type partitionConsumerResponse struct {
-	broker   *brokerConsumer
-	response *FetchResponse
+	broker       *brokerConsumer
+	subscription *brokerSubscription
+	response     *FetchResponse
+}
+
+type brokerSubscription struct {
+	child       *partitionConsumer
+	released    chan none
+	releaseOnce sync.Once
+}
+
+func newBrokerSubscription(child *partitionConsumer) *brokerSubscription {
+	return &brokerSubscription{
+		child:    child,
+		released: make(chan none),
+	}
+}
+
+func (s *brokerSubscription) release() {
+	s.releaseOnce.Do(func() {
+		close(s.released)
+	})
 }
 
 type partitionConsumer struct {
 	highWaterMarkOffset atomic.Int64 // must be at the top of the struct because https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 
-	consumer *consumer
-	conf     *Config
-	broker   *brokerConsumer
-	messages chan *ConsumerMessage
-	errors   chan *ConsumerError
-	feeder   chan *partitionConsumerResponse
+	consumer           *consumer
+	conf               *Config
+	broker             *brokerConsumer
+	brokerSubscription *brokerSubscription
+	messages           chan *ConsumerMessage
+	errors             chan *ConsumerError
+	feeder             chan *partitionConsumerResponse
 
 	leaderEpoch          int32
 	preferredReadReplica int32
@@ -511,39 +534,51 @@ func (child *partitionConsumer) dispatcher() {
 		close(child.feeder)
 	}()
 
+	var backoff <-chan time.Time
 	for {
 		select {
 		case <-child.dispatcherStop:
 			return
-		case <-child.trigger:
-		}
-
-		select {
-		case <-child.dispatcherStop:
-			return
 		case <-child.dying:
-			if child.broker == nil {
-				return
+			child.waitForBrokerHandover()
+			return
+		case <-child.trigger:
+			// only set the timer when none is pending, so retries increments
+			// once per dispatch attempt rather than once per trigger
+			if backoff == nil {
+				backoff = time.After(child.computeBackoff())
 			}
-			continue
-		case <-time.After(child.computeBackoff()):
+		case <-backoff:
+			backoff = nil
 			if child.broker != nil {
 				child.consumer.unrefBrokerConsumer(child.broker)
 				child.broker = nil
 			}
-
 			if err := child.dispatch(); err != nil {
 				select {
 				case <-child.dispatcherStop:
 					return
 				case <-child.dying:
-					continue
+					return
 				default:
 					child.sendError(err)
 					child.triggerRedispatch()
 				}
 			}
 		}
+	}
+}
+
+// waitForBrokerHandover blocks until the brokerConsumer releases the current
+// subscription, so the deferred close(feeder) cannot race an in-flight
+// write to the feeder from subscriptionConsumer.
+func (child *partitionConsumer) waitForBrokerHandover() {
+	if child.broker == nil {
+		return
+	}
+	select {
+	case <-child.dispatcherStop:
+	case <-child.brokerSubscription.released:
 	}
 }
 
@@ -579,10 +614,12 @@ func (child *partitionConsumer) dispatch() error {
 	child.leaderEpoch = epoch
 	for {
 		child.broker = child.consumer.refBrokerConsumer(broker)
-		if child.broker.queueSubscription(child) {
+		child.brokerSubscription = newBrokerSubscription(child)
+		if child.broker.queueSubscription(child.brokerSubscription) {
 			return nil
 		}
 
+		child.brokerSubscription.release()
 		child.consumer.unrefBrokerConsumer(child.broker)
 	}
 }
@@ -627,11 +664,6 @@ func (child *partitionConsumer) AsyncClose() {
 	// dispatcher shut itself down, which eventually closes messages and errors
 	child.closeOnce.Do(func() {
 		close(child.dying)
-
-		select {
-		case child.trigger <- none{}:
-		default:
-		}
 	})
 }
 
@@ -661,6 +693,7 @@ func (child *partitionConsumer) responseFeeder() {
 feederLoop:
 	for feederResponse := range child.feeder {
 		broker := feederResponse.broker
+		subscription := feederResponse.subscription
 
 		msgs, child.responseResult = child.parseResponse(feederResponse.response)
 
@@ -690,7 +723,10 @@ feederLoop:
 							break remainingLoop
 						}
 					}
-					if !broker.queueSubscription(child) {
+					if !broker.queueSubscription(subscription) {
+						// the broker is shutting down; release so any waiter on
+						// the dispatcher side can make progress
+						subscription.release()
 						child.triggerRedispatch()
 					}
 					continue feederLoop
@@ -945,9 +981,9 @@ func (child *partitionConsumer) IsPaused() bool {
 type brokerConsumer struct {
 	consumer         *consumer
 	broker           *Broker
-	input            chan *partitionConsumer
-	newSubscriptions chan []*partitionConsumer
-	subscriptions    map[*partitionConsumer]none
+	input            chan *brokerSubscription
+	newSubscriptions chan []*brokerSubscription
+	subscriptions    map[*partitionConsumer]*brokerSubscription
 	acks             sync.WaitGroup
 	refs             int
 	stop             chan none
@@ -958,9 +994,9 @@ func (c *consumer) newBrokerConsumer(broker *Broker) *brokerConsumer {
 	bc := &brokerConsumer{
 		consumer:         c,
 		broker:           broker,
-		input:            make(chan *partitionConsumer),
-		newSubscriptions: make(chan []*partitionConsumer),
-		subscriptions:    make(map[*partitionConsumer]none),
+		input:            make(chan *brokerSubscription),
+		newSubscriptions: make(chan []*brokerSubscription),
+		subscriptions:    make(map[*partitionConsumer]*brokerSubscription),
 		refs:             0,
 		stop:             make(chan none),
 	}
@@ -979,7 +1015,7 @@ func (bc *brokerConsumer) subscriptionManager() {
 	defer close(bc.newSubscriptions)
 
 	for {
-		var partitionConsumers []*partitionConsumer
+		var subscriptions []*brokerSubscription
 		stopping := false
 
 		// Check for any partition consumer asking to subscribe if there aren't
@@ -988,11 +1024,11 @@ func (bc *brokerConsumer) subscriptionManager() {
 		select {
 		case <-bc.stop:
 			return
-		case pc, ok := <-bc.input:
+		case subscription, ok := <-bc.input:
 			if !ok {
 				return
 			}
-			partitionConsumers = append(partitionConsumers, pc)
+			subscriptions = append(subscriptions, subscription)
 		case bc.newSubscriptions <- nil:
 			continue
 		}
@@ -1005,13 +1041,13 @@ func (bc *brokerConsumer) subscriptionManager() {
 			case <-bc.stop:
 				stopping = true
 				batchComplete = true
-			case pc, ok := <-bc.input:
+			case subscription, ok := <-bc.input:
 				if !ok {
 					inputClosed = true
 					batchComplete = true
 					continue
 				}
-				partitionConsumers = append(partitionConsumers, pc)
+				subscriptions = append(subscriptions, subscription)
 			case <-timer.C:
 				batchComplete = true
 			}
@@ -1020,9 +1056,9 @@ func (bc *brokerConsumer) subscriptionManager() {
 
 		Logger.Printf(
 			"consumer/broker/%d accumulated %d new subscriptions\n",
-			bc.broker.ID(), len(partitionConsumers))
+			bc.broker.ID(), len(subscriptions))
 
-		bc.newSubscriptions <- partitionConsumers
+		bc.newSubscriptions <- subscriptions
 		if inputClosed || stopping {
 			return
 		}
@@ -1057,11 +1093,11 @@ func (bc *brokerConsumer) subscriptionConsumer() {
 		}
 
 		bc.acks.Add(len(bc.subscriptions))
-		for child := range bc.subscriptions {
+		for child, subscription := range bc.subscriptions {
 			select {
 			case <-child.dying:
 				Logger.Printf("consumer/broker/%d closed dead subscription to %s/%d\n", bc.broker.ID(), child.topic, child.partition)
-				delete(bc.subscriptions, child)
+				bc.releaseSubscription(child)
 				child.stopDispatcher()
 				bc.acks.Done()
 				continue
@@ -1079,8 +1115,9 @@ func (bc *brokerConsumer) subscriptionConsumer() {
 			}
 
 			child.feeder <- &partitionConsumerResponse{
-				broker:   bc,
-				response: response,
+				broker:       bc,
+				subscription: subscription,
+				response:     response,
 			}
 		}
 		bc.acks.Wait()
@@ -1088,9 +1125,10 @@ func (bc *brokerConsumer) subscriptionConsumer() {
 	}
 }
 
-func (bc *brokerConsumer) updateSubscriptions(newSubscriptions []*partitionConsumer) {
-	for _, child := range newSubscriptions {
-		bc.subscriptions[child] = none{}
+func (bc *brokerConsumer) updateSubscriptions(newSubscriptions []*brokerSubscription) {
+	for _, subscription := range newSubscriptions {
+		child := subscription.child
+		bc.subscriptions[child] = subscription
 		Logger.Printf("consumer/broker/%d added subscription to %s/%d\n", bc.broker.ID(), child.topic, child.partition)
 	}
 
@@ -1098,7 +1136,7 @@ func (bc *brokerConsumer) updateSubscriptions(newSubscriptions []*partitionConsu
 		select {
 		case <-child.dying:
 			Logger.Printf("consumer/broker/%d closed dead subscription to %s/%d\n", bc.broker.ID(), child.topic, child.partition)
-			delete(bc.subscriptions, child)
+			bc.releaseSubscription(child)
 			child.stopDispatcher()
 		default:
 			// no-op
@@ -1111,7 +1149,7 @@ func (bc *brokerConsumer) handleResponses() {
 	for child := range bc.subscriptions {
 		select {
 		case <-child.dying:
-			delete(bc.subscriptions, child)
+			bc.releaseSubscription(child)
 			child.stopDispatcher()
 			continue
 		default:
@@ -1128,7 +1166,7 @@ func (bc *brokerConsumer) handleResponses() {
 						"consumer/broker/%d abandoned in favor of preferred replica broker/%d\n",
 						bc.broker.ID(), preferredBroker.ID())
 					child.triggerRedispatch()
-					delete(bc.subscriptions, child)
+					bc.releaseSubscription(child)
 				}
 			}
 			continue
@@ -1140,6 +1178,9 @@ func (bc *brokerConsumer) handleResponses() {
 		if errors.Is(result, errTimedOut) {
 			Logger.Printf("consumer/broker/%d abandoned subscription to %s/%d because consuming was taking too long\n",
 				bc.broker.ID(), child.topic, child.partition)
+			// responseFeeder already requeued this subscription onto bc.input
+			// so it will loop back through subscriptionManager so no need to
+			// release it here
 			delete(bc.subscriptions, child)
 		} else if errors.Is(result, ErrOffsetOutOfRange) {
 			// there's no point in retrying this it will just fail the same way again
@@ -1148,7 +1189,7 @@ func (bc *brokerConsumer) handleResponses() {
 			Logger.Printf("consumer/%s/%d shutting down because %s\n", child.topic, child.partition, result)
 			child.stopDispatcher()
 			child.AsyncClose()
-			delete(bc.subscriptions, child)
+			bc.releaseSubscription(child)
 		} else if errors.Is(result, ErrUnknownTopicOrPartition) ||
 			errors.Is(result, ErrNotLeaderForPartition) ||
 			errors.Is(result, ErrLeaderNotAvailable) ||
@@ -1159,14 +1200,14 @@ func (bc *brokerConsumer) handleResponses() {
 			Logger.Printf("consumer/broker/%d abandoned subscription to %s/%d because %s\n",
 				bc.broker.ID(), child.topic, child.partition, result)
 			child.triggerRedispatch()
-			delete(bc.subscriptions, child)
+			bc.releaseSubscription(child)
 		} else {
 			// dunno, tell the user and try redispatching
 			child.sendError(result)
 			Logger.Printf("consumer/broker/%d abandoned subscription to %s/%d because %s\n",
 				bc.broker.ID(), child.topic, child.partition, result)
 			child.triggerRedispatch()
-			delete(bc.subscriptions, child)
+			bc.releaseSubscription(child)
 		}
 	}
 }
@@ -1177,6 +1218,7 @@ func (bc *brokerConsumer) abort(err error) {
 	_ = bc.broker.Close() // we don't care about the error this might return, we already have one
 
 	for child := range bc.subscriptions {
+		bc.releaseSubscription(child)
 		select {
 		case <-child.dying:
 			child.stopDispatcher()
@@ -1186,7 +1228,9 @@ func (bc *brokerConsumer) abort(err error) {
 	}
 
 	for newSubscriptions := range bc.newSubscriptions {
-		for _, child := range newSubscriptions {
+		for _, subscription := range newSubscriptions {
+			child := subscription.child
+			subscription.release()
 			select {
 			case <-child.dying:
 				child.stopDispatcher()
@@ -1260,7 +1304,7 @@ func (bc *brokerConsumer) fetchNewMessages() (*FetchResponse, error) {
 	for child := range bc.subscriptions {
 		select {
 		case <-child.dying:
-			delete(bc.subscriptions, child)
+			bc.releaseSubscription(child)
 			child.stopDispatcher()
 			continue
 		default:
@@ -1285,11 +1329,18 @@ func (bc *brokerConsumer) stopConsuming() {
 	})
 }
 
-func (bc *brokerConsumer) queueSubscription(child *partitionConsumer) bool {
+func (bc *brokerConsumer) releaseSubscription(child *partitionConsumer) {
+	if subscription, ok := bc.subscriptions[child]; ok {
+		delete(bc.subscriptions, child)
+		subscription.release()
+	}
+}
+
+func (bc *brokerConsumer) queueSubscription(subscription *brokerSubscription) bool {
 	select {
 	case <-bc.stop:
 		return false
-	case bc.input <- child:
+	case bc.input <- subscription:
 		return true
 	}
 }

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1719,7 +1719,7 @@ func TestPartitionConsumerBrokerRace(t *testing.T) {
 	config.Consumer.MaxProcessingTime = time.Hour
 
 	broker := &brokerConsumer{
-		input: make(chan *partitionConsumer, 1),
+		input: make(chan *brokerSubscription, 1),
 		stop:  make(chan none),
 	}
 
@@ -1736,6 +1736,7 @@ func TestPartitionConsumerBrokerRace(t *testing.T) {
 		partition:      0,
 		fetchSize:      config.Consumer.Fetch.Default,
 	}
+	child.brokerSubscription = newBrokerSubscription(child)
 
 	response := &FetchResponse{}
 	response.AddMessage("my_topic", 0, nil, testMsg, 0)
@@ -1770,8 +1771,9 @@ func TestPartitionConsumerBrokerRace(t *testing.T) {
 	for range iterations {
 		broker.acks.Add(1)
 		child.feeder <- &partitionConsumerResponse{
-			broker:   broker,
-			response: response,
+			broker:       broker,
+			subscription: child.brokerSubscription,
+			response:     response,
 		}
 	}
 
@@ -1780,6 +1782,73 @@ func TestPartitionConsumerBrokerRace(t *testing.T) {
 
 	<-feederDone
 	<-messagesDone
+}
+
+// TestPartitionConsumerDispatcherOrphanedClose verifies the dispatcher exits
+// after AsyncClose when the brokerConsumer has detached this child from its
+// subscriptions and there is a pending redispatch on the trigger channel.
+func TestPartitionConsumerDispatcherOrphanedClose(t *testing.T) {
+	newOrphan := func() *partitionConsumer {
+		config := NewTestConfig()
+		config.Consumer.Retry.Backoff = time.Hour
+		config.Consumer.MaxWaitTime = 50 * time.Millisecond
+
+		c := &consumer{
+			conf:            config,
+			children:        make(map[string]map[int32]*partitionConsumer),
+			brokerConsumers: make(map[*Broker]*brokerConsumer),
+		}
+		bc := &brokerConsumer{consumer: c, input: make(chan *brokerSubscription), refs: 1}
+		child := &partitionConsumer{
+			consumer:       c,
+			conf:           config,
+			broker:         bc,
+			feeder:         make(chan *partitionConsumerResponse, 1),
+			trigger:        make(chan none, 1),
+			dying:          make(chan none),
+			dispatcherStop: make(chan none),
+		}
+		child.brokerSubscription = newBrokerSubscription(child)
+		return child
+	}
+
+	runDispatcher := func(t *testing.T, child *partitionConsumer) {
+		t.Helper()
+		done := make(chan none)
+		go func() {
+			defer close(done)
+			child.dispatcher()
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "dispatcher hung after AsyncClose on orphaned child")
+		}
+	}
+
+	t.Run("subscription released before dying", func(t *testing.T) {
+		child := newOrphan()
+		child.brokerSubscription.release()
+		child.triggerRedispatch()
+		close(child.dying)
+		runDispatcher(t, child)
+	})
+
+	t.Run("subscription released after dying", func(t *testing.T) {
+		child := newOrphan()
+		child.triggerRedispatch()
+		close(child.dying)
+		child.brokerSubscription.release()
+		runDispatcher(t, child)
+	})
+
+	t.Run("stopDispatcher unblocks waitForBrokerHandover", func(t *testing.T) {
+		child := newOrphan()
+		child.triggerRedispatch()
+		close(child.dying)
+		child.stopDispatcher()
+		runDispatcher(t, child)
+	})
 }
 
 func TestConsumerTimestamps(t *testing.T) {
@@ -2278,16 +2347,19 @@ func TestConsumerAbortNoGoroutineLeak(t *testing.T) {
 			metricRegistry:  newCleanupRegistry(config.MetricRegistry),
 		}
 		child.consumer = c
+		subscription := newBrokerSubscription(child)
 
 		bc := &brokerConsumer{
 			consumer:         c,
 			broker:           realBroker,
-			input:            make(chan *partitionConsumer),
-			newSubscriptions: make(chan []*partitionConsumer),
-			subscriptions:    map[*partitionConsumer]none{child: {}},
+			input:            make(chan *brokerSubscription),
+			newSubscriptions: make(chan []*brokerSubscription),
+			subscriptions:    map[*partitionConsumer]*brokerSubscription{child: subscription},
 			refs:             1,
 			stop:             make(chan none),
 		}
+		child.broker = bc
+		child.brokerSubscription = subscription
 		c.brokerConsumers[realBroker] = bc
 		return bc
 	}
@@ -2330,24 +2402,17 @@ func TestConsumerAbortNoGoroutineLeak(t *testing.T) {
 
 	t.Run("stops dispatcher for dying child", func(t *testing.T) {
 		child := newChild(config.ChannelBufferSize)
-		child.consumer = &consumer{
-			client:          client,
-			conf:            config,
-			children:        make(map[string]map[int32]*partitionConsumer),
-			brokerConsumers: make(map[*Broker]*brokerConsumer),
-			metricRegistry:  newCleanupRegistry(config.MetricRegistry),
-		}
-
-		// Start the dispatcher goroutine (it will block on <-child.trigger).
-		go child.dispatcher()
-
-		// Mark the child as dying (simulates AsyncClose during rebalance).
-		close(child.dying)
 
 		bc := newBrokerConsumer(child)
+
+		// simulate AsyncClose during rebalance
+		close(child.dying)
+
+		go child.dispatcher()
+
 		runAbort(t, bc)
 
-		// The dispatcher should have exited via stopDispatcher, closing feeder.
+		// the dispatcher should have exited, closing feeder.
 		select {
 		case _, ok := <-child.feeder:
 			require.False(t, ok, "feeder channel should be closed after dispatcher exits")
@@ -2415,7 +2480,7 @@ func TestConsumerAbortNoGoroutineLeak(t *testing.T) {
 
 		queued := make(chan bool, 1)
 		go func() {
-			queued <- bc.queueSubscription(newChild(config.ChannelBufferSize))
+			queued <- bc.queueSubscription(newBrokerSubscription(newChild(config.ChannelBufferSize)))
 		}()
 
 		select {


### PR DESCRIPTION
When AsyncClose ran concurrently with subscriptionConsumer dispatching a fetch response, the dispatcher could exit and close(feeder) while subscriptionConsumer still had a write in flight, panicking on a send to a closed channel.

Introduce brokerSubscription as an explicit handover handle: each subscription carries a released channel that the brokerConsumer closes when it drops the subscription from its live set. The dispatcher waits on this channel before closing the feeder, so the brokerConsumer is guaranteed to have stopped writing first.

Also restructure the dispatcher so dying is a top-level select case rather than nested under trigger.

This _should_ prevent a bunch of the remaining FVT flakes from failing periodically.