### PR TITLE
fix(offset): retry fetchInitialOffset on top-level coordinator errors

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -166,13 +166,17 @@ func (om *offsetManager) fetchInitialOffset(topic string, partition int32, retri
 
 	block := resp.GetBlock(topic, partition)
 	if block == nil {
-		return 0, 0, "", ErrIncompleteResponse
+		// v2+ surfaces some coordinator errors at the top level with no per-partition blocks
+		if resp.Err == ErrNoError {
+			return 0, 0, "", ErrIncompleteResponse
+		}
+		block = &OffsetFetchResponseBlock{Err: resp.Err}
 	}
 
 	switch block.Err {
 	case ErrNoError:
 		return block.Offset, block.LeaderEpoch, block.Metadata, nil
-	case ErrNotCoordinatorForConsumer:
+	case ErrNotCoordinatorForConsumer, ErrConsumerCoordinatorNotAvailable:
 		if retries <= 0 {
 			return 0, 0, "", block.Err
 		}

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func initOffsetManagerWithBackoffFunc(
@@ -559,6 +561,63 @@ func TestOffsetManagerFetchInitialLoadInProgress(t *testing.T) {
 	if retryCount.Load() == 0 {
 		t.Fatal("Expected at least one retry")
 	}
+}
+
+// fetchInitialOffset must retry when OffsetFetchResponse v2+ surfaces a
+// retriable coordinator error at the top level with no per-partition blocks
+func TestOffsetManagerFetchInitialTopLevelErr(t *testing.T) {
+	config := NewTestConfig()
+	config.Metadata.Retry.Max = 1
+	config.Consumer.Offsets.AutoCommit.Interval = 1 * time.Millisecond
+	// V0_10_2_0 is the first version that negotiates OffsetFetch v2,
+	// which carries a top-level error code
+	config.Version = V0_10_2_0
+
+	broker := NewMockBroker(t, 1)
+	defer broker.Close()
+	coordinator := NewMockBroker(t, 2)
+	defer coordinator.Close()
+
+	seedMeta := new(MetadataResponse)
+	seedMeta.AddBroker(coordinator.Addr(), coordinator.BrokerID())
+	seedMeta.AddTopicPartition("my_topic", 0, 1, []int32{}, []int32{}, []int32{}, ErrNoError)
+	broker.Returns(seedMeta)
+
+	testClient, err := NewClient([]string{broker.Addr()}, config)
+	require.NoError(t, err)
+
+	coordinator.Returns(&ConsumerMetadataResponse{
+		CoordinatorID:   coordinator.BrokerID(),
+		CoordinatorHost: "127.0.0.1",
+		CoordinatorPort: coordinator.Port(),
+	})
+
+	om, err := NewOffsetManagerFromClient("group", testClient)
+	require.NoError(t, err)
+
+	// first OffsetFetch reports NOT_COORDINATOR at the top level with no blocks
+	coordinator.Returns(&OffsetFetchResponse{Version: 2, Err: ErrNotCoordinatorForConsumer})
+
+	newCoordinator := NewMockBroker(t, 3)
+	defer newCoordinator.Close()
+	coordinator.Returns(&ConsumerMetadataResponse{
+		CoordinatorID:   newCoordinator.BrokerID(),
+		CoordinatorHost: "127.0.0.1",
+		CoordinatorPort: newCoordinator.Port(),
+	})
+
+	okResp := &OffsetFetchResponse{Version: 2}
+	okResp.AddBlock("my_topic", 0, &OffsetFetchResponseBlock{
+		Err: ErrNoError, Offset: 5, Metadata: "test_meta",
+	})
+	newCoordinator.Returns(okResp)
+
+	pom, err := om.ManagePartition("my_topic", 0)
+	require.NoError(t, err)
+
+	safeClose(t, pom)
+	safeClose(t, om)
+	safeClose(t, testClient)
 }
 
 func TestPartitionOffsetManagerInitialOffset(t *testing.T) {


### PR DESCRIPTION
OffsetFetchResponse v2+ can carry a retriable coordinator error at the top level with no per-partition blocks; route it through the existing retry switch instead of bailing as ErrIncompleteResponse.