### PR TITLE
feat(consumer): add OffsetCommit v8 request/response support

### DIFF
--- a/offset_commit_request.go
+++ b/offset_commit_request.go
@@ -30,7 +30,11 @@ func (b *offsetCommitRequestBlock) encode(pe packetEncoder, version int16) error
 		pe.putInt32(b.committedLeaderEpoch)
 	}
 
-	return pe.putString(b.metadata)
+	if err := pe.putString(b.metadata); err != nil {
+		return err
+	}
+	pe.putEmptyTaggedFieldArray()
+	return nil
 }
 
 func (b *offsetCommitRequestBlock) decode(pd packetDecoder, version int16) (err error) {
@@ -48,7 +52,10 @@ func (b *offsetCommitRequestBlock) decode(pd packetDecoder, version int16) (err 
 		}
 	}
 
-	b.metadata, err = pd.getString()
+	if b.metadata, err = pd.getString(); err != nil {
+		return err
+	}
+	_, err = pd.getEmptyTaggedFieldArray()
 	return err
 }
 
@@ -67,6 +74,7 @@ type OffsetCommitRequest struct {
 	// - 4 (kafka 2.0.0 and later)
 	// - 5&6 (kafka 2.1.0 and later)
 	// - 7 (kafka 2.3.0 and later)
+	// - 8 (kafka 2.4.0 and later, first flexible version)
 	Version int16
 	blocks  map[string]map[int32]*offsetCommitRequestBlock
 }
@@ -85,7 +93,10 @@ func NewOffsetCommitRequest(conf *Config, group string) *OffsetCommitRequest {
 		ConsumerGroupGeneration: GroupGenerationUndefined,
 	}
 
