### PR TITLE
fix(broker): snapshot fetch meters before deferred Mark

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -576,12 +576,17 @@ func (b *Broker) Produce(request *ProduceRequest) (*ProduceResponse, error) {
 
 // Fetch returns a FetchResponse or error
 func (b *Broker) Fetch(request *FetchRequest) (*FetchResponse, error) {
+	// snapshot meters under the lock; Open may reassign them on reconnect
+	b.lock.Lock()
+	fetchRate, brokerFetchRate := b.fetchRate, b.brokerFetchRate
+	b.lock.Unlock()
+
 	defer func() {
-		if b.fetchRate != nil {
-			b.fetchRate.Mark(1)
+		if fetchRate != nil {
+			fetchRate.Mark(1)
 		}
-		if b.brokerFetchRate != nil {
-			b.brokerFetchRate.Mark(1)
+		if brokerFetchRate != nil {
+			brokerFetchRate.Mark(1)
 		}
 	}()
 

--- a/broker.go
+++ b/broker.go
@@ -576,12 +576,12 @@ func (b *Broker) Produce(request *ProduceRequest) (*ProduceResponse, error) {
 
 // Fetch returns a FetchResponse or error
 func (b *Broker) Fetch(request *FetchRequest) (*FetchResponse, error) {
-	// snapshot meters under the lock; Open may reassign them on reconnect
-	b.lock.Lock()
-	fetchRate, brokerFetchRate := b.fetchRate, b.brokerFetchRate
-	b.lock.Unlock()
-
 	defer func() {
+		// snapshot meters under the lock; Open may reassign them on reconnect
+		b.lock.Lock()
+		fetchRate, brokerFetchRate := b.fetchRate, b.brokerFetchRate
+		b.lock.Unlock()
+
 		if fetchRate != nil {
 			fetchRate.Mark(1)
 		}

--- a/broker_test.go
+++ b/broker_test.go
@@ -352,20 +352,17 @@ func TestBrokerFetch(t *testing.T) {
 		req := &FetchRequest{MaxWaitTime: 100, MinBytes: 1, Version: 4}
 
 		var wg sync.WaitGroup
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 500 {
 				_, _ = broker.Fetch(req)
 			}
-		}()
-		go func() {
-			defer wg.Done()
+		})
+		wg.Go(func() {
 			for range 50 {
 				_ = broker.Close()
 				_ = broker.Open(conf)
 			}
-		}()
+		})
 		wg.Wait()
 	})
 }

--- a/broker_test.go
+++ b/broker_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -332,6 +333,41 @@ func TestBrokerOpenSASLv1FailThenReopenTransportError(t *testing.T) {
 
 	require.NotErrorIs(t, broker.Open(conf2), ErrAlreadyConnected)
 	_, _ = broker.Connected()
+}
+
+func TestBrokerFetch(t *testing.T) {
+	t.Run("metric mark does not race with concurrent reopen", func(t *testing.T) {
+		mb := NewMockBroker(t, 1)
+		defer mb.Close()
+		mb.SetHandlerByMap(map[string]MockResponse{
+			"FetchRequest": NewMockFetchResponse(t, 1),
+		})
+
+		broker := NewBroker(mb.Addr())
+		conf := NewTestConfig()
+		conf.Version = V0_11_0_0
+		require.NoError(t, broker.Open(conf))
+		t.Cleanup(func() { _ = broker.Close() })
+
+		req := &FetchRequest{MaxWaitTime: 100, MinBytes: 1, Version: 4}
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for range 500 {
+				_, _ = broker.Fetch(req)
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				_ = broker.Close()
+				_ = broker.Open(conf)
+			}
+		}()
+		wg.Wait()
+	})
 }
 
 var ErrTokenFailure = errors.New("Failure generating token")


### PR DESCRIPTION
The deferred Mark in Broker.Fetch read b.fetchRate / b.brokerFetchRate without b.lock, racing with Broker.Open's inner goroutine reassigning them on reconnect. Snapshot both under the lock and Mark the locals.

Fixes #3017