### PR TITLE
fix(client): scope metadata refresh errors to requested topics

### DIFF
--- a/client.go
+++ b/client.go
@@ -1073,9 +1073,9 @@ func (client *client) tryRefreshMetadata(topics []string, attemptsRemaining int,
 }
 
 // if no fatal error, returns a list of topics that need retrying due to ErrLeaderNotAvailable
-func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bool) (retry bool, err error) {
+func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bool) (bool, error) {
 	if client.Closed() {
-		return
+		return false, nil
 	}
 
 	client.lock.Lock()
@@ -1103,6 +1103,8 @@ func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bo
 		client.metadataTopics = make(map[string]none)
 		client.cachedPartitionsResults = make(map[string][maxPartitionIndex][]int32)
 	}
+	topicErrs := refreshError{}
+	retry := false
 	for _, topic := range data.Topics {
 		// topics must be added firstly to `metadataTopics` to guarantee that all
 		// requested topics must be recorded to keep them trackable for periodically
@@ -1117,18 +1119,18 @@ func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bo
 		case ErrNoError:
 			// no-op
 		case ErrInvalidTopic, ErrTopicAuthorizationFailed: // don't retry, don't store partial results
-			err = topic.Err
+			topicErrs[topic.Name] = topic.Err
 			continue
 		case ErrUnknownTopicOrPartition: // retry, do not store partial partition results
-			err = topic.Err
+			topicErrs[topic.Name] = topic.Err
 			retry = true
 			continue
 		case ErrLeaderNotAvailable: // retry, but store partial partition results
-			err = topic.Err
+			topicErrs[topic.Name] = topic.Err
 			retry = true
 		default: // don't retry, don't store partial results
 			Logger.Printf("Unexpected topic-level metadata error: %s", topic.Err)
-			err = topic.Err
+			topicErrs[topic.Name] = topic.Err
 			continue
 		}
 
@@ -1136,7 +1138,7 @@ func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bo
 		for _, partition := range topic.Partitions {
 			client.metadata[topic.Name][partition.ID] = partition
 			if errors.Is(partition.Err, ErrLeaderNotAvailable) {
-				err = partition.Err
+				topicErrs[topic.Name] = partition.Err
 				retry = true
 			}
 		}
@@ -1147,7 +1149,10 @@ func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bo
 		client.cachedPartitionsResults[topic.Name] = partitionCache
 	}
 
-	return
+	if len(topicErrs) == 0 {
+		return retry, nil
+	}
+	return retry, topicErrs
 }
 
 func (client *client) cachedCoordinator(consumerGroup string) *Broker {

--- a/client.go
+++ b/client.go
@@ -1103,7 +1103,7 @@ func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bo
 		client.metadataTopics = make(map[string]none)
 		client.cachedPartitionsResults = make(map[string][maxPartitionIndex][]int32)
 	}
-	topicErrs := refreshError{}
+	topicErrs := make(refreshError)
 	retry := false
 	for _, topic := range data.Topics {
 		// topics must be added firstly to `metadataTopics` to guarantee that all

--- a/client.go
+++ b/client.go
@@ -1119,18 +1119,18 @@ func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bo
 		case ErrNoError:
 			// no-op
 		case ErrInvalidTopic, ErrTopicAuthorizationFailed: // don't retry, don't store partial results
-			topicErrs[topic.Name] = topic.Err
+			topicErrs.addError(topic.Name, topic.Err)
 			continue
 		case ErrUnknownTopicOrPartition: // retry, do not store partial partition results
-			topicErrs[topic.Name] = topic.Err
+			topicErrs.addError(topic.Name, topic.Err)
 			retry = true
 			continue
 		case ErrLeaderNotAvailable: // retry, but store partial partition results
-			topicErrs[topic.Name] = topic.Err
+			topicErrs.addError(topic.Name, topic.Err)
 			retry = true
 		default: // don't retry, don't store partial results
 			Logger.Printf("Unexpected topic-level metadata error: %s", topic.Err)
-			topicErrs[topic.Name] = topic.Err
+			topicErrs.addError(topic.Name, topic.Err)
 			continue
 		}
 
