### PR TITLE
test(fvt): speedup functional test runs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,9 +73,9 @@ services:
     container_name: 'kafka-1'
     healthcheck:
       test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-1:9091']
-      interval: 15s
+      interval: 5s
       timeout: 15s
-      retries: 10
+      retries: 30
       start_period: 360s
     environment:
       <<: *kafka-base-env
@@ -90,9 +90,9 @@ services:
     container_name: 'kafka-2'
     healthcheck:
       test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-2:9091']
-      interval: 15s
+      interval: 5s
       timeout: 15s
-      retries: 10
+      retries: 30
       start_period: 360s
     environment:
       <<: *kafka-base-env
@@ -107,9 +107,9 @@ services:
     container_name: 'kafka-3'
     healthcheck:
       test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-3:9091']
-      interval: 15s
+      interval: 5s
       timeout: 15s
-      retries: 10
+      retries: 30
       start_period: 360s
     environment:
       <<: *kafka-base-env
@@ -124,9 +124,9 @@ services:
     container_name: 'kafka-4'
     healthcheck:
       test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-4:9091']
-      interval: 15s
+      interval: 5s
       timeout: 15s
-      retries: 10
+      retries: 30
       start_period: 360s
     environment:
       <<: *kafka-base-env
@@ -141,9 +141,9 @@ services:
     container_name: 'kafka-5'
     healthcheck:
       test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-5:9091']
-      interval: 15s
+      interval: 5s
       timeout: 15s
