### PR TITLE
fix: decode nullable ACL describe error messages

### DIFF
--- a/acl_describe_response.go
+++ b/acl_describe_response.go
@@ -48,12 +48,8 @@ func (d *DescribeAclsResponse) decode(pd packetDecoder, version int16) (err erro
 		return err
 	}
 
-	errmsg, err := pd.getString()
-	if err != nil {
+	if d.ErrMsg, err = pd.getNullableString(); err != nil {
 		return err
-	}
-	if errmsg != "" {
-		d.ErrMsg = &errmsg
 	}
 
 	n, err := pd.getArrayLength()

--- a/acl_describe_response_test.go
+++ b/acl_describe_response_test.go
@@ -77,6 +77,15 @@ func TestAclDescribeResponse(t *testing.T) {
 	}
 
 	testResponse(t, "describe", resp, aclDescribeResponseError)
+
+	errmsg = ""
+	resp = &DescribeAclsResponse{
+		ThrottleTime: 100 * time.Millisecond,
+		Err:          ErrBrokerNotAvailable,
+		ErrMsg:       &errmsg,
+		ResourceAcls: []*ResourceAcls{},
+	}
+	testResponse(t, "describe with empty error message", resp, nil)
 }
 
 func TestAclDescribeResponseV1(t *testing.T) {
@@ -104,6 +113,16 @@ func TestAclDescribeResponseV1(t *testing.T) {
 	}
 
 	testResponse(t, "describe", resp, aclDescribeResponseErrorV1)
+
+	errmsg = ""
+	resp = &DescribeAclsResponse{
+		Version:      1,
+		ThrottleTime: 100 * time.Millisecond,
+		Err:          ErrBrokerNotAvailable,
+		ErrMsg:       &errmsg,
+		ResourceAcls: []*ResourceAcls{},
+	}
+	testResponse(t, "describe with empty error message", resp, nil)
 }
 
 func TestAclDescribeResponseV2(t *testing.T) {
@@ -131,4 +150,14 @@ func TestAclDescribeResponseV2(t *testing.T) {
 	}
 
 	testResponse(t, "describe", resp, aclDescribeResponseErrorV2)
+
+	errmsg = ""
+	resp = &DescribeAclsResponse{
+		Version:      2,
+		ThrottleTime: 100 * time.Millisecond,
+		Err:          ErrBrokerNotAvailable,
+		ErrMsg:       &errmsg,
+		ResourceAcls: []*ResourceAcls{},
+	}
+	testResponse(t, "describe with empty error message", resp, nil)
 }


### PR DESCRIPTION
Kafka’s DescribeAclsResponse.json mark ErrorMessage as nullableVersions: 0+, so fix the protocol def to match