@@ -1138,7 +1138,7 @@ func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bo
 		for _, partition := range topic.Partitions {
 			client.metadata[topic.Name][partition.ID] = partition
 			if errors.Is(partition.Err, ErrLeaderNotAvailable) {
-				topicErrs[topic.Name] = partition.Err
+				topicErrs.addError(topic.Name, partition.Err)
 				retry = true
 			}
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -1118,14 +1118,12 @@ func TestClientRefreshesMetadataConcurrently(t *testing.T) {
 	seedBroker := NewMockBroker(t, 1)
 
 	seedBroker.setHandler(func(req *request) (res encoderWithHeader) {
-		time.Sleep(10 * time.Millisecond)
-		if req.body.key() != 3 {
-			t.Error("this test sends only Metadata requests")
-			return
+		mr, ok := req.body.(*MetadataRequest)
+		if !ok {
+			return nil
 		}
-		topics := req.body.(*MetadataRequest).Topics
 		resp := new(MetadataResponse)
-		for _, topic := range topics {
+		for _, topic := range mr.Topics {
 			switch topic {
 			case "topic1":
 				resp.Topics = append(resp.Topics, &TopicMetadata{
@@ -1156,17 +1154,16 @@ func TestClientRefreshesMetadataConcurrently(t *testing.T) {
 	config := NewTestConfig()
 	config.Metadata.SingleFlight = true
 	client, err := NewClient([]string{seedBroker.Addr()}, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
+
 	var waitGroup sync.WaitGroup
-	waitGroup.Add(1000)
-	for i := 0; i < 1000; i++ {
+	waitGroup.Add(100)
+	for i := 0; i < 100; i++ {
 		go func() {
 			defer waitGroup.Done()
 			assert.NoError(t, client.RefreshMetadata("topic1"))
 			assert.NoError(t, client.RefreshMetadata("topic2"))
-			assert.Error(t, client.RefreshMetadata("topic3"))
+			assert.ErrorIs(t, client.RefreshMetadata("topic3"), ErrUnknownTopicOrPartition)
 			topics, err := client.Topics()
 			assert.NoError(t, err)
 			assert.Len(t, topics, 2)

--- a/metadata.go
+++ b/metadata.go
@@ -2,6 +2,7 @@ package sarama
 
 import (
 	"errors"
+	"fmt"
 	"maps"
 	"slices"
 	"sync"
@@ -30,14 +31,22 @@ func (e refreshError) forTopics(topics []string) error {
 	errs := make([]error, 0, len(topics))
 	for _, topic := range topics {
 		if err, ok := e[topic]; ok {
-			errs = append(errs, err)
+			errs = append(errs, fmt.Errorf("%s: %w", topic, err))
 		}
 	}
 	return errors.Join(errs...)
 }
 
+// errors returns the per-topic errors in deterministic (sorted by topic) order,
+// each wrapped so its string carries the topic name. The wrap preserves the
+// underlying error for errors.Is/As.
 func (e refreshError) errors() []error {
-	return slices.Collect(maps.Values(e))
+	topics := slices.Sorted(maps.Keys(e))
+	errs := make([]error, len(topics))
+	for i, topic := range topics {
+		errs[i] = fmt.Errorf("%s: %w", topic, e[topic])
+	}
+	return errs
 }
 
 func errorForTopics(topics []string, err error) error {

--- a/metadata.go
+++ b/metadata.go
@@ -12,6 +12,12 @@ type metadataRefresh func(topics []string) error
 
 type refreshError map[string]error
 
+// addError adds an error for a topic to the set. The wrap preserves
+// the underlying error for errors.Is/As.
+func (e refreshError) addError(topic string, err error) {
+	e[topic] = fmt.Errorf("%s: %w", topic, err)
+}
+
 func (e refreshError) Error() string {
 	err := errors.Join(e.errors()...)
 	if err == nil {
@@ -31,20 +37,18 @@ func (e refreshError) forTopics(topics []string) error {
 	errs := make([]error, 0, len(topics))
 	for _, topic := range topics {
 		if err, ok := e[topic]; ok {
-			errs = append(errs, fmt.Errorf("%s: %w", topic, err))
+			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
 }
 
-// errors returns the per-topic errors in deterministic (sorted by topic) order,
-// each wrapped so its string carries the topic name. The wrap preserves the
-// underlying error for errors.Is/As.
+// errors returns the per-topic errors in deterministic (sorted by topic) order.
 func (e refreshError) errors() []error {
 	topics := slices.Sorted(maps.Keys(e))
 	errs := make([]error, len(topics))
 	for i, topic := range topics {
-		errs[i] = fmt.Errorf("%s: %w", topic, e[topic])
+		errs[i] = e[topic]
 	}
 	return errs
 }

--- a/metadata.go
+++ b/metadata.go
@@ -1,10 +1,55 @@
 package sarama
 
 import (
+	"errors"
+	"maps"
+	"slices"
 	"sync"
 )
 
 type metadataRefresh func(topics []string) error
+
+type refreshError map[string]error
+
+func (e refreshError) Error() string {
+	err := errors.Join(e.errors()...)
+	if err == nil {
+		return "metadata refresh failed"
+	}
+	return err.Error()
+}
+
+func (e refreshError) Unwrap() []error {
+	return e.errors()
+}
+
+func (e refreshError) forTopics(topics []string) error {
+	if len(topics) == 0 {
+		return errors.Join(e.errors()...)
+	}
+	errs := make([]error, 0, len(topics))
+	for _, topic := range topics {
+		if err, ok := e[topic]; ok {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func (e refreshError) errors() []error {
+	return slices.Collect(maps.Values(e))
+}
+
+func errorForTopics(topics []string, err error) error {
+	if err == nil {
+		return nil
+	}
+	var re refreshError
+	if errors.As(err, &re) {
+		return re.forTopics(topics)
+	}
+	return err
+}
 
 // currentRefresh makes sure sarama does not issue metadata requests
 // in parallel. If we need to refresh the metadata for a list of topics,
@@ -178,11 +223,12 @@ func newMetadataRefresh(f func(topics []string) error) *singleFlightMetadataRefr
 // If a refresh was already ongoing for a different list of topics, the function
 // accumulates the list of topics to refresh in the next refresh, and queues that refresh.
 // If no refresh is ongoing, it will start a new refresh, and return its result.
+// Per-topic errors from a shared refresh are filtered to the topics the caller requested.
 func (m *singleFlightMetadataRefresher) Refresh(topics []string) error {
 	for {
 		ch, queued := m.refreshOrQueue(topics)
 		if !queued {
-			return <-ch
+			return errorForTopics(topics, <-ch)
 		}
 		<-ch
 	}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -101,3 +101,36 @@ func TestMetadataRefreshConcurrency(t *testing.T) {
 	require.NoError(t, <-ch)
 	require.NoError(t, <-ch2)
 }
+
+func TestMetadataRefreshFiltersSharedTopicErrors(t *testing.T) {
+	t.Run("returns only the errors for the requested topics", func(t *testing.T) {
+		err := refreshError{
+			"topic1": ErrInvalidTopic,
+			"topic2": ErrUnknownTopicOrPartition,
+			"topic3": ErrLeaderNotAvailable,
+		}.forTopics([]string{"topic1", "topic3"})
+
+		require.ErrorIs(t, err, ErrInvalidTopic)
+		require.NotErrorIs(t, err, ErrUnknownTopicOrPartition)
+		require.ErrorIs(t, err, ErrLeaderNotAvailable)
+	})
+
+	t.Run("piggy-backed callers only see errors for their topics", func(t *testing.T) {
+		block := make(chan struct{})
+		refresh := newMetadataRefresh(func(topics []string) error {
+			<-block
+			return refreshError{"topic3": ErrUnknownTopicOrPartition}
+		})
+
+		// the first call starts an in-flight refresh covering all three
+		// topics; the next two piggy-back on it for subsets of those topics
+		batched, _ := refresh.refreshOrQueue([]string{"topic1", "topic2", "topic3"})
+		topic1, _ := refresh.refreshOrQueue([]string{"topic1"})
+		topic2, _ := refresh.refreshOrQueue([]string{"topic2"})
+		close(block)
+
+		require.ErrorIs(t, errorForTopics([]string{"topic1", "topic2", "topic3"}, <-batched), ErrUnknownTopicOrPartition)
+		require.NoError(t, errorForTopics([]string{"topic1"}, <-topic1))
+		require.NoError(t, errorForTopics([]string{"topic2"}, <-topic2))
+	})
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -104,11 +104,11 @@ func TestMetadataRefreshConcurrency(t *testing.T) {
 
 func TestMetadataRefreshFiltersSharedTopicErrors(t *testing.T) {
 	t.Run("returns only the errors for the requested topics", func(t *testing.T) {
-		err := refreshError{
-			"topic1": ErrInvalidTopic,
-			"topic2": ErrUnknownTopicOrPartition,
-			"topic3": ErrLeaderNotAvailable,
-		}.forTopics([]string{"topic1", "topic3"})
+		re := make(refreshError)
+		re.addError("topic1", ErrInvalidTopic)
+		re.addError("topic2", ErrUnknownTopicOrPartition)
+		re.addError("topic3", ErrLeaderNotAvailable)
+		err := re.forTopics([]string{"topic1", "topic3"})
 
 		require.ErrorIs(t, err, ErrInvalidTopic)
 		require.NotErrorIs(t, err, ErrUnknownTopicOrPartition)
@@ -124,7 +124,9 @@ func TestMetadataRefreshFiltersSharedTopicErrors(t *testing.T) {
 		block := make(chan struct{})
 		refresh := newMetadataRefresh(func(topics []string) error {
 			<-block
-			return refreshError{"topic3": ErrUnknownTopicOrPartition}
+			re := make(refreshError)
+			re.addError("topic3", ErrUnknownTopicOrPartition)
+			return re
 		})
 
 		// the first call starts an in-flight refresh covering all three

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -113,6 +113,11 @@ func TestMetadataRefreshFiltersSharedTopicErrors(t *testing.T) {
 		require.ErrorIs(t, err, ErrInvalidTopic)
 		require.NotErrorIs(t, err, ErrUnknownTopicOrPartition)
 		require.ErrorIs(t, err, ErrLeaderNotAvailable)
+
+		// each wrapped error names the topic it came from
+		require.ErrorContains(t, err, "topic1")
+		require.NotContains(t, err.Error(), "topic2")
+		require.ErrorContains(t, err, "topic3")
 	})
 
 	t.Run("piggy-backed callers only see errors for their topics", func(t *testing.T) {


### PR DESCRIPTION
When single-flight is enabled, concurrent callers can piggy-back on a shared metadata refresh. Previously a topic-level error from any topic in the batch was returned to every caller, even those that did not ask about the failing topic. Track errors per topic and filter the returned error to the caller's topic set.

Thanks to @DCjanus for discovering the original problem and identifying the fix