-      retries: 10
+      retries: 30
       start_period: 360s
     environment:
       <<: *kafka-base-env

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -122,6 +122,7 @@ func listOffsetsAndValidate(
 }
 
 func TestFuncAdminQuotas(t *testing.T) {
+	t.Parallel()
 	const (
 		waitFor = 10 * time.Second
 		tick    = 100 * time.Millisecond
@@ -252,6 +253,7 @@ func TestFuncAdminQuotas(t *testing.T) {
 }
 
 func TestFuncAdminDescribeGroups(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.3.0.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -309,6 +311,7 @@ func TestFuncAdminDescribeGroups(t *testing.T) {
 }
 
 func TestFuncAdminListConsumerGroups(t *testing.T) {
+	t.Parallel()
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
 
@@ -424,6 +427,7 @@ func TestFuncAdminListConsumerGroupOffsets(t *testing.T) {
 }
 
 func TestFuncAdminListOffsets(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.1.0.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -496,6 +500,7 @@ func TestFuncAdminListOffsets(t *testing.T) {
 }
 
 func TestFuncAdminAlterConsumerGroupOffsets(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.1.0.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -546,6 +551,7 @@ func TestFuncAdminAlterConsumerGroupOffsets(t *testing.T) {
 }
 
 func TestFuncAdminDescribeLogDirs(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.0.0.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -588,6 +594,7 @@ func TestFuncAdminDescribeLogDirs(t *testing.T) {
 }
 
 func TestFuncAdminDeleteGroup(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.4.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -638,6 +645,7 @@ func TestFuncAdminDeleteGroup(t *testing.T) {
 }
 
 func TestFuncAdminDeleteTopic(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "0.10.0.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -663,6 +671,7 @@ func TestFuncAdminDeleteTopic(t *testing.T) {
 // newer broker for the ElectLeaders V1 non-flexible path. See
 // https://github.com/IBM/sarama/pull/3312.
 func TestFuncAdminElectLeadersV1(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.3.0.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -705,6 +714,7 @@ func TestFuncAdminElectLeadersV1(t *testing.T) {
 }
 
 func TestFuncAdminIncrementalAlterConfigs(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.3.0.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -398,9 +398,9 @@ func defaultConfig(clientID string) *Config {
 	config.ClientID = clientID
 	config.Consumer.Return.Errors = true
 	config.Consumer.Offsets.Initial = OffsetOldest
-	config.Consumer.Group.Rebalance.Timeout = 30 * time.Second
-	config.Consumer.Group.Session.Timeout = 20 * time.Second
-	config.Consumer.Group.Heartbeat.Interval = 5 * time.Second
+	config.Consumer.Group.Rebalance.Timeout = 6 * time.Second
+	config.Consumer.Group.Session.Timeout = 6 * time.Second
+	config.Consumer.Group.Heartbeat.Interval = 2 * time.Second
 	config.Metadata.Full = false
 	config.Metadata.RefreshFrequency = 10 * time.Second
 	return config

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -194,7 +194,7 @@ func TestFuncConsumerGroupFuzzy(t *testing.T) {
 	}
 
 	groupID := testFuncConsumerGroupID(t)
-	sink := &testFuncConsumerGroupSink{msgs: make(chan testFuncConsumerGroupMessage, 30000)}
+	sink := &testFuncConsumerGroupSink{msgs: make(chan testFuncConsumerGroupMessage, 10000)}
 	waitForMessages := func(t *testing.T, n int) {
 		const (
 			waitFor = 60 * time.Second
@@ -206,37 +206,37 @@ func TestFuncConsumerGroupFuzzy(t *testing.T) {
 		}, waitFor, tick, "expected to consume %d messages, but consumed %d", n, sink.Len())
 	}
 
-	defer runTestFuncConsumerGroupMember(t, groupID, "M1", 1500, sink).Stop()
-	defer runTestFuncConsumerGroupMember(t, groupID, "M2", 3000, sink).Stop()
-	defer runTestFuncConsumerGroupMember(t, groupID, "M3", 1500, sink).Stop()
-	defer runTestFuncConsumerGroupMember(t, groupID, "M4", 200, sink).Stop()
-	defer runTestFuncConsumerGroupMember(t, groupID, "M5", 100, sink).Stop()
-	waitForMessages(t, 3000)
+	defer runTestFuncConsumerGroupMember(t, groupID, "M1", 500, sink).Stop()
+	defer runTestFuncConsumerGroupMember(t, groupID, "M2", 1000, sink).Stop()
+	defer runTestFuncConsumerGroupMember(t, groupID, "M3", 500, sink).Stop()
+	defer runTestFuncConsumerGroupMember(t, groupID, "M4", 70, sink).Stop()
+	defer runTestFuncConsumerGroupMember(t, groupID, "M5", 35, sink).Stop()
+	waitForMessages(t, 1000)
 
-	defer runTestFuncConsumerGroupMember(t, groupID, "M6", 300, sink).Stop()
-	defer runTestFuncConsumerGroupMember(t, groupID, "M7", 400, sink).Stop()
-	defer runTestFuncConsumerGroupMember(t, groupID, "M8", 500, sink).Stop()
-	defer runTestFuncConsumerGroupMember(t, groupID, "M9", 2000, sink).Stop()
-	waitForMessages(t, 8000)
+	defer runTestFuncConsumerGroupMember(t, groupID, "M6", 100, sink).Stop()
+	defer runTestFuncConsumerGroupMember(t, groupID, "M7", 135, sink).Stop()
+	defer runTestFuncConsumerGroupMember(t, groupID, "M8", 170, sink).Stop()
+	defer runTestFuncConsumerGroupMember(t, groupID, "M9", 670, sink).Stop()
+	waitForMessages(t, 2700)
 
-	defer runTestFuncConsumerGroupMember(t, groupID, "M10", 1000, sink).Stop()
-	waitForMessages(t, 10000)
+	defer runTestFuncConsumerGroupMember(t, groupID, "M10", 335, sink).Stop()
+	waitForMessages(t, 3300)
 
-	defer runTestFuncConsumerGroupMember(t, groupID, "M11", 1000, sink).Stop()
-	defer runTestFuncConsumerGroupMember(t, groupID, "M12", 2500, sink).Stop()
-	waitForMessages(t, 12000)
+	defer runTestFuncConsumerGroupMember(t, groupID, "M11", 335, sink).Stop()
+	defer runTestFuncConsumerGroupMember(t, groupID, "M12", 830, sink).Stop()
+	waitForMessages(t, 4000)
 
-	defer runTestFuncConsumerGroupMember(t, groupID, "M13", 1000, sink).Stop()
-	waitForMessages(t, 15000)
+	defer runTestFuncConsumerGroupMember(t, groupID, "M13", 320, sink).Stop()
+	waitForMessages(t, 5000)
 
-	if umap := sink.Close(); len(umap) != 15000 {
+	if umap := sink.Close(); len(umap) != 5000 {
 		dupes := make(map[string][]string)
 		for k, v := range umap {
 			if len(v) > 1 {
 				dupes[k] = v
 			}
 		}
-		t.Fatalf("expected %d unique messages to be consumed but got %d, including %d duplicates:\n%v", 15000, len(umap), len(dupes), dupes)
+		t.Fatalf("expected %d unique messages to be consumed but got %d, including %d duplicates:\n%v", 5000, len(umap), len(dupes), dupes)
 	}
 }
 
@@ -332,7 +332,7 @@ func testFuncConsumerGroupFuzzySeed(topic string) error {
 		}
 		total = total + newest - oldest
 	}
-	if total >= 21000 {
+	if total >= 7000 {
 		return nil
 	}
 
@@ -340,7 +340,7 @@ func testFuncConsumerGroupFuzzySeed(topic string) error {
 	if err != nil {
 		return err
 	}
-	for i := total; i < 21000; i++ {
+	for i := total; i < 7000; i++ {
 		producer.Input() <- &ProducerMessage{Topic: topic, Value: ByteEncoder([]byte("testdata"))}
 	}
 	return producer.Close()

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestFuncConsumerGroupPartitioning(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "0.10.2")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -52,6 +53,7 @@ func TestFuncConsumerGroupPartitioning(t *testing.T) {
 }
 
 func TestFuncConsumerGroupPartitioningStateful(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "0.10.2")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -97,6 +99,7 @@ func TestFuncConsumerGroupPartitioningStateful(t *testing.T) {
 }
 
 func TestFuncConsumerGroupExcessConsumers(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "0.10.2")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -181,6 +184,7 @@ func TestFuncConsumerGroupRebalanceAfterAddingPartitions(t *testing.T) {
 }
 
 func TestFuncConsumerGroupFuzzy(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "0.10.2")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -237,6 +241,7 @@ func TestFuncConsumerGroupFuzzy(t *testing.T) {
 }
 
 func TestFuncConsumerGroupOffsetDeletion(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.4.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)

--- a/functional_consumer_staticmembership_test.go
+++ b/functional_consumer_staticmembership_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestFuncConsumerGroupStaticMembership_Basic(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.3.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -65,6 +66,7 @@ func TestFuncConsumerGroupStaticMembership_Basic(t *testing.T) {
 }
 
 func TestFuncConsumerGroupStaticMembership_RejoinAndLeave(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.4.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
@@ -165,6 +167,7 @@ func TestFuncConsumerGroupStaticMembership_RejoinAndLeave(t *testing.T) {
 }
 
 func TestFuncConsumerGroupStaticMembership_Fenced(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "2.3.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)

--- a/functional_offset_manager_test.go
+++ b/functional_offset_manager_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestFuncOffsetManager(t *testing.T) {
+	t.Parallel()
 	checkKafkaVersion(t, "0.8.2")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)

--- a/functional_test.go
+++ b/functional_test.go
@@ -193,14 +193,13 @@ func prepareDockerTestEnvironment(ctx context.Context, env *testEnvironment) err
 	allBrokersUp := false
 
 	Logger.Printf("waiting for kafka %s brokers to come up...\n", env.KafkaVersion)
-	time.Sleep(10 * time.Second)
 
 mainLoop:
-	for i := 0; i < 30 && !allBrokersUp; i++ {
+	for i := 0; i < 90 && !allBrokersUp; i++ {
 		if i > 0 {
 			Logger.Printf("still waiting for kafka %s brokers to come up...\n", env.KafkaVersion)
+			time.Sleep(time.Second)
 		}
-		time.Sleep(3 * time.Second)
 		brokersOk := make([]bool, len(env.KafkaBrokerAddrs))
 
 		// first check that all bootstrap brokers are TCP accessible
@@ -377,8 +376,8 @@ func prepareTestTopics(ctx context.Context, env *testEnvironment) error {
 	{
 		var topicsOk bool
 		request := NewMetadataRequest(config.Version, testTopicNames)
-		for i := 0; i < 60 && !topicsOk; i++ {
-			time.Sleep(1 * time.Second)
+		for i := 0; i < 600 && !topicsOk; i++ {
+			time.Sleep(100 * time.Millisecond)
 			md, err := controller.GetMetadata(request)
 			if err != nil {
 				return fmt.Errorf("failed to get metadata for test topics: %w", err)
@@ -417,8 +416,8 @@ func prepareTestTopics(ctx context.Context, env *testEnvironment) error {
 	{
 		var topicsOk bool
 		request := NewMetadataRequest(config.Version, testTopicNames)
-		for i := 0; i < 60 && !topicsOk; i++ {
-			time.Sleep(1 * time.Second)
+		for i := 0; i < 600 && !topicsOk; i++ {
+			time.Sleep(100 * time.Millisecond)
 			md, err := controller.GetMetadata(request)
 			if err != nil {
 				return fmt.Errorf("failed to get metadata for test topics: %w", err)


### PR DESCRIPTION
A few commits to try and see if we can bring down the execution times for our FVTs as they consistently exceed 10-12 minutes each nowadays.