### PR TITLE
feat(consumer): cap partition consumer retries

### DIFF
--- a/config.go
+++ b/config.go
@@ -382,6 +382,12 @@ type Config struct {
 			// more sophisticated backoff strategies. This takes precedence over
 			// `Backoff` if set.
 			BackoffFunc func(retries int) time.Duration
+			// The maximum number of consecutive failed dispatch attempts before a
+			// partition consumer gives up, sends ErrConsumerRetriesExhausted on
+			// its Errors channel and closes itself. In a consumer group this
+			// ends the session and triggers a fresh rejoin. The counter resets
+			// on the next successful fetch. Defaults to 0 (unlimited).
+			Max int
 		}
 
 		// Fetch is the namespace for controlling how many bytes are retrieved by any
@@ -825,6 +831,8 @@ func (c *Config) Validate() error {
 		return ConfigurationError("Consumer.MaxProcessingTime must be > 0")
 	case c.Consumer.Retry.Backoff < 0:
 		return ConfigurationError("Consumer.Retry.Backoff must be >= 0")
+	case c.Consumer.Retry.Max < 0:
+		return ConfigurationError("Consumer.Retry.Max must be >= 0")
 	case c.Consumer.Offsets.AutoCommit.Interval <= 0:
 		return ConfigurationError("Consumer.Offsets.AutoCommit.Interval must be > 0")
 	case c.Consumer.Offsets.Initial != OffsetOldest && c.Consumer.Offsets.Initial != OffsetNewest:

--- a/consumer.go
+++ b/consumer.go
@@ -550,6 +550,14 @@ func (child *partitionConsumer) dispatcher() {
 			child.waitForBrokerHandover()
 			return
 		case <-child.trigger:
+			if max := child.conf.Consumer.Retry.Max; max > 0 && int(child.retries.Load()) >= max {
+				Logger.Printf("consumer/%s/%d giving up after %d consecutive failures\n",
+					child.topic, child.partition, child.retries.Load())
+				child.sendError(ErrConsumerRetriesExhausted)
+				child.AsyncClose()
+				child.waitForBrokerHandover()
+				return
+			}
 			// only set the timer when none is pending, so retries increments
 			// once per dispatch attempt rather than once per trigger
 			if backoff == nil {

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1851,6 +1851,46 @@ func TestPartitionConsumerDispatcherOrphanedClose(t *testing.T) {
 	})
 }
 
+func TestPartitionConsumerRetryMax(t *testing.T) {
+	config := NewTestConfig()
+	config.Consumer.Return.Errors = true
+	config.Consumer.Retry.Max = 3
+
+	child := &partitionConsumer{
+		consumer:       &consumer{},
+		conf:           config,
+		topic:          "my_topic",
+		partition:      7,
+		errors:         make(chan *ConsumerError, 1),
+		feeder:         make(chan *partitionConsumerResponse, 1),
+		trigger:        make(chan none, 1),
+		dying:          make(chan none),
+		dispatcherStop: make(chan none),
+	}
+	child.retries.Store(int32(config.Consumer.Retry.Max))
+
+	done := make(chan none)
+	go func() {
+		defer close(done)
+		child.dispatcher()
+	}()
+
+	child.trigger <- none{}
+
+	select {
+	case err := <-child.errors:
+		require.ErrorIs(t, err.Err, ErrConsumerRetriesExhausted)
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "expected ErrConsumerRetriesExhausted on errors channel")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		require.FailNow(t, "dispatcher did not exit after Retry.Max")
+	}
+}
+
 func TestPartitionConsumerComputeBackoff(t *testing.T) {
 	newChild := func() *partitionConsumer {
 		return &partitionConsumer{

--- a/errors.go
+++ b/errors.go
@@ -45,6 +45,12 @@ var ErrMessageTooLarge = errors.New("kafka: message is larger than Consumer.Fetc
 // a RecordBatch.
 var ErrConsumerOffsetNotAdvanced = errors.New("kafka: consumer offset was not advanced after a RecordBatch")
 
+// ErrConsumerRetriesExhausted is sent on a partition consumer's Errors channel
+// when Consumer.Retry.Max consecutive dispatch attempts have failed. The
+// partition consumer self-closes immediately after; in a consumer group this
+// ends the session and triggers a fresh rejoin.
+var ErrConsumerRetriesExhausted = errors.New("kafka: partition consumer giving up after consecutive failures")
+
 // ErrControllerNotAvailable is returned when server didn't give correct controller id. May be kafka server's version
 // is lower than 0.10.0.0.
 var ErrControllerNotAvailable = errors.New("kafka: controller is not available")


### PR DESCRIPTION
A partition consumer currently retries forever after a broker disconnect or other dispatch failure. A single stuck partition can thus keep the consumer-group session alive (no rebalance) while the application sees no messages.

Add Consumer.Retry.Max as an opt-in maximum on the number of dispatch failures. When the max is hit the partition consumer sends ErrConsumerRetriesExhausted on its Errors channel and closes itself; inside a consumer group the deferred sess.cancel() then ends the session and triggers a fresh rejoin, picking up new metadata and a healthy broker. Defaults to 0 (unlimited) to keep existing behaviour.