### PR TITLE
feat: support join group v7

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -473,7 +473,9 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 	if c.config.Version.IsAtLeast(V2_3_0_0) {
 		req.Version = 5
 		req.GroupInstanceId = c.groupInstanceId
-		if c.config.Version.IsAtLeast(V2_4_0_0) {
+		if c.config.Version.IsAtLeast(V2_5_0_0) {
+			req.Version = 7
+		} else if c.config.Version.IsAtLeast(V2_4_0_0) {
 			req.Version = 6
 		}
 	}

--- a/join_group_request.go
+++ b/join_group_request.go
@@ -184,7 +184,7 @@ func (r *JoinGroupRequest) headerVersion() int16 {
 }
 
 func (r *JoinGroupRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 6
+	return r.Version >= 0 && r.Version <= 7
 }
 
 func (r *JoinGroupRequest) isFlexible() bool {
@@ -197,6 +197,8 @@ func (r *JoinGroupRequest) isFlexibleVersion(version int16) bool {
 
 func (r *JoinGroupRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 7:
+		return V2_5_0_0
 	case 6:
 		return V2_4_0_0
 	case 5:

--- a/join_group_response.go
+++ b/join_group_response.go
@@ -20,6 +20,8 @@ type JoinGroupResponse struct {
 	MemberId string
 	// Members contains the per-group-member information.
 	Members []GroupMember
+	// ProtocolType contains the protocol type of the group (KIP-559)
+	ProtocolType *string
 }
 
 func (r *JoinGroupResponse) setVersion(v int16) {
@@ -55,8 +57,17 @@ func (r *JoinGroupResponse) encode(pe packetEncoder) error {
 	pe.putKError(r.Err)
 	pe.putInt32(r.GenerationId)
 
-	if err := pe.putString(r.GroupProtocol); err != nil {
-		return err
+	if r.Version >= 7 {
+		if err := pe.putNullableString(r.ProtocolType); err != nil {
+			return err
+		}
+		if err := pe.putNullableString(&r.GroupProtocol); err != nil {
+			return err
+		}
+	} else {
+		if err := pe.putString(r.GroupProtocol); err != nil {
+			return err
+		}
 	}
 	if err := pe.putString(r.LeaderId); err != nil {
 		return err
@@ -106,8 +117,19 @@ func (r *JoinGroupResponse) decode(pd packetDecoder, version int16) (err error) 
 		return
 	}
 
-	if r.GroupProtocol, err = pd.getString(); err != nil {
-		return
+	if r.Version >= 7 {
+		if r.ProtocolType, err = pd.getNullableString(); err != nil {
+			return
+		}
+		if groupProtocol, err := pd.getNullableString(); err != nil {
+			return err
+		} else if groupProtocol != nil {
+			r.GroupProtocol = *groupProtocol
+		}
+	} else {
+		if r.GroupProtocol, err = pd.getString(); err != nil {
+			return
+		}
 	}
 
 	if r.LeaderId, err = pd.getString(); err != nil {
@@ -174,7 +196,7 @@ func (r *JoinGroupResponse) headerVersion() int16 {
 }
 
 func (r *JoinGroupResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 6
+	return r.Version >= 0 && r.Version <= 7
 }
 
 func (r *JoinGroupResponse) isFlexible() bool {
@@ -187,6 +209,8 @@ func (r *JoinGroupResponse) isFlexibleVersion(version int16) bool {
 
 func (r *JoinGroupResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 7:
+		return V2_5_0_0
 	case 6:
 		return V2_4_0_0
 	case 5:

--- a/join_group_response_test.go
+++ b/join_group_response_test.go
@@ -216,10 +216,27 @@ var (
 		1, // no members
 		0, // empty tagged fields
 	}
+
+	joinGroupResponseV7 = []byte{
+		0, 0, 0, 100, // ThrottleTimeMs
+		0x00, 0x00, // No error
+		0x00, 0x01, 0x02, 0x03, // Generation ID
+		9, 'c', 'o', 'n', 's', 'u', 'm', 'e', 'r', // Protocol Type
+		9, 'p', 'r', 'o', 't', 'o', 'c', 'o', 'l', // Protocol name chosen
+		4, 'f', 'o', 'o', // Leader ID
+		4, 'b', 'a', 'r', // Member ID
+		2,                // One member info
+		4, 'm', 'i', 'd', // memberId
+		4, 'g', 'i', 'd', // GroupInstanceId
+		4, 1, 2, 3, // Metadata
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
 )
 
 func TestJoinGroupResponse3plus(t *testing.T) {
 	groupInstanceId := "gid"
+	protocolType := "consumer"
 	tests := []struct {
 		CaseName     string
 		Version      int16
@@ -273,6 +290,24 @@ func TestJoinGroupResponse3plus(t *testing.T) {
 				LeaderId:      "",
 				MemberId:      "foo",
 				Members:       nil,
+			},
+		},
+		{
+			"v7",
+			7,
+			joinGroupResponseV7,
+			&JoinGroupResponse{
+				Version:       7,
+				ThrottleTime:  100,
+				Err:           ErrNoError,
+				GenerationId:  0x00010203,
+				ProtocolType:  &protocolType,
+				GroupProtocol: "protocol",
+				LeaderId:      "foo",
+				MemberId:      "bar",
+				Members: []GroupMember{
+					{"mid", &groupInstanceId, []byte{1, 2, 3}},
+				},
 			},
 		},
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -366,14 +366,13 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 			V2_5_0_0,
 			map[int16]int16{
 				apiKeyOffsetFetch:      7, // up from 6
+				apiKeyJoinGroup:        7, // up from 6
 				apiKeyInitProducerId:   3, // up from 2
 				apiKeyDescribeAcls:     2, // up from 1
 				apiKeyCreateAcls:       2, // up from 1
 				apiKeyDeleteAcls:       2, // up from 1
 				apiKeySASLAuth:         2, // up from 1
 				apiKeyCreatePartitions: 2, // up from 1
-				// TODO: JoinGroupRequest v7 is not supported, but expected for KafkaVersion 2.5.0
-				// apiKeyJoinGroup:               7, // up from 6
 				// TODO: SyncGroupRequest v5 is not supported, but expected for KafkaVersion 2.5.0
 				// apiKeySyncGroup:               5, // up from 4
 				// TODO: TxnOffsetCommitRequest v3 is not supported, but expected for KafkaVersion 2.5.0


### PR DESCRIPTION
The request is unchanged.

There are two changes to the response. A new protocol type nullable string is added to report the class of protocol as described in KIP-559. The existing protocol name field, `GroupProtocol`, is now nullable. However, since this is already a `string` field the null case is currently represented as the empty string. We might consider adding a new `ProtocolName` `*string` field to mirror the existing field and distinguish the null case. However, while mirroring is straightforward for the `decode` case, it is difficult to know how to handle the possible ambiguity in the `encode` case when trying to derive the correct value from two potentially inconsistent fields.