-	if conf.Version.IsAtLeast(V2_3_0_0) {
+	if conf.Version.IsAtLeast(V2_4_0_0) {
+		// Version 8 is the first flexible version.
+		request.Version = 8
+	} else if conf.Version.IsAtLeast(V2_3_0_0) {
 		// Version 7 adds GroupInstanceId.
 		request.Version = 7
 	} else if conf.Version.IsAtLeast(V2_1_0_0) {
@@ -116,7 +127,7 @@ func NewOffsetCommitRequest(conf *Config, group string) *OffsetCommitRequest {
 }
 
 func (r *OffsetCommitRequest) encode(pe packetEncoder) error {
-	if r.Version < 0 || r.Version > 7 {
+	if r.Version < 0 || r.Version > 8 {
 		return PacketEncodingError{"invalid or unsupported OffsetCommitRequest version field"}
 	}
 
@@ -167,7 +178,9 @@ func (r *OffsetCommitRequest) encode(pe packetEncoder) error {
 				return err
 			}
 		}
+		pe.putEmptyTaggedFieldArray()
 	}
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -204,33 +217,37 @@ func (r *OffsetCommitRequest) decode(pd packetDecoder, version int16) (err error
 	if err != nil {
 		return err
 	}
-	if topicCount == 0 {
-		return nil
-	}
-	r.blocks = make(map[string]map[int32]*offsetCommitRequestBlock)
-	for i := 0; i < topicCount; i++ {
-		topic, err := pd.getString()
-		if err != nil {
-			return err
-		}
-		partitionCount, err := pd.getArrayLength()
-		if err != nil {
-			return err
-		}
-		r.blocks[topic] = make(map[int32]*offsetCommitRequestBlock)
-		for j := 0; j < partitionCount; j++ {
-			partition, err := pd.getInt32()
+	if topicCount > 0 {
+		r.blocks = make(map[string]map[int32]*offsetCommitRequestBlock)
+		for i := 0; i < topicCount; i++ {
+			topic, err := pd.getString()
 			if err != nil {
 				return err
 			}
-			block := &offsetCommitRequestBlock{}
-			if err := block.decode(pd, r.Version); err != nil {
+			partitionCount, err := pd.getArrayLength()
+			if err != nil {
 				return err
 			}
-			r.blocks[topic][partition] = block
+			r.blocks[topic] = make(map[int32]*offsetCommitRequestBlock)
+			for j := 0; j < partitionCount; j++ {
+				partition, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				block := &offsetCommitRequestBlock{}
+				if err := block.decode(pd, r.Version); err != nil {
+					return err
+				}
+				r.blocks[topic][partition] = block
+			}
+			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+				return err
+			}
 		}
 	}
-	return nil
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
 }
 
 func (r *OffsetCommitRequest) key() int16 {
@@ -242,15 +259,28 @@ func (r *OffsetCommitRequest) version() int16 {
 }
 
 func (r *OffsetCommitRequest) headerVersion() int16 {
+	if r.Version >= 8 {
+		return 2
+	}
 	return 1
 }
 
 func (r *OffsetCommitRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 8
+}
+
+func (r *OffsetCommitRequest) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *OffsetCommitRequest) isFlexibleVersion(version int16) bool {
+	return version >= 8
 }
 
 func (r *OffsetCommitRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 8:
+		return V2_4_0_0
 	case 7:
 		return V2_3_0_0
 	case 5, 6:

--- a/offset_commit_request_test.go
+++ b/offset_commit_request_test.go
@@ -140,6 +140,22 @@ var (
 		0, 0, 0, 3, // CommittedEpoch
 		0, 4, 'm', 'e', 't', 'a', // CommittedMetadata
 	}
+	offsetCommitRequestOneBlockV8 = []byte{
+		0x04, 'f', 'o', 'o', // GroupId (compact string)
+		0x00, 0x00, 0x00, 0x01, // GenerationId
+		0x04, 'm', 'i', 'd', // MemberId (compact string)
+		0x04, 'g', 'i', 'd', // GroupInstanceId (compact nullable string)
+		0x02,                          // One Topic (compact array length)
+		0x06, 't', 'o', 'p', 'i', 'c', // Name (compact string)
+		0x02,                   // One Partition (compact array length)
+		0x00, 0x00, 0x00, 0x01, // PartitionIndex
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // CommittedOffset
+		0x00, 0x00, 0x00, 0x03, // CommittedEpoch
+		0x05, 'm', 'e', 't', 'a', // CommittedMetadata (compact string)
+		0x00, // partition tagged fields
+		0x00, // topic tagged fields
+		0x00, // request tagged fields
+	}
 )
 
 func TestOffsetCommitRequestV5AndPlus(t *testing.T) {
@@ -188,6 +204,23 @@ func TestOffsetCommitRequestV5AndPlus(t *testing.T) {
 			offsetCommitRequestOneBlockV7,
 			&OffsetCommitRequest{
 				Version:                 7,
+				ConsumerGroup:           "foo",
+				ConsumerGroupGeneration: 1,
+				ConsumerID:              "mid",
+				GroupInstanceId:         &groupInstanceId,
+				blocks: map[string]map[int32]*offsetCommitRequestBlock{
+					"topic": {
+						1: &offsetCommitRequestBlock{offset: 2, metadata: "meta", committedLeaderEpoch: 3},
+					},
+				},
+			},
+		},
+		{
+			"v8",
+			8,
+			offsetCommitRequestOneBlockV8,
+			&OffsetCommitRequest{
+				Version:                 8,
 				ConsumerGroup:           "foo",
 				ConsumerGroupGeneration: 1,
 				ConsumerID:              "mid",

--- a/offset_commit_response.go
+++ b/offset_commit_response.go
@@ -41,8 +41,11 @@ func (r *OffsetCommitResponse) encode(pe packetEncoder) error {
 		for partition, kerror := range partitions {
 			pe.putInt32(partition)
 			pe.putKError(kerror)
+			pe.putEmptyTaggedFieldArray()
 		}
+		pe.putEmptyTaggedFieldArray()
 	}
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -57,38 +60,47 @@ func (r *OffsetCommitResponse) decode(pd packetDecoder, version int16) (err erro
 	}
 
 	numTopics, err := pd.getArrayLength()
-	if err != nil || numTopics == 0 {
+	if err != nil {
 		return err
 	}
 
-	r.Errors = make(map[string]map[int32]KError, numTopics)
-	for i := 0; i < numTopics; i++ {
-		name, err := pd.getString()
-		if err != nil {
-			return err
-		}
-
-		numErrors, err := pd.getArrayLength()
-		if err != nil {
-			return err
-		}
-
-		r.Errors[name] = make(map[int32]KError, numErrors)
-
-		for j := 0; j < numErrors; j++ {
-			id, err := pd.getInt32()
+	if numTopics > 0 {
+		r.Errors = make(map[string]map[int32]KError, numTopics)
+		for i := 0; i < numTopics; i++ {
+			name, err := pd.getString()
 			if err != nil {
 				return err
 			}
 
-			r.Errors[name][id], err = pd.getKError()
+			numErrors, err := pd.getArrayLength()
 			if err != nil {
+				return err
+			}
+
+			r.Errors[name] = make(map[int32]KError, numErrors)
+
+			for j := 0; j < numErrors; j++ {
+				id, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+
+				r.Errors[name][id], err = pd.getKError()
+				if err != nil {
+					return err
+				}
+				if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+					return err
+				}
+			}
+			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
 				return err
 			}
 		}
 	}
 
-	return nil
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
 }
 
 func (r *OffsetCommitResponse) key() int16 {
@@ -100,15 +112,28 @@ func (r *OffsetCommitResponse) version() int16 {
 }
 
 func (r *OffsetCommitResponse) headerVersion() int16 {
+	if r.Version >= 8 {
+		return 1
+	}
 	return 0
 }
 
 func (r *OffsetCommitResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 8
+}
+
+func (r *OffsetCommitResponse) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *OffsetCommitResponse) isFlexibleVersion(version int16) bool {
+	return version >= 8
 }
 
 func (r *OffsetCommitResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 8:
+		return V2_4_0_0
 	case 7:
 		return V2_3_0_0
 	case 5, 6:

--- a/offset_commit_response_test.go
+++ b/offset_commit_response_test.go
@@ -27,6 +27,17 @@ var (
 		0, 0, 0, 3, // PartitionIndex
 		0, 0, // ErrorCode
 	}
+	noEmptyOffsetCommitResponseV8 = []byte{
+		0x00, 0x00, 0x00, 0x64, // ThrottleTimeMs = 100
+		0x02,                          // Topic Len (compact array length)
+		0x06, 't', 'o', 'p', 'i', 'c', // Name (compact string)
+		0x02,                   // Partition Len (compact array length)
+		0x00, 0x00, 0x00, 0x03, // PartitionIndex
+		0x00, 0x00, // ErrorCode
+		0x00, // partition tagged fields
+		0x00, // topic tagged fields
+		0x00, // response tagged fields
+	}
 )
 
 func TestEmptyOffsetCommitResponse(t *testing.T) {
@@ -65,6 +76,20 @@ func TestEmptyOffsetCommitResponse(t *testing.T) {
 			&OffsetCommitResponse{
 				ThrottleTimeMs: 100,
 				Version:        3,
+				Errors: map[string]map[int32]KError{
+					"topic": {
+						3: ErrNoError,
+					},
+				},
+			},
+		},
+		{
+			"v8",
+			8,
+			noEmptyOffsetCommitResponseV8,
+			&OffsetCommitResponse{
+				ThrottleTimeMs: 100,
+				Version:        8,
 				Errors: map[string]map[int32]KError{
 					"topic": {
 						3: ErrNoError,

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -329,6 +329,10 @@ func (om *offsetManager) constructRequest() *OffsetCommitRequest {
 		r.Version = 7
 		r.GroupInstanceId = om.groupInstanceId
 	}
+	// Version 8 is the first flexible version.
+	if om.conf.Version.IsAtLeast(V2_4_0_0) {
+		r.Version = 8
+	}
 
 	// commit timestamp was only briefly supported in V1 where we set it to
 	// ReceiveTime (-1) to tell the broker to set it to the time when the commit

--- a/request_test.go
+++ b/request_test.go
@@ -335,14 +335,13 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V2_4_0_0,
 			map[int16]int16{
-				apiKeyProduce:            8, // up from 7
-				apiKeyMetadata:           9, // up from 8
-				apiKeyLeaderAndIsr:       4, // up from 2
-				apiKeyStopReplica:        2, // up from 1
-				apiKeyUpdateMetadata:     6, // up from 5
-				apiKeyControlledShutdown: 3, // up from 2
-				// TODO: OffsetCommitRequest v8 is not supported, but expected for KafkaVersion 2.4.0
-				// apiKeyOffsetCommit:                8, // up from 7
+				apiKeyProduce:                     8, // up from 7
+				apiKeyMetadata:                    9, // up from 8
+				apiKeyLeaderAndIsr:                4, // up from 2
+				apiKeyStopReplica:                 2, // up from 1
+				apiKeyUpdateMetadata:              6, // up from 5
+				apiKeyControlledShutdown:          3, // up from 2
+				apiKeyOffsetCommit:                8, // up from 7
 				apiKeyOffsetFetch:                 6, // up from 5
 				apiKeyFindCoordinator:             3, // up from 2
 				apiKeyJoinGroup:                   6, // up from 5


### PR DESCRIPTION
OffsetCommit v8 is the first flexible version of the API (KIP-482), introduced in Kafka 2.4.0. Wire encoding switches to compact strings, compact arrays, and per-struct tagged-fields trailers; request and response headers gain a tagged-fields trailer too (request header v2, response header v1).

Bumps both call sites (NewOffsetCommitRequest for the admin path and offsetManager.constructRequest for the consumer-group path) to negotiate v8 when Config.Version is at least V2_4_0_0.