### PR TITLE
feat(consumer): warn on sustained partition retries

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -455,6 +455,9 @@ type partitionConsumer struct {
 
 var errTimedOut = errors.New("timed out feeding messages to the user") // not user-facing
 
+// log every Nth consecutive failure (~20s apart at the default backoff)
+const stuckRetryThreshold = 10
+
 func (child *partitionConsumer) sendError(err error) {
 	cErr := &ConsumerError{
 		Topic:     child.topic,
@@ -518,8 +521,12 @@ func (child *partitionConsumer) stopDispatcher() {
 }
 
 func (child *partitionConsumer) computeBackoff() time.Duration {
+	retries := child.retries.Add(1)
+	if retries >= stuckRetryThreshold && retries%stuckRetryThreshold == 0 {
+		Logger.Printf("consumer/%s/%d still retrying after %d consecutive failures\n",
+			child.topic, child.partition, retries)
+	}
 	if child.conf.Consumer.Retry.BackoffFunc != nil {
-		retries := child.retries.Add(1)
 		return child.conf.Consumer.Retry.BackoffFunc(int(retries))
 	}
 	return child.conf.Consumer.Retry.Backoff

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -1166,7 +1166,9 @@ type ConsumerGroupHandler interface {
 
 	// ConsumeClaim must start a consumer loop of ConsumerGroupClaim's Messages().
 	// Once the Messages() channel is closed, the Handler must finish its processing
-	// loop and exit.
+	// loop and exit. Handlers should also return when ConsumerGroupSession.Context()
+	// is done; Messages() alone can block while the partition consumer is retrying
+	// (e.g. after a broker disconnect). See examples/consumergroup.
 	ConsumeClaim(ConsumerGroupSession, ConsumerGroupClaim) error
 }
 

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1851,6 +1851,57 @@ func TestPartitionConsumerDispatcherOrphanedClose(t *testing.T) {
 	})
 }
 
+func TestPartitionConsumerComputeBackoff(t *testing.T) {
+	newChild := func() *partitionConsumer {
+		return &partitionConsumer{
+			conf:      NewTestConfig(),
+			topic:     "my_topic",
+			partition: 7,
+		}
+	}
+
+	t.Run("returns configured backoff", func(t *testing.T) {
+		child := newChild()
+		child.conf.Consumer.Retry.Backoff = 7 * time.Millisecond
+		require.Equal(t, 7*time.Millisecond, child.computeBackoff())
+	})
+
+	t.Run("BackoffFunc receives consecutive retry counts", func(t *testing.T) {
+		child := newChild()
+		var seen []int
+		child.conf.Consumer.Retry.BackoffFunc = func(retries int) time.Duration {
+			seen = append(seen, retries)
+			return 0
+		}
+		for i := 0; i < 3; i++ {
+			child.computeBackoff()
+		}
+		require.Equal(t, []int{1, 2, 3}, seen)
+	})
+
+	t.Run("emits stuck warning at threshold and each multiple", func(t *testing.T) {
+		child := newChild()
+		var buf bytes.Buffer
+		orig := Logger
+		Logger = log.New(&buf, "", 0)
+		t.Cleanup(func() { Logger = orig })
+
+		expectStuckWarning := func(want string) {
+			t.Helper()
+			buf.Reset()
+			for i := 1; i < stuckRetryThreshold; i++ {
+				child.computeBackoff()
+			}
+			require.NotContains(t, buf.String(), "still retrying")
+			child.computeBackoff()
+			require.Contains(t, buf.String(), want)
+		}
+
+		expectStuckWarning("consumer/my_topic/7 still retrying after 10")
+		expectStuckWarning("consumer/my_topic/7 still retrying after 20")
+	})
+}
+
 func TestConsumerTimestamps(t *testing.T) {
 	now := time.Now().Truncate(time.Millisecond)
 	type testMessage struct {


### PR DESCRIPTION
After a broker disconnect a partition consumer can sit retrying indefinitely. Each attempt's error is logged but nothing tells the operator the same partition is still failing ten retries later, so it's hard to tell a transient blip from a stuck partition.

Bump child.retries on every backoff (it was only incremented when a BackoffFunc was configured) and log every 10 consecutive failures.

Also note on ConsumeClaim that handlers should return when the session context is done; reading Messages() alone hangs while a partition keeps retrying.

---

We've had a few users complain about scenarios like this "I get EOF errors and then my consumers go silent and stop consuming any message until I restart my whole app", so try and make this clearer when its happening