### PR TITLE
refactor: replace eapache/queue with generic ring buffer

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -9,8 +9,9 @@ import (
 	"time"
 
 	"github.com/eapache/go-resiliency/breaker"
-	"github.com/eapache/queue"
 	"github.com/rcrowley/go-metrics"
+
+	"github.com/IBM/sarama/internal/queue"
 )
 
 // ErrProducerRetryBufferOverflow is returned when the bridging retry buffer is full and OOM prevention needs to be applied.
@@ -1030,7 +1031,7 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 	// This is because the AsyncProduce callback inside the bridge is invoked from the broker
 	// responseReceiver goroutine and closing the broker requires such goroutine to be finished
 	go withRecover(func() {
-		buf := queue.New()
+		buf := queue.New[*brokerProducerResponse]()
 		for {
 			if buf.Length() == 0 {
 				res, ok := <-pending
@@ -1043,7 +1044,7 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 			}
 			// Send the head pending response or buffer another one
 			// so that we never block the callback
-			headRes := buf.Peek().(*brokerProducerResponse)
+			headRes := buf.Peek()
 			select {
 			case res, ok := <-pending:
 				if !ok {
@@ -1559,7 +1560,7 @@ func (p *asyncProducer) retryHandler() {
 
 	var currentByteSize int64
 	var msg *ProducerMessage
-	buf := queue.New()
+	buf := queue.New[*ProducerMessage]()
 
 	for {
 		if buf.Length() == 0 {
@@ -1567,8 +1568,8 @@ func (p *asyncProducer) retryHandler() {
 		} else {
 			select {
 			case msg = <-p.retries:
-			case p.input <- buf.Peek().(*ProducerMessage):
-				msgToRemove := buf.Remove().(*ProducerMessage)
+			case p.input <- buf.Peek():
+				msgToRemove := buf.Remove()
 				currentByteSize -= int64(msgToRemove.ByteSize(version))
 				continue
 			}
@@ -1585,7 +1586,7 @@ func (p *asyncProducer) retryHandler() {
 			continue
 		}
 
-		msgToHandle := buf.Peek().(*ProducerMessage)
+		msgToHandle := buf.Peek()
 		if msgToHandle.flags == 0 {
 			select {
 			case p.input <- msgToHandle:

--- a/async_producer.go
+++ b/async_producer.go
@@ -1031,7 +1031,7 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 	// This is because the AsyncProduce callback inside the bridge is invoked from the broker
 	// responseReceiver goroutine and closing the broker requires such goroutine to be finished
 	go withRecover(func() {
-		buf := queue.New[*brokerProducerResponse]()
+		var buf queue.Queue[*brokerProducerResponse]
 		for {
 			if buf.Length() == 0 {
 				res, ok := <-pending
@@ -1560,7 +1560,7 @@ func (p *asyncProducer) retryHandler() {
 
 	var currentByteSize int64
 	var msg *ProducerMessage
-	buf := queue.New[*ProducerMessage]()
+	var buf queue.Queue[*ProducerMessage]
 
 	for {
 		if buf.Length() == 0 {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.25.0
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/eapache/go-resiliency v1.7.0
-	github.com/eapache/queue v1.1.0
 	github.com/jcmturner/gofork v1.7.6
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/klauspost/compress v1.18.6

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/eapache/go-resiliency v1.7.0 h1:n3NRTnBn5N0Cbi/IeOHuQn9s2UwVUH7Ga0ZWcP+9JTA=
 github.com/eapache/go-resiliency v1.7.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
-github.com/eapache/queue v1.1.0 h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=
-github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -56,8 +54,6 @@ go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.6.0/go.mod h1:OFC/31mSvZgRz0V1QTNCzfAI1aIRzbiufJtkMIlEp58=
-golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
-golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
 golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
@@ -67,8 +63,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
-golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -3,17 +3,13 @@
 package queue
 
 // power of two so wrap-around can use bitwise AND
-const minLen = 16
+const minLen = 1 << 4
 
-// Queue is a generic FIFO ring buffer.
+// Queue is a generic FIFO ring buffer. The zero value is an empty queue ready
+// for use.
 type Queue[T any] struct {
 	buf               []T
 	head, tail, count int
-}
-
-// New returns an empty Queue.
-func New[T any]() *Queue[T] {
-	return &Queue[T]{buf: make([]T, minLen)}
 }
 
 // Length returns the number of elements in the queue.
@@ -21,9 +17,10 @@ func (q *Queue[T]) Length() int {
 	return q.count
 }
 
-// resize rebuilds buf at 2*count with head back at index 0.
+// resize rebuilds buf with head back at index 0, sized to 2*count but never
+// below minLen so the zero value of Queue grows on first Add.
 func (q *Queue[T]) resize() {
-	newBuf := make([]T, q.count<<1)
+	newBuf := make([]T, max(minLen, q.count<<1))
 	if q.tail > q.head {
 		copy(newBuf, q.buf[q.head:q.tail])
 	} else {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,0 +1,71 @@
+// Package queue is a generic FIFO ring buffer adapted from
+// github.com/eapache/queue. It is not safe for concurrent use.
+package queue
+
+// power of two so wrap-around can use bitwise AND
+const minLen = 16
+
+// Queue is a generic FIFO ring buffer.
+type Queue[T any] struct {
+	buf               []T
+	head, tail, count int
+}
+
+// New returns an empty Queue.
+func New[T any]() *Queue[T] {
+	return &Queue[T]{buf: make([]T, minLen)}
+}
+
+// Length returns the number of elements in the queue.
+func (q *Queue[T]) Length() int {
+	return q.count
+}
+
+// resize rebuilds buf at 2*count with head back at index 0.
+func (q *Queue[T]) resize() {
+	newBuf := make([]T, q.count<<1)
+	if q.tail > q.head {
+		copy(newBuf, q.buf[q.head:q.tail])
+	} else {
+		n := copy(newBuf, q.buf[q.head:])
+		copy(newBuf[n:], q.buf[:q.tail])
+	}
+	q.head = 0
+	q.tail = q.count
+	q.buf = newBuf
+}
+
+// Add appends elem, growing the buffer if it is full.
+func (q *Queue[T]) Add(elem T) {
+	if q.count == len(q.buf) {
+		q.resize()
+	}
+	q.buf[q.tail] = elem
+	q.tail = (q.tail + 1) & (len(q.buf) - 1)
+	q.count++
+}
+
+// Peek returns the head element. It panics if the queue is empty.
+func (q *Queue[T]) Peek() T {
+	if q.count <= 0 {
+		panic("queue: Peek() called on empty queue")
+	}
+	return q.buf[q.head]
+}
+
+// Remove pops and returns the head element. It panics if the queue is empty.
+func (q *Queue[T]) Remove() T {
+	if q.count <= 0 {
+		panic("queue: Remove() called on empty queue")
+	}
+	ret := q.buf[q.head]
+	var zero T
+	q.buf[q.head] = zero // clear slot so the popped element can be GC'd
+	q.head = (q.head + 1) & (len(q.buf) - 1)
+	q.count--
+	// shrink once we're down to a quarter of the buffer
+	if len(q.buf) > minLen && (q.count<<2) == len(q.buf) {
+		q.resize()
+	}
+	return ret
+}

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -61,21 +61,16 @@ func TestQueue(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
-	t.Run("works with pointer types and clears slot on remove", func(t *testing.T) {
+	t.Run("clears slot on remove so the popped element can be GC'd", func(t *testing.T) {
 		type box struct{ v int }
 		var q Queue[*box]
-		a, b := &box{v: 1}, &box{v: 2}
-		q.Add(a)
-		q.Add(b)
+		q.Add(&box{v: 1})
+		q.Add(&box{v: 2})
+		head := q.head
 		got := q.Remove()
 		require.NotNil(t, got)
 		assert.Equal(t, 1, got.v)
-		// the just-vacated slot must hold the zero value so the referent can
-		// be garbage collected. We can't inspect head directly, but Remove
-		// followed by Add at the same slot must not return the old element.
-		q.Add(&box{v: 3})
-		assert.Equal(t, 2, q.Remove().v)
-		assert.Equal(t, 3, q.Remove().v)
+		assert.Nil(t, q.buf[head])
 	})
 
 	t.Run("peek on empty queue panics", func(t *testing.T) {

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestQueue(t *testing.T) {
-	t.Run("new queue reports zero length", func(t *testing.T) {
-		q := New[int]()
+	t.Run("zero value reports zero length", func(t *testing.T) {
+		var q Queue[int]
 		assert.Equal(t, 0, q.Length())
 	})
 
 	t.Run("add then peek then remove preserves FIFO order", func(t *testing.T) {
-		q := New[int]()
+		var q Queue[int]
 		for i := 0; i < 5; i++ {
 			q.Add(i)
 		}
@@ -27,7 +27,7 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("grows beyond initial capacity", func(t *testing.T) {
-		q := New[int]()
+		var q Queue[int]
 		const n = 1024
 		for i := 0; i < n; i++ {
 			q.Add(i)
@@ -40,7 +40,7 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("interleaved add and remove wraps around buffer", func(t *testing.T) {
-		q := New[int]()
+		var q Queue[int]
 		var want []int
 		for i := 0; i < 100; i++ {
 			q.Add(i)
@@ -63,7 +63,7 @@ func TestQueue(t *testing.T) {
 
 	t.Run("works with pointer types and clears slot on remove", func(t *testing.T) {
 		type box struct{ v int }
-		q := New[*box]()
+		var q Queue[*box]
 		a, b := &box{v: 1}, &box{v: 2}
 		q.Add(a)
 		q.Add(b)
@@ -79,17 +79,17 @@ func TestQueue(t *testing.T) {
 	})
 
 	t.Run("peek on empty queue panics", func(t *testing.T) {
-		q := New[int]()
+		var q Queue[int]
 		assert.Panics(t, func() { q.Peek() })
 	})
 
 	t.Run("remove on empty queue panics", func(t *testing.T) {
-		q := New[int]()
+		var q Queue[int]
 		assert.Panics(t, func() { q.Remove() })
 	})
 
 	t.Run("shrinks when sparsely populated", func(t *testing.T) {
-		q := New[int]()
+		var q Queue[int]
 		// grow well beyond minLen
 		for i := 0; i < 1024; i++ {
 			q.Add(i)

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -1,0 +1,105 @@
+package queue
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue(t *testing.T) {
+	t.Run("new queue reports zero length", func(t *testing.T) {
+		q := New[int]()
+		assert.Equal(t, 0, q.Length())
+	})
+
+	t.Run("add then peek then remove preserves FIFO order", func(t *testing.T) {
+		q := New[int]()
+		for i := 0; i < 5; i++ {
+			q.Add(i)
+		}
+		assert.Equal(t, 5, q.Length())
+		for i := 0; i < 5; i++ {
+			assert.Equal(t, i, q.Peek())
+			assert.Equal(t, i, q.Remove())
+		}
+		assert.Equal(t, 0, q.Length())
+	})
+
+	t.Run("grows beyond initial capacity", func(t *testing.T) {
+		q := New[int]()
+		const n = 1024
+		for i := 0; i < n; i++ {
+			q.Add(i)
+		}
+		assert.Equal(t, n, q.Length())
+		for i := 0; i < n; i++ {
+			assert.Equal(t, i, q.Remove())
+		}
+		assert.Equal(t, 0, q.Length())
+	})
+
+	t.Run("interleaved add and remove wraps around buffer", func(t *testing.T) {
+		q := New[int]()
+		var want []int
+		for i := 0; i < 100; i++ {
+			q.Add(i)
+			q.Add(i + 1000)
+			want = append(want, i, i+1000)
+		}
+		var got []int
+		for q.Length() > 0 {
+			got = append(got, q.Remove())
+		}
+		// re-add and drain to force wrap-around past the original tail
+		for i := 0; i < 50; i++ {
+			q.Add(i)
+		}
+		for q.Length() > 0 {
+			q.Remove()
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("works with pointer types and clears slot on remove", func(t *testing.T) {
+		type box struct{ v int }
+		q := New[*box]()
+		a, b := &box{v: 1}, &box{v: 2}
+		q.Add(a)
+		q.Add(b)
+		got := q.Remove()
+		require.NotNil(t, got)
+		assert.Equal(t, 1, got.v)
+		// the just-vacated slot must hold the zero value so the referent can
+		// be garbage collected. We can't inspect head directly, but Remove
+		// followed by Add at the same slot must not return the old element.
+		q.Add(&box{v: 3})
+		assert.Equal(t, 2, q.Remove().v)
+		assert.Equal(t, 3, q.Remove().v)
+	})
+
+	t.Run("peek on empty queue panics", func(t *testing.T) {
+		q := New[int]()
+		assert.Panics(t, func() { q.Peek() })
+	})
+
+	t.Run("remove on empty queue panics", func(t *testing.T) {
+		q := New[int]()
+		assert.Panics(t, func() { q.Remove() })
+	})
+
+	t.Run("shrinks when sparsely populated", func(t *testing.T) {
+		q := New[int]()
+		// grow well beyond minLen
+		for i := 0; i < 1024; i++ {
+			q.Add(i)
+		}
+		grownCap := cap(q.buf)
+		// drain most elements to trigger shrink path repeatedly
+		for i := 0; i < 1020; i++ {
+			q.Remove()
+		}
+		assert.Less(t, cap(q.buf), grownCap)
+		assert.Equal(t, 4, q.Length())
+	})
+}


### PR DESCRIPTION
Drop the github.com/eapache/queue dep for an internal generic Queue[T] of the same shape. The async producer's two queues now hold typed pointers instead of interface{}, halving the backing buffer footprint and dropping four type assertions.

benchstat on an M1 Pro, n=12, -benchtime=1s:

| benchmark      | eapache      | generic      | delta             |
|----------------|--------------|--------------|-------------------|
| SteadyState-10 | 38.39n ± 0%  | 37.92n ± 0%  | -1.24% (p=0.000)  |
| Burst64-10     | 694.3n ± 1%  | 502.6n ± 1%  | -27.61% (p=0.000) |
| Burst1024-10   | 11.368µ ± 6% | 7.956µ ± 0%  | -30.02% (p=0.000) |
| Burst16384-10  | 292.3µ ± 1%  | 191.7µ ± 1%  | -34.40% (p=0.000) |
| Window1024-10  | 38.56n ± 1%  | 38.31n ± 4%  | ~ (p=0.225)       |
| geomean        | 1.278µ       | 1.022µ       | -20.08%           |

| benchmark      | eapache     | generic     | delta             |
|----------------|-------------|-------------|-------------------|
| SteadyState-10 | 82.00 B     | 82.00 B     | ~ (p=1.000)       |
| Burst64-10     | 2.375 KiB   | 1.125 KiB   | -52.63% (p=0.000) |
| Burst1024-10   | 54.00 KiB   | 27.12 KiB   | -49.77% (p=0.000) |
| Burst16384-10  | 776.0 KiB   | 392.4 KiB   | -49.44% (p=0.000) |
| Window1024-10  | 82.00 B     | 82.00 B     | ~ (p=1.000)       |
| geomean        | 3.639 KiB   | 2.383 KiB   | -34.53%           |