### PR TITLE
feat(admin): support OffsetFetchRequest v8

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -115,6 +115,17 @@ type ClusterAdmin interface {
 	// List the consumer group offsets available in the cluster.
 	ListConsumerGroupOffsets(group string, topicPartitions map[string][]int32) (*OffsetFetchResponse, error)
 
+	// ListConsumerGroupOffsetsBatch fetches committed offsets for multiple consumer groups
+	// in a single round trip per coordinator using OffsetFetch v8+ (KIP-709). A nil
+	// partitions map fetches offsets for all topics in that group.
+	//
+	// Returns ErrUnsupportedVersion if any coordinator advertises < v8. Requires
+	// Config.ApiVersionsRequest to be enabled for the version check to take effect.
+	//
+	// On a retriable per-group error all coordinators are re-resolved and every group
+	// is re-batched. Non-retriable per-group errors are returned in the per-group Err.
+	ListConsumerGroupOffsetsBatch(groupTopics map[string]map[string][]int32) (map[string]*OffsetFetchResponseGroup, error)
+
 	// ListOffsets lists offsets for the specified topic partitions.
 	// Each value is OffsetNewest, OffsetOldest, or a timestamp in milliseconds.
 	// Results are keyed by topic/partition and include per-partition errors.
@@ -1205,14 +1216,76 @@ func (ca *clusterAdmin) ListConsumerGroupOffsets(group string, topicPartitions m
 		if err != nil {
 			return err
 		}
-		if !errors.Is(response.Err, ErrNoError) {
-			return response.Err
+		if groupErr := response.GroupError(); !errors.Is(groupErr, ErrNoError) {
+			return groupErr
 		}
 
 		return nil
 	})
 
 	return response, err
+}
+
+func (ca *clusterAdmin) ListConsumerGroupOffsetsBatch(groupTopics map[string]map[string][]int32) (map[string]*OffsetFetchResponseGroup, error) {
+	type brokerBatch struct {
+		broker *Broker
+		groups []OffsetFetchRequestGroup
+	}
+
+	result := make(map[string]*OffsetFetchResponseGroup, len(groupTopics))
+	err := ca.retryOnError(isRetriableGroupCoordinatorError, func() (err error) {
+		defer func() {
+			if err != nil && isRetriableGroupCoordinatorError(err) {
+				for group := range groupTopics {
+					_ = ca.client.RefreshCoordinator(group)
+				}
+			}
+		}()
+
+		// re-resolve coordinators each attempt; key by broker id to coalesce groups
+		// sharing a coordinator
+		batches := make(map[int32]*brokerBatch)
+		for group, partitions := range groupTopics {
+			coordinator, cerr := ca.client.Coordinator(group)
+			if cerr != nil {
+				return cerr
+			}
+			batch, ok := batches[coordinator.ID()]
+			if !ok {
+				batch = &brokerBatch{broker: coordinator}
+				batches[coordinator.ID()] = batch
+			}
+			batch.groups = append(batch.groups,
+				OffsetFetchRequestGroup{GroupId: group, Partitions: partitions})
+		}
+
+		clear(result)
+		for _, batch := range batches {
+			req := NewOffsetFetchRequest(ca.conf.Version, "", nil)
+			req.Groups = batch.groups
+			if _, ok := batch.broker.negotiateApiVersion(req, 8); !ok {
+				return ErrUnsupportedVersion
+			}
+			resp, ferr := batch.broker.FetchOffset(req)
+			if ferr != nil {
+				return ferr
+			}
+			for i := range resp.Groups {
+				g := &resp.Groups[i]
+				// retriable per-group error re-batches every group on retry; non-retriable
+				// errors are left on g.Err for the caller
+				if g.Err != ErrNoError && isRetriableGroupCoordinatorError(g.Err) {
+					return g.Err
+				}
+				result[g.GroupId] = g
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func (ca *clusterAdmin) DeleteConsumerGroupOffset(group string, topic string, partition int32) error {

--- a/admin.go
+++ b/admin.go
@@ -1246,12 +1246,12 @@ func (ca *clusterAdmin) ListConsumerGroupOffsetsBatch(groupTopics map[string]map
 		// sharing a coordinator
 		batches := make(map[int32]*brokerBatch)
 		for group, partitions := range groupTopics {
-			coordinator, cerr := ca.client.Coordinator(group)
-			if cerr != nil {
-				return cerr
+			coordinator, err := ca.client.Coordinator(group)
+			if err != nil {
+				return err
 			}
-			batch, ok := batches[coordinator.ID()]
-			if !ok {
+			batch := batches[coordinator.ID()]
+			if batch == nil {
 				batch = &brokerBatch{broker: coordinator}
 				batches[coordinator.ID()] = batch
 			}
@@ -1266,9 +1266,9 @@ func (ca *clusterAdmin) ListConsumerGroupOffsetsBatch(groupTopics map[string]map
 			if _, ok := batch.broker.negotiateApiVersion(req, 8); !ok {
 				return ErrUnsupportedVersion
 			}
-			resp, ferr := batch.broker.FetchOffset(req)
-			if ferr != nil {
-				return ferr
+			resp, err := batch.broker.FetchOffset(req)
+			if err != nil {
+				return err
 			}
 			for i := range resp.Groups {
 				g := &resp.Groups[i]

--- a/admin_test.go
+++ b/admin_test.go
@@ -1749,50 +1749,220 @@ func TestListConsumerGroupsMultiBroker(t *testing.T) {
 }
 
 func TestListConsumerGroupOffsets(t *testing.T) {
-	seedBroker := NewMockBroker(t, 1)
-	defer seedBroker.Close()
+	const (
+		group          = "my-group"
+		topic          = "my-topic"
+		partition      = int32(0)
+		expectedOffset = int64(0)
+	)
 
-	group := "my-group"
-	topic := "my-topic"
-	partition := int32(0)
-	expectedOffset := int64(0)
+	fetch := func(t *testing.T, version KafkaVersion) *OffsetFetchResponse {
+		t.Helper()
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"OffsetFetchRequest": NewMockOffsetFetchResponse(t).
+				SetOffset(group, topic, partition, expectedOffset, "", ErrNoError).
+				SetError(ErrNoError),
+			"MetadataRequest":        mockMetadataFor(t, broker),
+			"FindCoordinatorRequest": mockGroupCoordinators(t, broker, group),
+		})
+		response, err := newTestAdminAt(t, version, broker).
+			ListConsumerGroupOffsets(group, map[string][]int32{topic: {0}})
+		require.NoError(t, err)
+		return response
+	}
 
-	seedBroker.SetHandlerByMap(map[string]MockResponse{
-		"OffsetFetchRequest": NewMockOffsetFetchResponse(t).SetOffset(group, "my-topic", partition, expectedOffset, "", ErrNoError).SetError(ErrNoError),
-		"MetadataRequest": NewMockMetadataResponse(t).
-			SetController(seedBroker.BrokerID()).
-			SetBroker(seedBroker.Addr(), seedBroker.BrokerID()),
-		"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).SetCoordinator(CoordinatorGroup, group, seedBroker),
+	t.Run("returns legacy blocks for older versions", func(t *testing.T) {
+		response := fetch(t, V1_0_0_0)
+		block := response.GetBlock(topic, partition)
+		require.NotNil(t, block)
+		assert.Equal(t, expectedOffset, block.Offset)
+		assert.Equal(t, expectedOffset, response.Blocks[topic][partition].Offset)
 	})
 
-	config := NewTestConfig()
-	config.Version = V1_0_0_0
-
-	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	response, err := admin.ListConsumerGroupOffsets(group, map[string][]int32{
-		topic: {0},
+	t.Run("mirrors v8 group response into legacy blocks", func(t *testing.T) {
+		response := fetch(t, V3_0_0_0)
+		block := response.GetBlock(topic, partition)
+		require.NotNil(t, block)
+		require.Contains(t, response.Blocks, topic)
+		assert.Equal(t, expectedOffset, response.Blocks[topic][partition].Offset)
+		assert.Equal(t, ErrNoError, response.Err)
 	})
-	if err != nil {
-		t.Fatalf("ListConsumerGroupOffsets failed with error %v", err)
+}
+
+func TestListConsumerGroupOffsetsBatch(t *testing.T) {
+	const (
+		topic           = "my-topic"
+		groupA          = "group-a"
+		groupB          = "group-b"
+		expectedOffsetA = int64(7)
+		expectedOffsetB = int64(13)
+	)
+	bothGroups := map[string]map[string][]int32{
+		groupA: {topic: {0}},
+		groupB: {topic: {0}},
 	}
 
-	block := response.GetBlock(topic, partition)
-	if block == nil {
-		t.Fatalf("Expected block for topic %v and partition %v to exist, but it doesn't", topic, partition)
+	// setup wires a single mock broker as the coordinator for every named group
+	// and serves the given OffsetFetchRequest handler. Returns a v3.0 admin.
+	setup := func(t *testing.T, offsetFetch MockResponse, groups ...string) ClusterAdmin {
+		t.Helper()
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"OffsetFetchRequest":     offsetFetch,
+			"MetadataRequest":        mockMetadataFor(t, broker),
+			"FindCoordinatorRequest": mockGroupCoordinators(t, broker, groups...),
+		})
+		return newTestAdminAt(t, V3_0_0_0, broker)
 	}
 
-	if block.Offset != expectedOffset {
-		t.Fatalf("Expected offset %v, got %v", expectedOffset, block.Offset)
+	// groupBlock builds a v8 response group entry with a single block.
+	groupBlock := func(group string, offset int64) OffsetFetchResponseGroup {
+		return OffsetFetchResponseGroup{
+			GroupId: group,
+			Blocks:  map[string]map[int32]*OffsetFetchResponseBlock{topic: {0: {Offset: offset}}},
+		}
 	}
 
-	err = admin.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("fetches offsets for multiple groups", func(t *testing.T) {
+		admin := setup(t, NewMockOffsetFetchResponse(t).
+			SetOffset(groupA, topic, 0, expectedOffsetA, "", ErrNoError).
+			SetOffset(groupB, topic, 0, expectedOffsetB, "", ErrNoError).
+			SetError(ErrNoError), groupA, groupB)
+
+		result, err := admin.ListConsumerGroupOffsetsBatch(bothGroups)
+		require.NoError(t, err)
+		assertGroupOffset(t, result, groupA, topic, 0, expectedOffsetA)
+		assertGroupOffset(t, result, groupB, topic, 0, expectedOffsetB)
+	})
+
+	t.Run("nil partitions fetches all topics for the group", func(t *testing.T) {
+		const otherTopic = "other-topic"
+		admin := setup(t, NewMockOffsetFetchResponse(t).
+			SetOffset(groupA, topic, 0, expectedOffsetA, "", ErrNoError).
+			SetOffset(groupA, otherTopic, 0, expectedOffsetB, "", ErrNoError).
+			SetError(ErrNoError), groupA)
+
+		result, err := admin.ListConsumerGroupOffsetsBatch(map[string]map[string][]int32{groupA: nil})
+		require.NoError(t, err)
+		assertGroupOffset(t, result, groupA, topic, 0, expectedOffsetA)
+		assertGroupOffset(t, result, groupA, otherTopic, 0, expectedOffsetB)
+	})
+
+	t.Run("rejects broker downgrade below v8", func(t *testing.T) {
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"ApiVersionsRequest": NewMockApiVersionsResponse(t).SetApiKeys([]ApiVersionsResponseKey{
+				{ApiKey: apiKeyOffsetFetch, MinVersion: 0, MaxVersion: 7},
+			}),
+			"MetadataRequest":        mockMetadataFor(t, broker),
+			"FindCoordinatorRequest": mockGroupCoordinators(t, broker, groupA, groupB),
+		})
+		config := NewTestConfig()
+		config.ApiVersionsRequest = true
+		config.Version = V3_0_0_0
+		admin, err := NewClusterAdmin([]string{broker.Addr()}, config)
+		require.NoError(t, err)
+		t.Cleanup(func() { admin.Close() })
+
+		_, err = admin.ListConsumerGroupOffsetsBatch(bothGroups)
+		require.ErrorIs(t, err, ErrUnsupportedVersion)
+	})
+
+	t.Run("limits broker's advertised max to client's supported max", func(t *testing.T) {
+		// Kafka 4.x brokers advertise OffsetFetch versions above the highest the
+		// client knows how to encode. The client must limit to its own max.
+		// 9999 keeps this test honest as we add more protocol versions later.
+		broker := newMockBroker(t, 1)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"ApiVersionsRequest": NewMockApiVersionsResponse(t).SetApiKeys([]ApiVersionsResponseKey{
+				{ApiKey: apiKeyOffsetFetch, MinVersion: 0, MaxVersion: 9999},
+			}),
+			"MetadataRequest":        mockMetadataFor(t, broker),
+			"FindCoordinatorRequest": mockGroupCoordinators(t, broker, groupA, groupB),
+			"OffsetFetchRequest": NewMockOffsetFetchResponse(t).
+				SetOffset(groupA, topic, 0, expectedOffsetA, "", ErrNoError).
+				SetOffset(groupB, topic, 0, expectedOffsetB, "", ErrNoError).
+				SetError(ErrNoError),
+		})
+		config := NewTestConfig()
+		config.ApiVersionsRequest = true
+		config.Version = V3_0_0_0
+		admin, err := NewClusterAdmin([]string{broker.Addr()}, config)
+		require.NoError(t, err)
+		t.Cleanup(func() { admin.Close() })
+
+		result, err := admin.ListConsumerGroupOffsetsBatch(bothGroups)
+		require.NoError(t, err)
+		assertGroupOffset(t, result, groupA, topic, 0, expectedOffsetA)
+		assertGroupOffset(t, result, groupB, topic, 0, expectedOffsetB)
+	})
+
+	t.Run("retries on retriable per-group error", func(t *testing.T) {
+		first := &OffsetFetchResponse{Version: 8, Groups: []OffsetFetchResponseGroup{
+			{GroupId: groupA, Err: ErrNotCoordinatorForConsumer},
+			groupBlock(groupB, expectedOffsetB),
+		}}
+		second := &OffsetFetchResponse{Version: 8, Groups: []OffsetFetchResponseGroup{
+			groupBlock(groupA, expectedOffsetA),
+			groupBlock(groupB, expectedOffsetB),
+		}}
+		admin := setup(t, NewMockSequence(first, second), groupA, groupB)
+
+		result, err := admin.ListConsumerGroupOffsetsBatch(bothGroups)
+		require.NoError(t, err)
+		assertGroupOffset(t, result, groupA, topic, 0, expectedOffsetA)
+		assertGroupOffset(t, result, groupB, topic, 0, expectedOffsetB)
+	})
+
+	t.Run("returns non-retriable per-group error without retry", func(t *testing.T) {
+		resp := &OffsetFetchResponse{Version: 8, Groups: []OffsetFetchResponseGroup{
+			{GroupId: groupA, Err: ErrGroupAuthorizationFailed},
+			groupBlock(groupB, expectedOffsetB),
+		}}
+		admin := setup(t, NewMockWrapper(resp), groupA, groupB)
+
+		result, err := admin.ListConsumerGroupOffsetsBatch(bothGroups)
+		require.NoError(t, err)
+		require.Contains(t, result, groupA)
+		assert.Equal(t, ErrGroupAuthorizationFailed, result[groupA].Err)
+		assertGroupOffset(t, result, groupB, topic, 0, expectedOffsetB)
+	})
+
+	t.Run("splits groups across coordinators", func(t *testing.T) {
+		seed := newMockBroker(t, 1)
+		coordA := newMockBroker(t, 2)
+		coordB := newMockBroker(t, 3)
+		metadata := mockMetadataFor(t, seed, coordA, coordB)
+		findCoord := NewMockFindCoordinatorResponse(t).
+			SetCoordinator(CoordinatorGroup, groupA, coordA).
+			SetCoordinator(CoordinatorGroup, groupB, coordB)
+		seed.SetHandlerByMap(map[string]MockResponse{
+			"MetadataRequest":        metadata,
+			"FindCoordinatorRequest": findCoord,
+		})
+		for _, c := range []struct {
+			broker *MockBroker
+			group  string
+			offset int64
+		}{
+			{coordA, groupA, expectedOffsetA},
+			{coordB, groupB, expectedOffsetB},
+		} {
+			c.broker.SetHandlerByMap(map[string]MockResponse{
+				"MetadataRequest":        metadata,
+				"FindCoordinatorRequest": findCoord,
+				"OffsetFetchRequest": NewMockOffsetFetchResponse(t).
+					SetOffset(c.group, topic, 0, c.offset, "", ErrNoError).
+					SetError(ErrNoError),
+			})
+		}
+
+		result, err := newTestAdminAt(t, V3_0_0_0, seed).ListConsumerGroupOffsetsBatch(bothGroups)
+		require.NoError(t, err)
+		assertGroupOffset(t, result, groupA, topic, 0, expectedOffsetA)
+		assertGroupOffset(t, result, groupB, topic, 0, expectedOffsetB)
+	})
 }
 
 // newMockBroker spins up a MockBroker with auto-cleanup.
@@ -1807,13 +1977,39 @@ func newMockBroker(t *testing.T, id int32) *MockBroker {
 // retry backoff disabled and auto-cleanup.
 func newTestAdmin(t *testing.T, seed *MockBroker) ClusterAdmin {
 	t.Helper()
+	return newTestAdminAt(t, V2_1_0_0, seed)
+}
+
+// newTestAdminAt is like newTestAdmin but with a caller-chosen KafkaVersion.
+func newTestAdminAt(t *testing.T, version KafkaVersion, seed *MockBroker) ClusterAdmin {
+	t.Helper()
 	config := NewTestConfig()
-	config.Version = V2_1_0_0
+	config.Version = version
 	config.Admin.Retry.Backoff = 0
 	admin, err := NewClusterAdmin([]string{seed.Addr()}, config)
 	require.NoError(t, err)
 	t.Cleanup(func() { admin.Close() })
 	return admin
+}
+
+// mockGroupCoordinators builds a FindCoordinator handler placing every named
+// group on coordinator.
+func mockGroupCoordinators(t *testing.T, coordinator *MockBroker, groups ...string) *MockFindCoordinatorResponse {
+	t.Helper()
+	r := NewMockFindCoordinatorResponse(t)
+	for _, g := range groups {
+		r.SetCoordinator(CoordinatorGroup, g, coordinator)
+	}
+	return r
+}
+
+// assertGroupOffset asserts result has groupID with the expected offset at topic/partition.
+func assertGroupOffset(t *testing.T, result map[string]*OffsetFetchResponseGroup, groupID, topic string, partition int32, expected int64) {
+	t.Helper()
+	require.Contains(t, result, groupID)
+	block := result[groupID].GetBlock(topic, partition)
+	require.NotNil(t, block)
+	assert.Equal(t, expected, block.Offset)
 }
 
 // mockMetadataFor builds a MockMetadataResponse with controller and brokers

--- a/broker.go
+++ b/broker.go
@@ -1177,6 +1177,22 @@ func (b *Broker) sendAndReceive(req protocolBody, res protocolBody) error {
 	return nil
 }
 
+// negotiateApiVersion clamps pb's version to the broker's advertised maximum
+// for pb's API (treating pb's current version as the client max). When the
+// broker has not advertised ApiVersions info, pb's version is left untouched
+// (optimistic). Returns (0, false) if the resulting version is below
+// minVersion.
+func (b *Broker) negotiateApiVersion(pb protocolBody, minVersion int16) (int16, bool) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	_ = restrictApiVersion(pb, b.brokerAPIVersions)
+	if pb.version() < minVersion {
+		return 0, false
+	}
+	return pb.version(), true
+}
+
 func handleResponsePromise(req protocolBody, res protocolBody, promise *responsePromise, metricRegistry metrics.Registry) error {
 	select {
 	case buf := <-promise.packets:

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -425,6 +425,59 @@ func TestFuncAdminListConsumerGroupOffsets(t *testing.T) {
 	t.Logf("coordinator broker %d", coordinator.id)
 }
 
+func TestFuncAdminListConsumerGroupOffsetsBatch(t *testing.T) {
+	checkKafkaVersion(t, "3.0.0.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	config := NewFunctionalTestConfig()
+	config.ClientID = t.Name()
+	client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer safeClose(t, client)
+
+	groupA := testFuncConsumerGroupID(t)
+	groupB := testFuncConsumerGroupID(t)
+	const (
+		topic      = "test.4"
+		partition  = int32(0)
+		offsetGrpA = int64(2)
+		offsetGrpB = int64(3)
+	)
+
+	for _, c := range []struct {
+		group  string
+		offset int64
+	}{{groupA, offsetGrpA}, {groupB, offsetGrpB}} {
+		offsetMgr, err := NewOffsetManagerFromClient(c.group, client)
+		require.NoError(t, err)
+		markOffset(t, offsetMgr, topic, partition, c.offset)
+		offsetMgr.Commit()
+		safeClose(t, offsetMgr)
+	}
+
+	adminClient, err := NewClusterAdminFromClient(client)
+	require.NoError(t, err)
+
+	result, err := adminClient.ListConsumerGroupOffsetsBatch(map[string]map[string][]int32{
+		groupA: {topic: {partition}},
+		groupB: {topic: {partition}},
+	})
+	require.NoError(t, err)
+
+	for _, c := range []struct {
+		group  string
+		offset int64
+	}{{groupA, offsetGrpA}, {groupB, offsetGrpB}} {
+		require.Contains(t, result, c.group)
+		require.Equal(t, ErrNoError, result[c.group].Err)
+		block := result[c.group].GetBlock(topic, partition)
+		require.NotNil(t, block, "missing block for %s/%s/%d", c.group, topic, partition)
+		require.Equal(t, ErrNoError, block.Err)
+		require.Equal(t, c.offset, block.Offset)
+	}
+}
+
 func TestFuncAdminListOffsets(t *testing.T) {
 	t.Parallel()
 	checkKafkaVersion(t, "2.1.0.0")

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -644,9 +644,23 @@ func (mr *MockOffsetFetchResponse) SetError(kerror KError) *MockOffsetFetchRespo
 
 func (mr *MockOffsetFetchResponse) For(reqBody versionedDecoder) encoderWithHeader {
 	req := reqBody.(*OffsetFetchRequest)
-	group := req.ConsumerGroup
 	res := &OffsetFetchResponse{Version: req.Version}
 
+	if res.Version >= 8 {
+		res.Groups = make([]OffsetFetchResponseGroup, len(req.Groups))
+		for i, g := range req.Groups {
+			respGroup := OffsetFetchResponseGroup{GroupId: g.GroupId, Err: mr.error}
+			for topic, partitions := range mr.offsets[g.GroupId] {
+				for partition, block := range partitions {
+					respGroup.AddBlock(topic, partition, block)
+				}
+			}
+			res.Groups[i] = respGroup
+		}
+		return res
+	}
+
+	group := req.ConsumerGroup
 	for topic, partitions := range mr.offsets[group] {
 		for partition, block := range partitions {
 			res.AddBlock(topic, partition, block)

--- a/offset_fetch_request.go
+++ b/offset_fetch_request.go
@@ -1,10 +1,25 @@
 package sarama
 
+// OffsetFetchRequestGroup is a per-group entry in an OffsetFetch v8+ request.
+// A nil Partitions map fetches offsets for all topics in the group.
+type OffsetFetchRequestGroup struct {
+	GroupId    string
+	Partitions map[string][]int32
+}
+
+func (g *OffsetFetchRequestGroup) AddPartition(topic string, partitionID int32) {
+	if g.Partitions == nil {
+		g.Partitions = make(map[string][]int32)
+	}
+	g.Partitions[topic] = append(g.Partitions[topic], partitionID)
+}
+
 type OffsetFetchRequest struct {
 	Version       int16
-	ConsumerGroup string
-	RequireStable bool // requires v7+
+	ConsumerGroup string // v0-7; on v8+ populate Groups instead
+	RequireStable bool   // v7+
 	partitions    map[string][]int32
+	Groups        []OffsetFetchRequestGroup // v8+
 }
 
 func (r *OffsetFetchRequest) setVersion(v int16) {
@@ -19,6 +34,12 @@ func NewOffsetFetchRequest(
 	request := &OffsetFetchRequest{
 		ConsumerGroup: group,
 		partitions:    partitions,
+	}
+	if version.IsAtLeast(V3_0_0_0) {
+		// Version 8 is adding support for fetching offsets for multiple groups at a time.
+		request.Version = 8
+		request.Groups = []OffsetFetchRequestGroup{{GroupId: group, Partitions: partitions}}
+		return request
 	}
 	if version.IsAtLeast(V2_5_0_0) {
 		// Version 7 is adding the require stable flag.
@@ -49,26 +70,72 @@ func NewOffsetFetchRequest(
 }
 
 func (r *OffsetFetchRequest) encode(pe packetEncoder) (err error) {
-	if r.Version < 0 || r.Version > 7 {
+	if r.Version < 0 || r.Version > 8 {
 		return PacketEncodingError{"invalid or unsupported OffsetFetchRequest version field"}
 	}
 
-	err = pe.putString(r.ConsumerGroup)
+	if r.RequireStable && r.Version < 7 {
+		return PacketEncodingError{"requireStable is not supported. use version 7 or later"}
+	}
+
+	if r.Version >= 8 {
+		if err := pe.putArrayLength(len(r.Groups)); err != nil {
+			return err
+		}
+		for _, g := range r.Groups {
+			if err := pe.putString(g.GroupId); err != nil {
+				return err
+			}
+
+			// nil Partitions encodes as null topics array (fetch all)
+			topicCount := len(g.Partitions)
+			if g.Partitions == nil {
+				topicCount = -1
+			}
+			if err := pe.putArrayLength(topicCount); err != nil {
+				return err
+			}
+			for topic, partitions := range g.Partitions {
+				if err := pe.putString(topic); err != nil {
+					return err
+				}
+				if err := pe.putInt32Array(partitions); err != nil {
+					return err
+				}
+				pe.putEmptyTaggedFieldArray()
+			}
+
+			pe.putEmptyTaggedFieldArray()
+		}
+
+		pe.putBool(r.RequireStable)
+		pe.putEmptyTaggedFieldArray()
+		return nil
+	}
+
+	consumerGroup := r.ConsumerGroup
+	partitions := r.partitions
+	if consumerGroup == "" && len(r.Groups) == 1 {
+		consumerGroup = r.Groups[0].GroupId
+		partitions = r.Groups[0].Partitions
+	}
+
+	err = pe.putString(consumerGroup)
 	if err != nil {
 		return err
 	}
 
-	if r.partitions == nil && r.Version >= 2 {
+	if partitions == nil && r.Version >= 2 {
 		if err := pe.putArrayLength(-1); err != nil {
 			return err
 		}
 	} else {
-		if err = pe.putArrayLength(len(r.partitions)); err != nil {
+		if err = pe.putArrayLength(len(partitions)); err != nil {
 			return err
 		}
 	}
 
-	for topic, partitions := range r.partitions {
+	for topic, partitions := range partitions {
 		err = pe.putString(topic)
 		if err != nil {
 			return err
@@ -82,10 +149,6 @@ func (r *OffsetFetchRequest) encode(pe packetEncoder) (err error) {
 		pe.putEmptyTaggedFieldArray()
 	}
 
-	if r.RequireStable && r.Version < 7 {
-		return PacketEncodingError{"requireStable is not supported. use version 7 or later"}
-	}
-
 	if r.Version >= 7 {
 		pe.putBool(r.RequireStable)
 	}
@@ -96,6 +159,64 @@ func (r *OffsetFetchRequest) encode(pe packetEncoder) (err error) {
 
 func (r *OffsetFetchRequest) decode(pd packetDecoder, version int16) (err error) {
 	r.Version = version
+
+	if r.Version >= 8 {
+		groupCount, err := pd.getArrayLength()
+		if err != nil {
+			return err
+		}
+		if groupCount > 0 {
+			r.Groups = make([]OffsetFetchRequestGroup, groupCount)
+		}
+		for i := range groupCount {
+			groupID, err := pd.getString()
+			if err != nil {
+				return err
+			}
+			r.Groups[i].GroupId = groupID
+
+			// peek first byte to distinguish null (0x00) from empty (0x01)
+			topicCountMarker, err := pd.peekInt8(0)
+			if err != nil {
+				return err
+			}
+			topicCount, err := pd.getArrayLength()
+			if err != nil {
+				return err
+			}
+			if topicCountMarker != 0 {
+				partitions := make(map[string][]int32, topicCount)
+				for range topicCount {
+					topic, err := pd.getString()
+					if err != nil {
+						return err
+					}
+					ps, err := pd.getInt32Array()
+					if err != nil {
+						return err
+					}
+					if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+						return err
+					}
+					partitions[topic] = ps
+				}
+				r.Groups[i].Partitions = partitions
+			}
+
+			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+				return err
+			}
+		}
+
+		r.RequireStable, err = pd.getBool()
+		if err != nil {
+			return err
+		}
+
+		_, err = pd.getEmptyTaggedFieldArray()
+		return err
+	}
+
 	r.ConsumerGroup, err = pd.getString()
 	if err != nil {
 		return err
@@ -157,7 +278,7 @@ func (r *OffsetFetchRequest) headerVersion() int16 {
 }
 
 func (r *OffsetFetchRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 8
 }
 
 func (r *OffsetFetchRequest) isFlexible() bool {
@@ -170,6 +291,8 @@ func (r *OffsetFetchRequest) isFlexibleVersion(version int16) bool {
 
 func (r *OffsetFetchRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 8:
+		return V3_0_0_0
 	case 7:
 		return V2_5_0_0
 	case 6:
@@ -192,15 +315,47 @@ func (r *OffsetFetchRequest) requiredVersion() KafkaVersion {
 }
 
 func (r *OffsetFetchRequest) ZeroPartitions() {
+	if r.Version >= 8 {
+		if len(r.Groups) == 0 {
+			r.Groups = []OffsetFetchRequestGroup{{GroupId: r.ConsumerGroup}}
+		}
+		if r.Groups[0].Partitions == nil {
+			r.Groups[0].Partitions = make(map[string][]int32)
+		}
+		return
+	}
 	if r.partitions == nil && r.Version >= 2 {
 		r.partitions = make(map[string][]int32)
 	}
 }
 
+// AddPartition appends a partition to the request. On v8+ it targets Groups[0]
+// (seeded from ConsumerGroup if needed); use AddGroupPartition for v8 batches.
 func (r *OffsetFetchRequest) AddPartition(topic string, partitionID int32) {
+	if r.Version >= 8 {
+		if len(r.Groups) == 0 {
+			r.Groups = []OffsetFetchRequestGroup{{GroupId: r.ConsumerGroup}}
+		}
+		r.Groups[0].AddPartition(topic, partitionID)
+		return
+	}
 	if r.partitions == nil {
 		r.partitions = make(map[string][]int32)
 	}
 
 	r.partitions[topic] = append(r.partitions[topic], partitionID)
+}
+
+// AddGroupPartition adds a partition under group in a v8+ batch, creating the
+// group entry if absent.
+func (r *OffsetFetchRequest) AddGroupPartition(group, topic string, partitionID int32) {
+	for i := range r.Groups {
+		if r.Groups[i].GroupId == group {
+			r.Groups[i].AddPartition(topic, partitionID)
+			return
+		}
+	}
+	g := OffsetFetchRequestGroup{GroupId: group}
+	g.AddPartition(topic, partitionID)
+	r.Groups = append(r.Groups, g)
 }

--- a/offset_fetch_request.go
+++ b/offset_fetch_request.go
@@ -79,6 +79,9 @@ func (r *OffsetFetchRequest) encode(pe packetEncoder) (err error) {
 	}
 
 	if r.Version >= 8 {
+		if len(r.Groups) == 0 {
+			return PacketEncodingError{"version 8 or later requires Groups to be populated"}
+		}
 		if err := pe.putArrayLength(len(r.Groups)); err != nil {
 			return err
 		}
@@ -111,6 +114,10 @@ func (r *OffsetFetchRequest) encode(pe packetEncoder) (err error) {
 		pe.putBool(r.RequireStable)
 		pe.putEmptyTaggedFieldArray()
 		return nil
+	}
+
+	if len(r.Groups) > 1 {
+		return PacketEncodingError{"multiple groups require version 8 or later"}
 	}
 
 	consumerGroup := r.ConsumerGroup

--- a/offset_fetch_request_test.go
+++ b/offset_fetch_request_test.go
@@ -5,6 +5,9 @@ package sarama
 import (
 	"fmt"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -50,9 +53,52 @@ var (
 		0x00, 0x00, 0x00,
 	}
 
+	offsetFetchRequestNoPartitionsV8 = []byte{
+		0x02,                     // Groups array, length 1
+		0x05, 'b', 'l', 'a', 'h', // GroupId "blah"
+		0x01, // Topics array, length 0
+		0x00, // per-group tagged fields
+		0x01, // RequireStable = true
+		0x00, // top-level tagged fields
+	}
+
+	offsetFetchRequestOnePartitionV8 = []byte{
+		0x02,                     // Groups array, length 1
+		0x05, 'b', 'l', 'a', 'h', // GroupId "blah"
+		0x02,                                                                  // Topics array, length 1
+		0x0E, 't', 'o', 'p', 'i', 'c', 'T', 'h', 'e', 'F', 'i', 'r', 's', 't', // topic name
+		0x02,                   // PartitionIndexes array, length 1
+		0x4F, 0x4F, 0x4F, 0x4F, // partition index
+		0x00, // per-topic tagged fields
+		0x00, // per-group tagged fields
+		0x00, // RequireStable = false
+		0x00, // top-level tagged fields
+	}
+
 	offsetFetchRequestAllPartitions = []byte{
 		0x00, 0x04, 'b', 'l', 'a', 'h',
 		0xff, 0xff, 0xff, 0xff,
+	}
+
+	offsetFetchRequestAllPartitionsV8 = []byte{
+		0x02,                     // Groups array, length 1
+		0x05, 'b', 'l', 'a', 'h', // GroupId "blah"
+		0x00, // Topics array, null (fetch all topics)
+		0x00, // per-group tagged fields
+		0x00, // RequireStable = false
+		0x00, // top-level tagged fields
+	}
+
+	offsetFetchRequestTwoGroupsV8 = []byte{
+		0x03,                     // Groups array, length 2
+		0x05, 'b', 'l', 'a', 'h', // GroupId "blah"
+		0x01,                // Topics array, length 0
+		0x00,                // per-group tagged fields
+		0x04, 'q', 'u', 'x', // GroupId "qux"
+		0x01, // Topics array, length 0
+		0x00, // per-group tagged fields
+		0x00, // RequireStable = false
+		0x00, // top-level tagged fields
 	}
 )
 
@@ -87,6 +133,17 @@ func TestOffsetFetchRequestNoPartitions(t *testing.T) {
 
 		testRequest(t, fmt.Sprintf("no partitions %d", version), request, offsetFetchRequestNoPartitionsV7)
 	}
+
+	{ // v8
+		request := &OffsetFetchRequest{
+			Version:       8,
+			RequireStable: true,
+			Groups: []OffsetFetchRequestGroup{
+				{GroupId: "blah", Partitions: map[string][]int32{}},
+			},
+		}
+		testRequest(t, "no partitions 8", request, offsetFetchRequestNoPartitionsV8)
+	}
 }
 
 func TestOffsetFetchRequest(t *testing.T) {
@@ -115,6 +172,67 @@ func TestOffsetFetchRequest(t *testing.T) {
 		request.AddPartition("topicTheFirst", 0x4F4F4F4F)
 		testRequest(t, fmt.Sprintf("one partition %d", version), request, offsetFetchRequestOnePartitionV7)
 	}
+
+	{ // v8
+		request := &OffsetFetchRequest{
+			Version: 8,
+			Groups: []OffsetFetchRequestGroup{
+				{GroupId: "blah", Partitions: map[string][]int32{"topicTheFirst": {0x4F4F4F4F}}},
+			},
+		}
+		testRequest(t, "one partition 8", request, offsetFetchRequestOnePartitionV8)
+	}
+
+	{ // v8, two groups
+		request := &OffsetFetchRequest{
+			Version: 8,
+			Groups: []OffsetFetchRequestGroup{
+				{GroupId: "blah", Partitions: map[string][]int32{}},
+				{GroupId: "qux", Partitions: map[string][]int32{}},
+			},
+		}
+		testRequest(t, "two groups v8", request, offsetFetchRequestTwoGroupsV8)
+	}
+
+	{ // downgraded single-group v8 request
+		request := &OffsetFetchRequest{
+			Version: 7,
+			Groups: []OffsetFetchRequestGroup{
+				{GroupId: "blah", Partitions: map[string][]int32{"topicTheFirst": {0x4F4F4F4F}}},
+			},
+		}
+		testRequestEncode(t, "downgraded single group fallback", request, offsetFetchRequestOnePartitionV7)
+	}
+}
+
+func TestOffsetFetchRequestAddGroupPartition(t *testing.T) {
+	t.Run("creates a new group entry", func(t *testing.T) {
+		request := &OffsetFetchRequest{Version: 8}
+		request.AddGroupPartition("g1", "t1", 0)
+
+		require.Len(t, request.Groups, 1)
+		assert.Equal(t, "g1", request.Groups[0].GroupId)
+		assert.Equal(t, []int32{0}, request.Groups[0].Partitions["t1"])
+	})
+
+	t.Run("appends to an existing group entry", func(t *testing.T) {
+		request := &OffsetFetchRequest{
+			Version: 8,
+			Groups: []OffsetFetchRequestGroup{
+				{GroupId: "g1", Partitions: map[string][]int32{"t1": {0}}},
+			},
+		}
+		request.AddGroupPartition("g1", "t1", 1)
+		request.AddGroupPartition("g1", "t2", 7)
+		request.AddGroupPartition("g2", "t3", 2)
+
+		require.Len(t, request.Groups, 2)
+		assert.Equal(t, "g1", request.Groups[0].GroupId)
+		assert.Equal(t, []int32{0, 1}, request.Groups[0].Partitions["t1"])
+		assert.Equal(t, []int32{7}, request.Groups[0].Partitions["t2"])
+		assert.Equal(t, "g2", request.Groups[1].GroupId)
+		assert.Equal(t, []int32{2}, request.Groups[1].Partitions["t3"])
+	})
 }
 
 func TestOffsetFetchRequestAllPartitions(t *testing.T) {
@@ -122,4 +240,33 @@ func TestOffsetFetchRequestAllPartitions(t *testing.T) {
 		request := &OffsetFetchRequest{Version: int16(version), ConsumerGroup: "blah"}
 		testRequest(t, fmt.Sprintf("all partitions %d", version), request, offsetFetchRequestAllPartitions)
 	}
+
+	{ // v8
+		request := &OffsetFetchRequest{
+			Version: 8,
+			Groups: []OffsetFetchRequestGroup{
+				{GroupId: "blah", Partitions: nil},
+			},
+		}
+		testRequest(t, "all partitions 8", request, offsetFetchRequestAllPartitionsV8)
+	}
+
+	{ // decoded v8 null topics array
+		request := new(OffsetFetchRequest)
+		require.NoError(t, versionedDecode(offsetFetchRequestAllPartitionsV8, request, 8, nil))
+		require.Len(t, request.Groups, 1)
+		assert.Nil(t, request.Groups[0].Partitions)
+
+		packet := testRequestEncode(t, "decoded all partitions 8", request, offsetFetchRequestAllPartitionsV8)
+		testRequestDecode(t, "decoded all partitions 8", request, packet)
+	}
+}
+
+func TestNewOffsetFetchRequestDowngrade(t *testing.T) {
+	request := NewOffsetFetchRequest(V3_0_0_0, "blah", map[string][]int32{"topicTheFirst": {0x4F4F4F4F}})
+	request.setVersion(7)
+
+	assert.Equal(t, "blah", request.ConsumerGroup)
+	assert.Equal(t, map[string][]int32{"topicTheFirst": {int32(0x4F4F4F4F)}}, request.partitions)
+	testRequestEncode(t, "downgraded single group v8 request", request, offsetFetchRequestOnePartitionV7)
 }

--- a/offset_fetch_request_test.go
+++ b/offset_fetch_request_test.go
@@ -205,6 +205,26 @@ func TestOffsetFetchRequest(t *testing.T) {
 	}
 }
 
+func TestOffsetFetchRequestValidation(t *testing.T) {
+	t.Run("v8 with empty groups", func(t *testing.T) {
+		request := &OffsetFetchRequest{Version: 8}
+		_, err := encode(request, nil)
+		require.ErrorContains(t, err, "version 8 or later requires Groups to be populated")
+	})
+
+	t.Run("pre-v8 with multiple groups", func(t *testing.T) {
+		request := &OffsetFetchRequest{
+			Version: 7,
+			Groups: []OffsetFetchRequestGroup{
+				{GroupId: "a"},
+				{GroupId: "b"},
+			},
+		}
+		_, err := encode(request, nil)
+		require.ErrorContains(t, err, "multiple groups require version 8 or later")
+	})
+}
+
 func TestOffsetFetchRequestAddGroupPartition(t *testing.T) {
 	t.Run("creates a new group entry", func(t *testing.T) {
 		request := &OffsetFetchRequest{Version: 8}

--- a/offset_fetch_response.go
+++ b/offset_fetch_response.go
@@ -58,11 +58,41 @@ func (b *OffsetFetchResponseBlock) encode(pe packetEncoder, version int16) (err 
 	return nil
 }
 
+// OffsetFetchResponseGroup is a per-group entry in an OffsetFetch v8+ response.
+type OffsetFetchResponseGroup struct {
+	GroupId string
+	Blocks  map[string]map[int32]*OffsetFetchResponseBlock
+	Err     KError
+}
+
+func (g *OffsetFetchResponseGroup) AddBlock(topic string, partition int32, block *OffsetFetchResponseBlock) {
+	if g.Blocks == nil {
+		g.Blocks = make(map[string]map[int32]*OffsetFetchResponseBlock)
+	}
+	partitions := g.Blocks[topic]
+	if partitions == nil {
+		partitions = make(map[int32]*OffsetFetchResponseBlock)
+		g.Blocks[topic] = partitions
+	}
+	partitions[partition] = block
+}
+
+func (g *OffsetFetchResponseGroup) GetBlock(topic string, partition int32) *OffsetFetchResponseBlock {
+	if g.Blocks == nil {
+		return nil
+	}
+	if g.Blocks[topic] == nil {
+		return nil
+	}
+	return g.Blocks[topic][partition]
+}
+
 type OffsetFetchResponse struct {
 	Version        int16
 	ThrottleTimeMs int32
-	Blocks         map[string]map[int32]*OffsetFetchResponseBlock
-	Err            KError
+	Blocks         map[string]map[int32]*OffsetFetchResponseBlock // v0-7; on v8+ see Groups
+	Err            KError                                         // v0-7; on v8+ see Groups[i].Err
+	Groups         []OffsetFetchResponseGroup                     // v8+
 }
 
 func (r *OffsetFetchResponse) setVersion(v int16) {
@@ -73,6 +103,43 @@ func (r *OffsetFetchResponse) encode(pe packetEncoder) (err error) {
 	if r.Version >= 3 {
 		pe.putInt32(r.ThrottleTimeMs)
 	}
+
+	if r.Version >= 8 {
+		if err := pe.putArrayLength(len(r.Groups)); err != nil {
+			return err
+		}
+		for _, g := range r.Groups {
+			if err := pe.putString(g.GroupId); err != nil {
+				return err
+			}
+
+			if err := pe.putArrayLength(len(g.Blocks)); err != nil {
+				return err
+			}
+			for topic, partitions := range g.Blocks {
+				if err := pe.putString(topic); err != nil {
+					return err
+				}
+				if err := pe.putArrayLength(len(partitions)); err != nil {
+					return err
+				}
+				for partition, block := range partitions {
+					pe.putInt32(partition)
+					if err := block.encode(pe, r.Version); err != nil {
+						return err
+					}
+				}
+				pe.putEmptyTaggedFieldArray()
+			}
+
+			pe.putKError(g.Err)
+			pe.putEmptyTaggedFieldArray()
+		}
+
+		pe.putEmptyTaggedFieldArray()
+		return nil
+	}
+
 	err = pe.putArrayLength(len(r.Blocks))
 	if err != nil {
 		return err
@@ -111,6 +178,80 @@ func (r *OffsetFetchResponse) decode(pd packetDecoder, version int16) (err error
 		if err != nil {
 			return err
 		}
+	}
+
+	if version >= 8 {
+		groupCount, err := pd.getArrayLength()
+		if err != nil {
+			return err
+		}
+		if groupCount > 0 {
+			r.Groups = make([]OffsetFetchResponseGroup, groupCount)
+		}
+		for i := range groupCount {
+			groupID, err := pd.getString()
+			if err != nil {
+				return err
+			}
+			r.Groups[i].GroupId = groupID
+
+			numTopics, err := pd.getArrayLength()
+			if err != nil {
+				return err
+			}
+
+			blocks := make(map[string]map[int32]*OffsetFetchResponseBlock, numTopics)
+			for range numTopics {
+				name, err := pd.getString()
+				if err != nil {
+					return err
+				}
+
+				numBlocks, err := pd.getArrayLength()
+				if err != nil {
+					return err
+				}
+
+				blocks[name] = nil
+				if numBlocks > 0 {
+					blocks[name] = make(map[int32]*OffsetFetchResponseBlock, numBlocks)
+				}
+				for range numBlocks {
+					id, err := pd.getInt32()
+					if err != nil {
+						return err
+					}
+
+					block := new(OffsetFetchResponseBlock)
+					if err := block.decode(pd, version); err != nil {
+						return err
+					}
+
+					blocks[name][id] = block
+				}
+
+				if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+					return err
+				}
+			}
+			r.Groups[i].Blocks = blocks
+
+			groupErr, err := pd.getKError()
+			if err != nil {
+				return err
+			}
+			r.Groups[i].Err = groupErr
+
+			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+				return err
+			}
+		}
+		if len(r.Groups) > 0 {
+			r.Blocks = r.Groups[0].Blocks
+			r.Err = r.Groups[0].Err
+		}
+		_, err = pd.getEmptyTaggedFieldArray()
+		return err
 	}
 
 	numTopics, err := pd.getArrayLength()
@@ -184,7 +325,7 @@ func (r *OffsetFetchResponse) headerVersion() int16 {
 }
 
 func (r *OffsetFetchResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 8
 }
 
 func (r *OffsetFetchResponse) isFlexible() bool {
@@ -197,6 +338,8 @@ func (r *OffsetFetchResponse) isFlexibleVersion(version int16) bool {
 
 func (r *OffsetFetchResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 8:
+		return V3_0_0_0
 	case 7:
 		return V2_5_0_0
 	case 6:
@@ -222,7 +365,39 @@ func (r *OffsetFetchResponse) throttleTime() time.Duration {
 	return time.Duration(r.ThrottleTimeMs) * time.Millisecond
 }
 
+// GroupError returns the group-level error: for v8+ the error of Groups[0],
+// otherwise the top-level Err.
+func (r *OffsetFetchResponse) GroupError() KError {
+	if r.Version >= 8 {
+		if len(r.Groups) == 0 {
+			return ErrNoError
+		}
+		return r.Groups[0].Err
+	}
+	return r.Err
+}
+
+// GetGroup returns the per-group entry for groupID, or nil if absent or on v0-7.
+func (r *OffsetFetchResponse) GetGroup(groupID string) *OffsetFetchResponseGroup {
+	if r.Version < 8 {
+		return nil
+	}
+	for i := range r.Groups {
+		if r.Groups[i].GroupId == groupID {
+			return &r.Groups[i]
+		}
+	}
+	return nil
+}
+
+// GetBlock returns the block for topic/partition. On v8+ it looks up Groups[0].
 func (r *OffsetFetchResponse) GetBlock(topic string, partition int32) *OffsetFetchResponseBlock {
+	if r.Version >= 8 {
+		if len(r.Groups) == 0 {
+			return nil
+		}
+		return r.Groups[0].GetBlock(topic, partition)
+	}
 	if r.Blocks == nil {
 		return nil
 	}
@@ -234,7 +409,28 @@ func (r *OffsetFetchResponse) GetBlock(topic string, partition int32) *OffsetFet
 	return r.Blocks[topic][partition]
 }
 
+// GetGroupBlock returns the block for groupID/topic/partition, or nil on v0-7.
+func (r *OffsetFetchResponse) GetGroupBlock(groupID string, topic string, partition int32) *OffsetFetchResponseBlock {
+	if r.Version < 8 {
+		return nil
+	}
+	group := r.GetGroup(groupID)
+	if group == nil {
+		return nil
+	}
+	return group.GetBlock(topic, partition)
+}
+
+// AddBlock adds a block for topic/partition. On v8+ it appends under Groups[0],
+// creating it if needed.
 func (r *OffsetFetchResponse) AddBlock(topic string, partition int32, block *OffsetFetchResponseBlock) {
+	if r.Version >= 8 {
+		if len(r.Groups) == 0 {
+			r.Groups = []OffsetFetchResponseGroup{{}}
+		}
+		r.Groups[0].AddBlock(topic, partition, block)
+		return
+	}
 	if r.Blocks == nil {
 		r.Blocks = make(map[string]map[int32]*OffsetFetchResponseBlock)
 	}
@@ -244,4 +440,19 @@ func (r *OffsetFetchResponse) AddBlock(topic string, partition int32, block *Off
 		r.Blocks[topic] = partitions
 	}
 	partitions[partition] = block
+}
+
+// AddGroupBlock adds a block for groupID/topic/partition, creating the group
+// entry if needed. On v0-7 it falls back to AddBlock and ignores groupID.
+func (r *OffsetFetchResponse) AddGroupBlock(groupID string, topic string, partition int32, block *OffsetFetchResponseBlock) {
+	if r.Version < 8 {
+		r.AddBlock(topic, partition, block)
+		return
+	}
+	group := r.GetGroup(groupID)
+	if group == nil {
+		r.Groups = append(r.Groups, OffsetFetchResponseGroup{GroupId: groupID})
+		group = &r.Groups[len(r.Groups)-1]
+	}
+	group.AddBlock(topic, partition, block)
 }

--- a/offset_fetch_response.go
+++ b/offset_fetch_response.go
@@ -78,12 +78,6 @@ func (g *OffsetFetchResponseGroup) AddBlock(topic string, partition int32, block
 }
 
 func (g *OffsetFetchResponseGroup) GetBlock(topic string, partition int32) *OffsetFetchResponseBlock {
-	if g.Blocks == nil {
-		return nil
-	}
-	if g.Blocks[topic] == nil {
-		return nil
-	}
 	return g.Blocks[topic][partition]
 }
 

--- a/offset_fetch_response_test.go
+++ b/offset_fetch_response_test.go
@@ -37,6 +37,49 @@ var (
 		0x00, 0x00, 0x00, 0x00,
 		0x00, 0x2A,
 	}
+
+	emptyOffsetFetchResponseV8 = []byte{
+		0x00, 0x00, 0x00, 0x09, // ThrottleTime = 9
+		0x02,                     // Groups array, length 1
+		0x05, 'b', 'l', 'a', 'h', // GroupId "blah"
+		0x01,       // Topics array, length 0
+		0x00, 0x2A, // group-level ErrorCode = ErrInvalidRequest
+		0x00, // per-group tagged fields
+		0x00, // top-level tagged fields
+	}
+
+	offsetFetchResponseTwoGroupsV8 = []byte{
+		0x00, 0x00, 0x00, 0x09, // ThrottleTime = 9
+		0x03,                     // Groups array, length 2
+		0x05, 'b', 'l', 'a', 'h', // GroupId "blah"
+		0x01,       // Topics array, length 0
+		0x00, 0x00, // group-level ErrorCode = ErrNoError
+		0x00,                // per-group tagged fields
+		0x04, 'q', 'u', 'x', // GroupId "qux"
+		0x01,       // Topics array, length 0
+		0x00, 0x2A, // group-level ErrorCode = ErrInvalidRequest
+		0x00, // per-group tagged fields
+		0x00, // top-level tagged fields
+	}
+
+	offsetFetchResponseOnePartitionV8 = []byte{
+		0x00, 0x00, 0x00, 0x09, // ThrottleTime = 9
+		0x02,                     // Groups array, length 1
+		0x05, 'b', 'l', 'a', 'h', // GroupId "blah"
+		0x02,      // Topics array, length 1
+		0x02, 't', // topic name "t"
+		0x02,                   // Partitions array, length 1
+		0x00, 0x00, 0x00, 0x00, // PartitionIndex = 0
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0A, // CommittedOffset = 10
+		0x00, 0x00, 0x00, 0x64, // CommittedLeaderEpoch = 100
+		0x03, 'm', 'd', // Metadata "md"
+		0x00, 0x07, // ErrorCode = ErrRequestTimedOut
+		0x00,       // per-partition tagged fields
+		0x00,       // per-topic tagged fields
+		0x00, 0x2A, // group-level ErrorCode = ErrInvalidRequest
+		0x00, // per-group tagged fields
+		0x00, // top-level tagged fields
+	}
 )
 
 func TestEmptyOffsetFetchResponse(t *testing.T) {
@@ -52,6 +95,17 @@ func TestEmptyOffsetFetchResponse(t *testing.T) {
 		responseV3 := OffsetFetchResponse{Version: int16(version), Err: ErrInvalidRequest, ThrottleTimeMs: 9}
 		testResponse(t, fmt.Sprintf("empty v%d", version), &responseV3, emptyOffsetFetchResponseV3)
 	}
+
+	responseV8 := OffsetFetchResponse{
+		Version:        8,
+		ThrottleTimeMs: 9,
+		Blocks:         map[string]map[int32]*OffsetFetchResponseBlock{},
+		Err:            ErrInvalidRequest,
+		Groups: []OffsetFetchResponseGroup{
+			{GroupId: "blah", Blocks: map[string]map[int32]*OffsetFetchResponseBlock{}, Err: ErrInvalidRequest},
+		},
+	}
+	testResponse(t, "empty v8", &responseV8, emptyOffsetFetchResponseV8)
 }
 
 func TestOffsetFetchResponseNullMetadata(t *testing.T) {
@@ -93,4 +147,58 @@ func TestNormalOffsetFetchResponse(t *testing.T) {
 	responseV5.AddBlock("t", 0, &OffsetFetchResponseBlock{Offset: 10, LeaderEpoch: 100, Metadata: "md", Err: ErrRequestTimedOut})
 	responseV5.Blocks["m"] = nil
 	testResponse(t, "normal V5", &responseV5, nil)
+
+	responseV8 := OffsetFetchResponse{
+		Version:        8,
+		ThrottleTimeMs: 9,
+		Groups:         []OffsetFetchResponseGroup{{GroupId: "blah", Err: ErrInvalidRequest}},
+	}
+	responseV8.AddBlock("t", 0, &OffsetFetchResponseBlock{Offset: 10, LeaderEpoch: 100, Metadata: "md", Err: ErrRequestTimedOut})
+	responseV8.Blocks = responseV8.Groups[0].Blocks
+	responseV8.Err = responseV8.Groups[0].Err
+	testResponse(t, "normal v8", &responseV8, offsetFetchResponseOnePartitionV8)
+	// GetBlock should route through Groups[0] for v8+
+	block := responseV8.GetBlock("t", 0)
+	require.NotNil(t, block)
+	assert.Equal(t, int64(10), block.Offset)
+}
+
+func TestOffsetFetchResponseAddGroupBlockV8(t *testing.T) {
+	response := OffsetFetchResponse{Version: 8}
+	response.AddGroupBlock("g1", "t1", 0, &OffsetFetchResponseBlock{Offset: 100})
+	response.AddGroupBlock("g2", "t1", 0, &OffsetFetchResponseBlock{Offset: 200})
+
+	require.Len(t, response.Groups, 2)
+	assert.Equal(t, "g1", response.Groups[0].GroupId)
+	assert.Equal(t, int64(100), response.GetGroupBlock("g1", "t1", 0).Offset)
+	assert.Equal(t, "g2", response.Groups[1].GroupId)
+	assert.Equal(t, int64(200), response.GetGroupBlock("g2", "t1", 0).Offset)
+
+	// Check fallback for v0-7
+	responseV7 := OffsetFetchResponse{Version: 7}
+	responseV7.AddGroupBlock("g1", "t1", 0, &OffsetFetchResponseBlock{Offset: 300})
+	assert.Equal(t, int64(300), responseV7.GetBlock("t1", 0).Offset)
+	assert.Nil(t, responseV7.GetGroupBlock("g1", "t1", 0))
+}
+
+func TestOffsetFetchResponseMultipleGroupsV8(t *testing.T) {
+	response := OffsetFetchResponse{
+		Version:        8,
+		ThrottleTimeMs: 9,
+		Blocks:         map[string]map[int32]*OffsetFetchResponseBlock{},
+		Groups: []OffsetFetchResponseGroup{
+			{GroupId: "blah", Blocks: map[string]map[int32]*OffsetFetchResponseBlock{}, Err: ErrNoError},
+			{GroupId: "qux", Blocks: map[string]map[int32]*OffsetFetchResponseBlock{}, Err: ErrInvalidRequest},
+		},
+	}
+	testResponse(t, "two groups v8", &response, offsetFetchResponseTwoGroupsV8)
+
+	decoded := new(OffsetFetchResponse)
+	require.NoError(t, versionedDecode(offsetFetchResponseTwoGroupsV8, decoded, 8, nil))
+	require.Len(t, decoded.Groups, 2)
+	assert.Equal(t, "blah", decoded.Groups[0].GroupId)
+	assert.Equal(t, ErrNoError, decoded.Groups[0].Err)
+	assert.Equal(t, "qux", decoded.Groups[1].GroupId)
+	assert.Equal(t, ErrInvalidRequest, decoded.Groups[1].Err)
+	assert.Equal(t, ErrNoError, decoded.GroupError())
 }

--- a/request_test.go
+++ b/request_test.go
@@ -380,6 +380,12 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 			},
 		},
 		{
+			V3_0_0_0,
+			map[int16]int16{
+				apiKeyOffsetFetch: 8, // up from 7
+			},
+		},
+		{
 			V3_1_0_0,
 			map[int16]int16{
 				apiKeyJoinGroup: 8, // up from 7


### PR DESCRIPTION
This is quite tricky to support in a backwards compatible way because the previous API only supported fetching offsets for a single group and had top-level constructs for that, but from v8 onwards you can fetch for multiple groups in one request. We want to support that, but need to continue to support the old method and expectations around single group usage too, so we map to/from the fields on the fly, using Groups[0] in the v8 case. Eventually we'd want users to migrate entirely to the new APIs and we could remove the old ones.

Fixes #2827