### PR TITLE
test(fvt): use a per-message timeout in follower failover test

### DIFF
--- a/functional_consumer_follower_fetch_test.go
+++ b/functional_consumer_follower_fetch_test.go
@@ -5,10 +5,14 @@ package sarama
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestConsumerFetchFollowerFailover(t *testing.T) {
@@ -28,17 +32,13 @@ func TestConsumerFetchFollowerFailover(t *testing.T) {
 
 	// pick a partition and find the ID for one of the follower brokers
 	admin, err := NewClusterAdmin(FunctionalTestEnv.KafkaBrokerAddrs, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer admin.Close()
 
 	metadata, err := admin.DescribeTopics([]string{topic})
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	partition := metadata[0].Partitions[0]
-	leader := metadata[0].Partitions[0].Leader
+	leader := partition.Leader
 	follower := int32(-1)
 	for _, replica := range partition.Replicas {
 		if replica == leader {
@@ -47,6 +47,7 @@ func TestConsumerFetchFollowerFailover(t *testing.T) {
 		follower = replica
 		break
 	}
+	require.NotEqual(t, int32(-1), follower, "no follower replica found")
 
 	t.Logf("topic %s has leader kafka-%d and our chosen follower is kafka-%d", topic, leader, follower)
 
@@ -54,24 +55,21 @@ func TestConsumerFetchFollowerFailover(t *testing.T) {
 	config.RackID = strconv.FormatInt(int64(follower), 10)
 
 	consumer, err := NewConsumer(FunctionalTestEnv.KafkaBrokerAddrs, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	pc, err := consumer.ConsumePartition(topic, partition.ID, OffsetOldest)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer func() {
 		pc.Close()
 		consumer.Close()
 	}()
 
 	producer, err := NewSyncProducer(FunctionalTestEnv.KafkaBrokerAddrs, config)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	defer producer.Close()
+
+	var lastProduced atomic.Int64
+	lastProduced.Store(-1)
 
 	var wg sync.WaitGroup
 	wg.Add(numMsg)
@@ -83,49 +81,97 @@ func TestConsumerFetchFollowerFailover(t *testing.T) {
 			}
 			if _, offset, err := producer.SendMessage(msg); err != nil {
 				t.Error(i, err)
-			} else if offset%50 == 0 {
-				t.Logf("sent: %d\n", offset)
+			} else {
+				lastProduced.Store(offset)
+				if offset%50 == 0 {
+					t.Logf("sent: %d\n", offset)
+				}
 			}
 			wg.Done()
 			time.Sleep(time.Millisecond * 25)
 		}
 	}()
 
-	i := 0
+	const stallTimeout = 30 * time.Second
+	recv := func(expected int) *ConsumerMessage {
+		t.Helper()
+		select {
+		case msg := <-pc.Messages():
+			return msg
+		case err, ok := <-pc.Errors():
+			if !ok {
+				t.Fatalf("consumer error channel closed before offset %d", expected)
+			}
+			t.Fatalf("consumer error waiting for offset %d: %v", expected, err)
+		case <-time.After(stallTimeout):
+			t.Fatalf("consumer stalled waiting for offset %d after %s (HWM=%d, last produced=%d)",
+				expected, stallTimeout, pc.HighWaterMarkOffset(), lastProduced.Load())
+		}
+		return nil
+	}
 
+	i := 0
 	for ; i < numMsg/8; i++ {
-		msg := <-pc.Messages()
+		msg := recv(i)
 		if msg.Offset%50 == 0 {
 			t.Logf("recv: %d\n", msg.Offset)
 		}
 	}
 
+	// register restart before stopping, so a Fatal below still restores the broker
 	t.Cleanup(func() {
 		if err := startDockerTestBroker(context.Background(), follower); err != nil {
 			t.Fatal(err)
 		}
 	})
-	if err := stopDockerTestBroker(context.Background(), follower); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, stopDockerTestBroker(context.Background(), follower))
+
+	// the leader pins HWM at the dead follower's last offset until it drops out of the ISR
+	waitForISRShrink(t, admin, topic, partition.ID, follower, 60*time.Second)
 
 	for ; i < numMsg/3; i++ {
-		msg := <-pc.Messages()
+		msg := recv(i)
 		if msg.Offset%50 == 0 {
 			t.Logf("recv: %d\n", msg.Offset)
 		}
 	}
 
-	if err := startDockerTestBroker(context.Background(), follower); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, startDockerTestBroker(context.Background(), follower))
 
 	for ; i < numMsg; i++ {
-		msg := <-pc.Messages()
+		msg := recv(i)
 		if msg.Offset%50 == 0 {
 			t.Logf("recv: %d\n", msg.Offset)
 		}
 	}
 
 	wg.Wait()
+}
+
+// waitForISRShrink polls topic metadata until removed is no longer in the ISR for partition.
+func waitForISRShrink(t *testing.T, admin ClusterAdmin, topic string, partition int32, removed int32, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastIsr []int32
+	for {
+		md, err := admin.DescribeTopics([]string{topic})
+		if err != nil {
+			t.Fatalf("describe topics while waiting for ISR shrink: %v", err)
+		}
+		for _, p := range md[0].Partitions {
+			if p.ID == partition {
+				lastIsr = p.Isr
+				break
+			}
+		}
+		if !slices.Contains(lastIsr, removed) {
+			t.Logf("ISR for %s/%d shrank to %v (removed kafka-%d)", topic, partition, lastIsr, removed)
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("kafka-%d still in ISR for %s/%d after %s (got %v)",
+				removed, topic, partition, timeout, lastIsr)
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
Add a 30s timeout on each pc.Messages() read so the test fails fast rather than running out the 15m binary timeout, which panics and also defeats gotestsum's --rerun-fails.

Also wait for the follower to drop out of the ISR after we stop it. Kafka can be slow about this for some reason (saw 14+ minutes once) and the leader won't advance HWM until it happens, so the consumer has nothing to make progress on.