### PR TITLE
fix(consumer): size partial-batch retry correctly

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -866,7 +866,13 @@ func (child *partitionConsumer) parseResponse(response *FetchResponse) ([]*Consu
 				child.sendError(ErrMessageTooLarge)
 				child.offset++ // skip this one so we can keep processing future messages
 			} else {
-				child.fetchSize *= 2
+				// if the broker told us the exact size of the partial batch, request that
+				// directly; otherwise fall back to doubling the fetch size
+				if block.partialBatchSize > child.fetchSize {
+					child.fetchSize = block.partialBatchSize
+				} else {
+					child.fetchSize *= 2
+				}
 				// check int32 overflow
 				if child.fetchSize < 0 {
 					child.fetchSize = math.MaxInt32

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -65,6 +65,11 @@ type FetchResponseBlock struct {
 	// recordsNextOffset contains the next consecutive offset following this response block.
 	// This field is computed locally and is not part of the server's binary response.
 	recordsNextOffset *int64
+
+	// partialBatchSize is the total on-wire size needed to fetch the trailing
+	// partial batch fully, when one is present. Zero if no partial trailing
+	// batch was detected or the size is unknown (e.g. legacy MessageSet).
+	partialBatchSize int32
 }
 
 func (b *FetchResponseBlock) decode(pd packetDecoder, version int16) (err error) {
@@ -181,6 +186,13 @@ func (b *FetchResponseBlock) decode(pd packetDecoder, version int16) (err error)
 		}
 
 		if partial || overflow {
+			if partial {
+				size, err := records.partialSize()
+				if err != nil {
+					return err
+				}
+				b.partialBatchSize = size
+			}
 			break
 		}
 	}

--- a/fetch_response_test.go
+++ b/fetch_response_test.go
@@ -418,6 +418,12 @@ func TestPartailFetchResponse(t *testing.T) {
 	if n != 0 {
 		t.Fatal("Decoding produced incorrect number of records.")
 	}
+
+	// batchLen (70) plus 12 bytes of FirstOffset and length-field overhead;
+	// see partialFetchResponse fixture above
+	if block.partialBatchSize != 70+12 {
+		t.Errorf("expected partialBatchSize %d, got %d", 70+12, block.partialBatchSize)
+	}
 }
 
 func TestEmptyRecordsFetchResponse(t *testing.T) {

--- a/functional_consumer_test.go
+++ b/functional_consumer_test.go
@@ -79,6 +79,57 @@ func TestConsumerHighWaterMarkOffset(t *testing.T) {
 	safeClose(t, pc)
 }
 
+// TestConsumerPartialBatchRecovery exercises the partial-batch recovery path
+// (#1657): the consumer's initial Fetch.Default is smaller than the produced
+// record batch, so the broker returns a partial batch and reports its true
+// size. The follow-up fetch must use that reported size to deliver the
+// message in a single retry instead of doubling its way up.
+func TestConsumerPartialBatchRecovery(t *testing.T) {
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	const payloadSize = 256 * 1024
+
+	producerConfig := NewFunctionalTestConfig()
+	producerConfig.Producer.Return.Successes = true
+	producerConfig.Producer.MaxMessageBytes = 2 * payloadSize
+
+	p, err := NewSyncProducer(FunctionalTestEnv.KafkaBrokerAddrs, producerConfig)
+	assert.NoError(t, err)
+	defer safeClose(t, p)
+
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	_, offset, err := p.SendMessage(&ProducerMessage{Topic: "test.1", Value: ByteEncoder(payload)})
+	assert.NoError(t, err)
+
+	consumerConfig := NewFunctionalTestConfig()
+	// 12 bytes is the minimum that lets the broker include the per-batch length
+	// field in the partial response, so the consumer can size its retry exactly
+	consumerConfig.Consumer.Fetch.Default = 12
+	consumerConfig.Consumer.Fetch.Max = 2 * payloadSize
+
+	c, err := NewConsumer(FunctionalTestEnv.KafkaBrokerAddrs, consumerConfig)
+	assert.NoError(t, err)
+	defer safeClose(t, c)
+
+	pc, err := c.ConsumePartition("test.1", 0, offset)
+	assert.NoError(t, err)
+	defer safeClose(t, pc)
+
+	select {
+	case msg := <-pc.Messages():
+		assert.Equal(t, offset, msg.Offset)
+		assert.Equal(t, payload, msg.Value)
+	case err := <-pc.Errors():
+		t.Fatalf("consumer error: %v", err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the large message")
+	}
+}
+
 // Makes sure that messages produced by all supported client versions/
 // compression codecs (except LZ4) combinations can be consumed by all
 // supported consumer versions. It relies on the KAFKA_VERSION environment

--- a/record_batch.go
+++ b/record_batch.go
@@ -50,6 +50,10 @@ type RecordBatch struct {
 
 	compressedRecords []byte
 	recordsLen        int // uncompressed records size
+	// partialSize is the total on-wire size of this batch (FirstOffset + length
+	// field + body) when PartialTrailingRecord is true and the partial state was
+	// caused by truncated bytes. Zero otherwise.
+	partialSize int32
 }
 
 func (b *RecordBatch) LastOffset() int64 {
@@ -170,6 +174,8 @@ func (b *RecordBatch) decode(pd packetDecoder) (err error) {
 	if err != nil {
 		if errors.Is(err, ErrInsufficientData) {
 			b.PartialTrailingRecord = true
+			// 8 (FirstOffset) + 4 (length field) + batchLen body
+			b.partialSize = batchLen + 12
 			b.Records = nil
 			return nil
 		}

--- a/records.go
+++ b/records.go
@@ -183,6 +183,28 @@ func (r *Records) isOverflow() (bool, error) {
 	return false, fmt.Errorf("unknown records type: %v", r.recordsType)
 }
 
+// partialSize reports the total on-wire size required to fetch the partial
+// trailing batch fully. Returns 0 when not partial or when the size is unknown
+// (e.g. legacy MessageSet partials).
+func (r *Records) partialSize() (int32, error) {
+	if r.recordsType == unknownRecords {
+		if empty, err := r.setTypeFromFields(); err != nil || empty {
+			return 0, err
+		}
+	}
+
+	switch r.recordsType {
+	case legacyRecords:
+		return 0, nil
+	case defaultRecords:
+		if r.RecordBatch == nil {
+			return 0, nil
+		}
+		return r.RecordBatch.partialSize, nil
+	}
+	return 0, fmt.Errorf("unknown records type: %v", r.recordsType)
+}
+
 func (r *Records) nextOffset() (*int64, error) {
 	switch r.recordsType {
 	case unknownRecords:


### PR DESCRIPTION
When a fetch response contains a partial trailing record batch, the broker already encodes the batch's full size in its length field. Capture it during decode and use it to size the follow-up fetch instead of just doubling Consumer.Fetch.Default until the batch fits.

Fixes #1657