### PR TITLE
feat: add Java-compatible murmur2 partitioner

### DIFF
--- a/functional_java_interop_test.go
+++ b/functional_java_interop_test.go
@@ -303,3 +303,175 @@ func javaConsumerArgs(topic string, startOffset int64, count int) []string {
 		"--max-messages", fmt.Sprint(count),
 	)
 }
+
+// produceKeyedWithJava produces key:value messages via the Java console producer,
+// which uses the DefaultPartitioner (murmur2) when a key is present.
+func produceKeyedWithJava(t *testing.T, topic string, messages []struct{ key, value string }) {
+	t.Helper()
+	producerPath := fmt.Sprintf("/opt/kafka-%s/bin/kafka-console-producer.sh", FunctionalTestEnv.KafkaVersion)
+	args := []string{"compose", "exec", "-T", brokerContainer, producerPath}
+	if kafkaVersionAtLeast("2.5.0") {
+		args = append(args, "--bootstrap-server", brokerAddr)
+	} else {
+		args = append(args, "--broker-list", brokerAddr)
+	}
+	args = append(args,
+		"--topic", topic,
+		"--property", "parse.key=true",
+		"--property", "key.separator=:",
+	)
+	cmd := exec.Command("docker", args...)
+
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+
+	stderr, err := cmd.StderrPipe()
+	require.NoError(t, err)
+
+	var stderrOutput strings.Builder
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s := bufio.NewScanner(stderr)
+		for s.Scan() {
+			stderrOutput.WriteString(s.Text() + "\n")
+		}
+	}()
+
+	require.NoError(t, cmd.Start())
+
+	for _, msg := range messages {
+		_, err := fmt.Fprintf(stdin, "%s:%s\n", msg.key, msg.value)
+		if err != nil {
+			stdin.Close()
+			waitErr := cmd.Wait()
+			wg.Wait()
+			if waitErr != nil {
+				err = fmt.Errorf("failed to write message: %w; Java producer failed: %w; stderr: %s", err, waitErr, stderrOutput.String())
+			}
+			require.NoError(t, err)
+		}
+	}
+	stdin.Close()
+
+	err = cmd.Wait()
+	wg.Wait()
+	if err != nil {
+		t.Logf("Java producer stderr: %s", stderrOutput.String())
+		require.NoError(t, err, "Java producer failed")
+	}
+}
+
+// consumeKeyedFromPartition consumes up to count messages from a specific partition,
+// returning them as key+value pairs.
+func consumeKeyedFromPartition(t *testing.T, topic string, partition int32, startOffset int64, count int) map[string]string {
+	t.Helper()
+	config := NewFunctionalTestConfig()
+	consumer, err := NewConsumer(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer consumer.Close()
+
+	pc, err := consumer.ConsumePartition(topic, partition, startOffset)
+	require.NoError(t, err)
+	defer pc.Close()
+
+	result := make(map[string]string, count)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	for len(result) < count {
+		select {
+		case msg := <-pc.Messages():
+			require.NotNil(t, msg)
+			result[string(msg.Key)] = string(msg.Value)
+		case err := <-pc.Errors():
+			require.NoError(t, err)
+		case <-ctx.Done():
+			return result
+		}
+	}
+	return result
+}
+
+// TestJavaMurmur2PartitionerInterop verifies that Sarama's NewMurmur2Partitioner
+// routes keyed messages to the same partitions as the Apache Kafka Java client's
+// DefaultPartitioner (which uses murmur2 internally).
+func TestJavaMurmur2PartitionerInterop(t *testing.T) {
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	checkKafkaVersion(t, "0.10.0")
+
+	const topic = "test.64"
+	const numPartitions = int32(64)
+
+	keyedMessages := []struct{ key, value string }{
+		{"foo", "value-foo"},
+		{"bar", "value-bar"},
+		{"baz", "value-baz"},
+		{"kafka", "value-kafka"},
+		{"sarama", "value-sarama"},
+		{"hello", "value-hello"},
+		{"world", "value-world"},
+	}
+
+	// record the end offsets per partition before we produce anything
+	startOffsets := make([]int64, numPartitions)
+	for p := int32(0); p < numPartitions; p++ {
+		startOffsets[p] = endOffsetForPartition(t, topic, p)
+	}
+
+	// produce with Java's DefaultPartitioner (murmur2)
+	produceKeyedWithJava(t, topic, keyedMessages)
+
+	// determine which partition each key landed on via Java
+	javaPartition := make(map[string]int32, len(keyedMessages))
+	for p := int32(0); p < numPartitions; p++ {
+		endOff := endOffsetForPartition(t, topic, p)
+		if endOff <= startOffsets[p] {
+			continue
+		}
+		msgs := consumeKeyedFromPartition(t, topic, p, startOffsets[p], int(endOff-startOffsets[p]))
+		for key := range msgs {
+			javaPartition[key] = p
+		}
+	}
+	require.Len(t, javaPartition, len(keyedMessages), "Java producer did not produce all messages")
+
+	// record new end offsets before Sarama production
+	for p := int32(0); p < numPartitions; p++ {
+		startOffsets[p] = endOffsetForPartition(t, topic, p)
+	}
+
+	// produce the same keyed messages with Sarama's murmur2 partitioner
+	config := NewFunctionalTestConfig()
+	config.Producer.Partitioner = NewMurmur2Partitioner
+	config.Producer.Return.Successes = true
+	config.Producer.RequiredAcks = WaitForAll
+
+	producer, err := NewSyncProducer(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer producer.Close()
+
+	saramaPartition := make(map[string]int32, len(keyedMessages))
+	for _, msg := range keyedMessages {
+		partition, _, err := producer.SendMessage(&ProducerMessage{
+			Topic: topic,
+			Key:   StringEncoder(msg.key),
+			Value: StringEncoder(msg.value),
+		})
+		require.NoError(t, err)
+		saramaPartition[msg.key] = partition
+	}
+
+	// assert every key landed on the same partition for both producers
+	for _, msg := range keyedMessages {
+		require.Equal(t,
+			javaPartition[msg.key],
+			saramaPartition[msg.key],
+			"key %q: Java partition %d != Sarama murmur2 partition %d",
+			msg.key, javaPartition[msg.key], saramaPartition[msg.key],
+		)
+	}
+}

--- a/murmur2.go
+++ b/murmur2.go
@@ -1,0 +1,42 @@
+package sarama
+
+// murmur2 implements the same hashing algorithm used by the Apache Kafka Java
+// client's DefaultPartitioner (org.apache.kafka.common.utils.Utils.murmur2).
+// It is a variant of MurmurHash2 with a fixed seed of 0x9747b28c and
+// little-endian byte ordering.
+//
+// Reference:
+//   - https://github.com/apache/kafka/blob/4.3.0/clients/src/main/java/org/apache/kafka/common/utils/Utils.java#L496-L541
+//   - https://github.com/aappleby/smhasher/blob/master/src/MurmurHash2.cpp
+func murmur2(b []byte) uint32 {
+	const (
+		seed uint32 = 0x9747b28c
+		m    uint32 = 0x5bd1e995
+		r           = 24
+	)
+	h := seed ^ uint32(len(b))
+	for len(b) >= 4 {
+		k := uint32(b[3])<<24 + uint32(b[2])<<16 + uint32(b[1])<<8 + uint32(b[0])
+		b = b[4:]
+		k *= m
+		k ^= k >> r
+		k *= m
+		h *= m
+		h ^= k
+	}
+	switch len(b) {
+	case 3:
+		h ^= uint32(b[2]) << 16
+		fallthrough
+	case 2:
+		h ^= uint32(b[1]) << 8
+		fallthrough
+	case 1:
+		h ^= uint32(b[0])
+		h *= m
+	}
+	h ^= h >> 13
+	h *= m
+	h ^= h >> 15
+	return h
+}

--- a/murmur2.go
+++ b/murmur2.go
@@ -1,5 +1,7 @@
 package sarama
 
+import "encoding/binary"
+
 // murmur2 implements the same hashing algorithm used by the Apache Kafka Java
 // client's DefaultPartitioner (org.apache.kafka.common.utils.Utils.murmur2).
 // It is a variant of MurmurHash2 with a fixed seed of 0x9747b28c and
@@ -16,7 +18,7 @@ func murmur2(b []byte) uint32 {
 	)
 	h := seed ^ uint32(len(b))
 	for len(b) >= 4 {
-		k := uint32(b[3])<<24 + uint32(b[2])<<16 + uint32(b[1])<<8 + uint32(b[0])
+		k := binary.LittleEndian.Uint32(b)
 		b = b[4:]
 		k *= m
 		k ^= k >> r

--- a/partitioner.go
+++ b/partitioner.go
@@ -246,3 +246,39 @@ func (p *hashPartitioner) RequiresConsistency() bool {
 func (p *hashPartitioner) MessageRequiresConsistency(message *ProducerMessage) bool {
 	return message.Key != nil
 }
+
+type murmur2Partitioner struct {
+	random Partitioner
+}
+
+// NewMurmur2Partitioner returns a Partitioner that replicates the partitioning
+// behavior of the Apache Kafka Java client's DefaultPartitioner. It uses the
+// murmur2 hash algorithm with the formula:
+//
+//	(murmur2(keyBytes) & 0x7fffffff) % numPartitions
+//
+// This guarantees that a given key is always routed to the same partition as a
+// Java producer using the default partitioner, enabling cross-language partition
+// affinity. If the message key is nil a random partition is chosen.
+func NewMurmur2Partitioner(topic string) Partitioner {
+	return &murmur2Partitioner{random: NewRandomPartitioner(topic)}
+}
+
+func (p *murmur2Partitioner) Partition(message *ProducerMessage, numPartitions int32) (int32, error) {
+	if message.Key == nil {
+		return p.random.Partition(message, numPartitions)
+	}
+	bytes, err := message.Key.Encode()
+	if err != nil {
+		return -1, err
+	}
+	return int32(murmur2(bytes)&0x7fffffff) % numPartitions, nil
+}
+
+func (p *murmur2Partitioner) RequiresConsistency() bool {
+	return true
+}
+
+func (p *murmur2Partitioner) MessageRequiresConsistency(message *ProducerMessage) bool {
+	return message.Key != nil
+}

--- a/partitioner_test.go
+++ b/partitioner_test.go
@@ -4,6 +4,7 @@ package sarama
 
 import (
 	"crypto/rand"
+	"fmt"
 	"hash/crc32"
 	"hash/fnv"
 	"log"
@@ -333,7 +334,7 @@ func TestMurmur2(t *testing.T) {
 		{"sarama", 770765511},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.input, func(t *testing.T) {
+		t.Run(fmt.Sprintf("input=%q", tc.input), func(t *testing.T) {
 			got := murmur2([]byte(tc.input))
 			if got != tc.expected {
 				t.Errorf("murmur2(%q) = %d, want %d", tc.input, got, tc.expected)

--- a/partitioner_test.go
+++ b/partitioner_test.go
@@ -318,6 +318,113 @@ func TestWithCustomFallbackPartitioner(t *testing.T) {
 	}
 }
 
+func TestMurmur2(t *testing.T) {
+	// expected values verified against the Apache Kafka Java client's
+	// org.apache.kafka.common.utils.Utils.murmur2() implementation
+	testCases := []struct {
+		input    string
+		expected uint32
+	}{
+		{"foo", 597841616},
+		{"bar", 988958145},
+		{"baz", 1973573280},
+		{"", 275646681},
+		{"kafka", 3496464228},
+		{"sarama", 770765511},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := murmur2([]byte(tc.input))
+			if got != tc.expected {
+				t.Errorf("murmur2(%q) = %d, want %d", tc.input, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestMurmur2Partitioner(t *testing.T) {
+	partitioner := NewMurmur2Partitioner("mytopic")
+
+	t.Run("single partition always returns 0", func(t *testing.T) {
+		choice, err := partitioner.Partition(&ProducerMessage{Key: StringEncoder("foo")}, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if choice != 0 {
+			t.Errorf("expected partition 0, got %d", choice)
+		}
+	})
+
+	t.Run("nil key returns random partition in range", func(t *testing.T) {
+		for i := 0; i < 50; i++ {
+			choice, err := partitioner.Partition(&ProducerMessage{}, 50)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if choice < 0 || choice >= 50 {
+				t.Errorf("partition %d out of range [0, 50)", choice)
+			}
+		}
+	})
+
+	t.Run("consistent for same key", func(t *testing.T) {
+		assertPartitioningConsistent(t, partitioner, &ProducerMessage{Key: StringEncoder("foo")}, 100)
+		assertPartitioningConsistent(t, partitioner, &ProducerMessage{Key: StringEncoder("bar")}, 100)
+	})
+
+	t.Run("partition in range for various keys", func(t *testing.T) {
+		keys := []string{"foo", "bar", "baz", "kafka", "sarama", "1468509572224"}
+		for _, key := range keys {
+			choice, err := partitioner.Partition(&ProducerMessage{Key: StringEncoder(key)}, 100)
+			if err != nil {
+				t.Fatalf("key %q: %v", key, err)
+			}
+			if choice < 0 || choice >= 100 {
+				t.Errorf("key %q: partition %d out of range [0, 100)", key, choice)
+			}
+		}
+	})
+
+	t.Run("known Java-compatible partition assignments", func(t *testing.T) {
+		// these expected partitions were verified against the Apache Kafka Java
+		// client's DefaultPartitioner with 100 partitions
+		testCases := []struct {
+			key       string
+			partition int32
+		}{
+			{"foo", 16},
+			{"bar", 45},
+			{"baz", 80},
+			{"kafka", 80},
+			{"sarama", 11},
+		}
+		for _, tc := range testCases {
+			choice, err := partitioner.Partition(&ProducerMessage{Key: StringEncoder(tc.key)}, 100)
+			if err != nil {
+				t.Fatalf("key %q: %v", tc.key, err)
+			}
+			if choice != tc.partition {
+				t.Errorf("key %q: got partition %d, want %d", tc.key, choice, tc.partition)
+			}
+		}
+	})
+}
+
+func TestMurmur2PartitionerConsistency(t *testing.T) {
+	partitioner := NewMurmur2Partitioner("mytopic")
+	ep, ok := partitioner.(DynamicConsistencyPartitioner)
+	if !ok {
+		t.Fatal("murmur2 partitioner does not implement DynamicConsistencyPartitioner")
+	}
+
+	if !ep.MessageRequiresConsistency(&ProducerMessage{Key: StringEncoder("hi")}) {
+		t.Error("messages with keys should require consistency")
+	}
+	if ep.MessageRequiresConsistency(&ProducerMessage{}) {
+		t.Error("messages without keys should not require consistency")
+	}
+}
+
 // By default, Sarama uses the message's key to consistently assign a partition to
 // a message using hashing. If no key is set, a random partition will be chosen.
 // This example shows how you can partition messages randomly, even when a key is set,


### PR DESCRIPTION
Add NewMurmur2Partitioner which replicates the Apache Kafka Java client's DefaultPartitioner hashing algorithm (Utils.murmur2), using the formula (murmur2(key) & 0x7fffffff) % numPartitions.

This allows Go producers to have partition affinity with Java producers without requiring users to supply their own custom partitioner.

Also adds unit tests covering raw hash values and known partition assignments, and a functional interop test that verifies Sarama's murmur2 partitioner routes keyed messages to the same partitions as the Java console producer.

Closes #3537