### PR TITLE
chore: better bounds checking

### DIFF
--- a/metadata_response_test.go
+++ b/metadata_response_test.go
@@ -559,3 +559,28 @@ func TestFlexibleMetadataResponseInvalidInt32ArrayLength(t *testing.T) {
 		t.Error("expected an error decoding a truncated flexible int32 array, got nil")
 	}
 }
+
+func TestFlexibleMetadataResponseInvalidInt32ArrayLengthOverflow(t *testing.T) {
+	packet := []byte{
+		0x00, 0x00, 0x00, 0x00, // throttle ms
+		0x01,                   // length of brokers (0)
+		0x00,                   // null cluster id
+		0x00, 0x00, 0x00, 0x00, // controller id
+		0x02,       // length of topics (1)
+		0x00, 0x00, // topic error
+		0x02, 't', // topic name
+		0x00,       // is internal
+		0x02,       // length of partitions (1)
+		0x00, 0x00, // partition error
+		0x00, 0x00, 0x00, 0x00, // partition id
+		0x00, 0x00, 0x00, 0x00, // leader id
+		0x00, 0x00, 0x00, 0x00, // leader epoch
+		0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x21, // length
+	}
+
+	response := MetadataResponse{}
+	err := versionedDecode(packet, &response, 9, nil)
+	if err == nil {
+		t.Error("expected an error decoding a truncated flexible int32 array, got nil")
+	}
+}

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -236,7 +236,7 @@ func (rd *realDecoder) getInt32Array() ([]int32, error) {
 		return nil, nil
 	}
 
-	if rd.remaining() < 4*n {
+	if rd.remaining()/4 < n {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData
 	}
@@ -258,7 +258,7 @@ func (rd *realDecoder) getInt64Array() ([]int64, error) {
 		return nil, nil
 	}
 
-	if rd.remaining() < 8*n {
+	if rd.remaining()/8 < n {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData
 	}
@@ -518,7 +518,7 @@ func (rd *realFlexibleDecoder) getInt32Array() ([]int32, error) {
 
 	arrayLength := int(n) - 1
 
-	if rd.remaining() < 4*arrayLength {
+	if rd.remaining()/4 < arrayLength {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData
 	}


### PR DESCRIPTION
Checking in units of items avoids possible overflow. Probably only strictly necessary for the flexible case (for which I provide an regression test) but consistency will help avoid similar problems in future.