### PR TITLE
test(fvt): register restart cleanup before stop

### DIFF
--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -398,10 +398,6 @@ func TestFuncAdminListConsumerGroupOffsets(t *testing.T) {
 	}
 
 	brokerID := coordinator.id
-	if err := stopDockerTestBroker(context.Background(), brokerID); err != nil {
-		t.Fatal(err)
-	}
-
 	t.Cleanup(
 		func() {
 			if err := startDockerTestBroker(context.Background(), brokerID); err != nil {
@@ -409,6 +405,9 @@ func TestFuncAdminListConsumerGroupOffsets(t *testing.T) {
 			}
 		},
 	)
+	if err := stopDockerTestBroker(context.Background(), brokerID); err != nil {
+		t.Fatal(err)
+	}
 
 	{
 		resp, err := adminClient.ListConsumerGroupOffsets(group, map[string][]int32{"test.4": {0, 1, 2, 3}})

--- a/functional_consumer_follower_fetch_test.go
+++ b/functional_consumer_follower_fetch_test.go
@@ -100,6 +100,11 @@ func TestConsumerFetchFollowerFailover(t *testing.T) {
 		}
 	}
 
+	t.Cleanup(func() {
+		if err := startDockerTestBroker(context.Background(), follower); err != nil {
+			t.Fatal(err)
+		}
+	})
 	if err := stopDockerTestBroker(context.Background(), follower); err != nil {
 		t.Fatal(err)
 	}

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -248,16 +248,15 @@ func TestFuncTxnProduceWithBrokerFailure(t *testing.T) {
 	err = producer.BeginTxn()
 	require.NoError(t, err)
 
-	if err := stopDockerTestBroker(context.Background(), txCoordinator.id); err != nil {
-		t.Fatal(err)
-	}
-
 	defer func() {
 		if err := startDockerTestBroker(context.Background(), txCoordinator.id); err != nil {
 			t.Fatal(err)
 		}
 		t.Logf("\n")
 	}()
+	if err := stopDockerTestBroker(context.Background(), txCoordinator.id); err != nil {
+		t.Fatal(err)
+	}
 
 	for i := 0; i < 1; i++ {
 		producer.Input() <- &ProducerMessage{Topic: "test.1", Key: nil, Value: StringEncoder("test")}


### PR DESCRIPTION
Even if stop itself fails, ensure the broker is restarted again before the next test runs - otherwise subsequent setupFunctionalTest calls sit in ensureFullyReplicated waiting on a dead broker.