### PR TITLE
feat(producer): add Produce v8 request/response support

### DIFF
--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2253,7 +2253,6 @@ func TestTxnProduceBumpEpoch(t *testing.T) {
 	broker.Returns(addPartitionsToTxnResponse)
 
 	produceResponse := new(ProduceResponse)
-	produceResponse.Version = 7
 	produceResponse.AddTopicPartition("test-topic", 0, ErrOutOfOrderSequenceNumber)
 	broker.Returns(produceResponse)
 

--- a/mockbroker.go
+++ b/mockbroker.go
@@ -368,6 +368,10 @@ func (b *MockBroker) defaultRequestHandler(req *request) (res encoderWithHeader)
 		if !ok {
 			return nil
 		}
+		// always match the response version to the request version
+		if pb, ok := res.(protocolBody); ok {
+			pb.setVersion(req.body.version())
+		}
 		return res
 	case <-time.After(expectationTimeout):
 		return nil

--- a/produce_request.go
+++ b/produce_request.go
@@ -219,11 +219,13 @@ func (r *ProduceRequest) headerVersion() int16 {
 }
 
 func (r *ProduceRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 8
 }
 
 func (r *ProduceRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 8:
+		return V2_4_0_0
 	case 7:
 		return V2_1_0_0
 	case 6:

--- a/produce_response.go
+++ b/produce_response.go
@@ -22,10 +22,20 @@ import (
 
 // partition_responses in protocol
 type ProduceResponseBlock struct {
-	Err         KError    // v0, error_code
-	Offset      int64     // v0, base_offset
-	Timestamp   time.Time // v2, log_append_time, and the broker is configured with `LogAppendTime`
-	StartOffset int64     // v5, log_start_offset
+	Err          KError                       // v0, error_code
+	Offset       int64                        // v0, base_offset
+	Timestamp    time.Time                    // v2, log_append_time, and the broker is configured with `LogAppendTime`
+	StartOffset  int64                        // v5, log_start_offset
+	RecordErrors []ProduceResponseRecordError // v8, record_errors (KIP-467)
+	ErrorMessage *string                      // v8, error_message (KIP-467)
+}
+
+// ProduceResponseRecordError identifies a record within a produced batch that
+// caused the whole batch to be dropped, along with the per-record error
+// message. Added in Produce response v8 (KIP-467).
+type ProduceResponseRecordError struct {
+	BatchIndex             int32   // v8, batch_index
+	BatchIndexErrorMessage *string // v8, batch_index_error_message (nullable)
 }
 
 func (b *ProduceResponseBlock) decode(pd packetDecoder, version int16) (err error) {
@@ -54,6 +64,27 @@ func (b *ProduceResponseBlock) decode(pd packetDecoder, version int16) (err erro
 		}
 	}
 
+	if version >= 8 {
+		numRecordErrors, err := pd.getArrayLength()
+		if err != nil {
+			return err
+		}
+		if numRecordErrors > 0 {
+			b.RecordErrors = make([]ProduceResponseRecordError, numRecordErrors)
+			for i := range b.RecordErrors {
+				if b.RecordErrors[i].BatchIndex, err = pd.getInt32(); err != nil {
+					return err
+				}
+				if b.RecordErrors[i].BatchIndexErrorMessage, err = pd.getNullableString(); err != nil {
+					return err
+				}
+			}
+		}
+		if b.ErrorMessage, err = pd.getNullableString(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -73,6 +104,21 @@ func (b *ProduceResponseBlock) encode(pe packetEncoder, version int16) (err erro
 
 	if version >= 5 {
 		pe.putInt64(b.StartOffset)
+	}
+
+	if version >= 8 {
+		if err = pe.putArrayLength(len(b.RecordErrors)); err != nil {
+			return err
+		}
+		for _, re := range b.RecordErrors {
+			pe.putInt32(re.BatchIndex)
+			if err = pe.putNullableString(re.BatchIndexErrorMessage); err != nil {
+				return err
+			}
+		}
+		if err = pe.putNullableString(b.ErrorMessage); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -176,11 +222,13 @@ func (r *ProduceResponse) headerVersion() int16 {
 }
 
 func (r *ProduceResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 8
 }
 
 func (r *ProduceResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 8:
+		return V2_4_0_0
 	case 7:
 		return V2_1_0_0
 	case 6:

--- a/produce_response_test.go
+++ b/produce_response_test.go
@@ -65,6 +65,24 @@ var (
 
 			0x00, 0x00, 0x00, 0x64, // 100 ms throttle time
 		},
+		8: { // version 8 adds RecordErrors and ErrorMessage (KIP-467)
+			0x00, 0x00, 0x00, 0x01,
+
+			0x00, 0x03, 'f', 'o', 'o',
+			0x00, 0x00, 0x00, 0x01,
+
+			0x00, 0x00, 0x00, 0x01, // Partition 1
+			0x00, 0x02, // ErrInvalidMessage
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, // Offset 255
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xE8, // Timestamp January 1st 0001 at 00:00:01,000 UTC (LogAppendTime was used)
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x32, // StartOffset 50
+			0x00, 0x00, 0x00, 0x01, // 1 record error
+			0x00, 0x00, 0x00, 0x03, // BatchIndex 3
+			0x00, 0x07, 'b', 'a', 'd', ' ', 'r', 'e', 'c', // BatchIndexErrorMessage "bad rec"
+			0x00, 0x09, 'b', 'a', 'd', ' ', 'b', 'a', 't', 'c', 'h', // ErrorMessage "bad batch"
+
+			0x00, 0x00, 0x00, 0x64, // 100 ms throttle time
+		},
 	}
 )
 
@@ -105,6 +123,21 @@ func TestProduceResponseDecode(t *testing.T) {
 					t.Error("Decoding failed for foo/1/StartOffset, got:", block.StartOffset)
 				}
 			}
+			if v >= 8 {
+				if len(block.RecordErrors) != 1 {
+					t.Error("Decoding failed for foo/1/RecordErrors, expected 1 entry, got:", len(block.RecordErrors))
+				} else {
+					if block.RecordErrors[0].BatchIndex != 3 {
+						t.Error("Decoding failed for foo/1/RecordErrors[0].BatchIndex, got:", block.RecordErrors[0].BatchIndex)
+					}
+					if block.RecordErrors[0].BatchIndexErrorMessage == nil || *block.RecordErrors[0].BatchIndexErrorMessage != "bad rec" {
+						t.Error("Decoding failed for foo/1/RecordErrors[0].BatchIndexErrorMessage, got:", block.RecordErrors[0].BatchIndexErrorMessage)
+					}
+				}
+				if block.ErrorMessage == nil || *block.ErrorMessage != "bad batch" {
+					t.Error("Decoding failed for foo/1/ErrorMessage, got:", block.ErrorMessage)
+				}
+			}
 		}
 		if v >= 1 {
 			if expected := 100 * time.Millisecond; response.ThrottleTime != expected {
@@ -119,12 +152,19 @@ func TestProduceResponseEncode(t *testing.T) {
 	response.Blocks = make(map[string]map[int32]*ProduceResponseBlock)
 	testEncodable(t, "empty", &response, produceResponseNoBlocksV0)
 
+	batchIndexErrMsg := "bad rec"
+	errMsg := "bad batch"
 	response.Blocks["foo"] = make(map[int32]*ProduceResponseBlock)
 	response.Blocks["foo"][1] = &ProduceResponseBlock{
 		Err:         ErrInvalidMessage,
 		Offset:      255,
 		Timestamp:   time.Unix(1, 0),
 		StartOffset: 50,
+		RecordErrors: []ProduceResponseRecordError{{
+			BatchIndex:             3,
+			BatchIndexErrorMessage: &batchIndexErrMsg,
+		}},
+		ErrorMessage: &errMsg,
 	}
 	response.ThrottleTime = 100 * time.Millisecond
 	for v, produceResponseManyBlocks := range produceResponseManyBlocksVersions {

--- a/produce_set.go
+++ b/produce_set.go
@@ -200,6 +200,9 @@ func (ps *produceSet) buildRequest() *ProduceRequest {
 	if ps.parent.conf.Version.IsAtLeast(V2_1_0_0) {
 		req.Version = 7
 	}
+	if ps.parent.conf.Version.IsAtLeast(V2_4_0_0) {
+		req.Version = 8
+	}
 
 	for topic, partitionSets := range ps.msgs {
 		for partition, set := range partitionSets {

--- a/request_test.go
+++ b/request_test.go
@@ -335,8 +335,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V2_4_0_0,
 			map[int16]int16{
-				// TODO: ProduceRequest v8 is not supported, but expected for KafkaVersion 2.4.0
-				// apiKeyProduce:                     8, // up from 7
+				apiKeyProduce:            8, // up from 7
 				apiKeyMetadata:           9, // up from 8
 				apiKeyLeaderAndIsr:       4, // up from 2
 				apiKeyStopReplica:        2, // up from 1


### PR DESCRIPTION
Adds protocol support for KIP-467 (Kafka 2.4.0) which extends the Produce response with per-record errors and a batch-level error message, and bumps the negotiated Produce version to 8 when the configured Kafka version is at least 2.4.0.

Also makes MockBroker's default request handler match the queued response version to the request version, so tests using broker.Returns() don't have to manually bump version numbers.