### PR TITLE
feat(protocol): support LeaveGroupRequest/Response v5 (KIP-800)

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -665,14 +665,16 @@ func (c *consumerGroup) leave() error {
 		GroupId:  c.groupID,
 		MemberId: c.memberID,
 	}
-	if c.config.Version.IsAtLeast(V0_11_0_0) {
+	if c.config.Version.IsAtLeast(V3_2_0_0) {
+		req.Version = 5
+	} else if c.config.Version.IsAtLeast(V2_4_0_0) {
+		req.Version = 4
+	} else if c.config.Version.IsAtLeast(V2_0_0_0) {
+		req.Version = 2
+	} else if c.config.Version.IsAtLeast(V0_11_0_0) {
 		req.Version = 1
 	}
-	if c.config.Version.IsAtLeast(V2_0_0_0) {
-		req.Version = 2
-	}
-	if c.config.Version.IsAtLeast(V2_4_0_0) {
-		req.Version = 4
+	if req.Version >= 3 {
 		req.Members = append(req.Members, MemberIdentity{
 			MemberId: c.memberID,
 		})

--- a/leave_group_request.go
+++ b/leave_group_request.go
@@ -3,6 +3,7 @@ package sarama
 type MemberIdentity struct {
 	MemberId        string
 	GroupInstanceId *string
+	Reason          *string // v5, nullable
 }
 
 type LeaveGroupRequest struct {
@@ -36,6 +37,11 @@ func (r *LeaveGroupRequest) encode(pe packetEncoder) error {
 			if err := pe.putNullableString(member.GroupInstanceId); err != nil {
 				return err
 			}
+			if r.Version >= 5 {
+				if err := pe.putNullableString(member.Reason); err != nil {
+					return err
+				}
+			}
 			pe.putEmptyTaggedFieldArray()
 		}
 	}
@@ -68,6 +74,11 @@ func (r *LeaveGroupRequest) decode(pd packetDecoder, version int16) (err error) 
 			if memberIdentity.GroupInstanceId, err = pd.getNullableString(); err != nil {
 				return err
 			}
+			if r.Version >= 5 {
+				if memberIdentity.Reason, err = pd.getNullableString(); err != nil {
+					return err
+				}
+			}
 			r.Members[i] = memberIdentity
 			_, err = pd.getEmptyTaggedFieldArray()
 			if err != nil {
@@ -96,7 +107,7 @@ func (r *LeaveGroupRequest) headerVersion() int16 {
 }
 
 func (r *LeaveGroupRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 4
+	return r.Version >= 0 && r.Version <= 5
 }
 
 func (r *LeaveGroupRequest) isFlexible() bool {
@@ -109,6 +120,8 @@ func (r *LeaveGroupRequest) isFlexibleVersion(version int16) bool {
 
 func (r *LeaveGroupRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 5:
+		return V3_2_0_0
 	case 4:
 		return V2_4_0_0
 	case 3:

--- a/leave_group_request_test.go
+++ b/leave_group_request_test.go
@@ -31,10 +31,24 @@ var (
 		0, // empty tagged fields
 		0, // empty tagged fields
 	}
+	basicLeaveGroupRequestV5 = []byte{
+		4, 'f', 'o', 'o',
+		3,                     // Two Member
+		5, 'm', 'i', 'd', '1', // MemberId
+		0,                     // GroupInstanceId  nil
+		0,                     // Reason nil
+		0,                     // empty tagged fields
+		5, 'm', 'i', 'd', '2', // MemberId
+		4, 'g', 'i', 'd', // GroupInstanceId
+		5, 'l', 'e', 'f', 't', // Reason
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
 )
 
 func TestLeaveGroupRequest(t *testing.T) {
 	groupInstanceId := "gid"
+	reason := "left"
 	tests := []struct {
 		CaseName     string
 		Version      int16
@@ -59,8 +73,8 @@ func TestLeaveGroupRequest(t *testing.T) {
 				Version: 3,
 				GroupId: "foo",
 				Members: []MemberIdentity{
-					{"mid1", nil},
-					{"mid2", &groupInstanceId},
+					{"mid1", nil, nil},
+					{"mid2", &groupInstanceId, nil},
 				},
 			},
 		},
@@ -72,8 +86,21 @@ func TestLeaveGroupRequest(t *testing.T) {
 				Version: 4,
 				GroupId: "foo",
 				Members: []MemberIdentity{
-					{"mid1", nil},
-					{"mid2", &groupInstanceId},
+					{"mid1", nil, nil},
+					{"mid2", &groupInstanceId, nil},
+				},
+			},
+		},
+		{
+			"v5",
+			5,
+			basicLeaveGroupRequestV5,
+			&LeaveGroupRequest{
+				Version: 5,
+				GroupId: "foo",
+				Members: []MemberIdentity{
+					{"mid1", nil, nil},
+					{"mid2", &groupInstanceId, &reason},
 				},
 			},
 		},

--- a/leave_group_response.go
+++ b/leave_group_response.go
@@ -96,7 +96,7 @@ func (r *LeaveGroupResponse) headerVersion() int16 {
 }
 
 func (r *LeaveGroupResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 4
+	return r.Version >= 0 && r.Version <= 5
 }
 
 func (r *LeaveGroupResponse) isFlexible() bool {
@@ -109,6 +109,8 @@ func (r *LeaveGroupResponse) isFlexibleVersion(version int16) bool {
 
 func (r *LeaveGroupResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 5:
+		return V3_2_0_0
 	case 4:
 		return V2_4_0_0
 	case 3:

--- a/leave_group_response_test.go
+++ b/leave_group_response_test.go
@@ -39,6 +39,20 @@ var (
 		0, // empty tagged fields
 		0, // empty tagged fields
 	}
+	leaveGroupResponseV5NoError = []byte{
+		0, 0, 0, 100, // ThrottleTime
+		0x00, 0x00, // Err
+		3,                     // Two Members
+		5, 'm', 'i', 'd', '1', // MemberId
+		0,    // GroupInstanceId
+		0, 0, // Err
+		0,                     // empty tagged fields
+		5, 'm', 'i', 'd', '2', // MemberId
+		4, 'g', 'i', 'd', // GroupInstanceId
+		0, 25, // Err
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
 )
 
 func TestLeaveGroupResponse(t *testing.T) {
@@ -97,6 +111,20 @@ func TestLeaveGroupResponse(t *testing.T) {
 			leaveGroupResponseV4NoError,
 			&LeaveGroupResponse{
 				Version:      4,
+				ThrottleTime: 100,
+				Err:          ErrNoError,
+				Members: []MemberResponse{
+					{"mid1", nil, ErrNoError},
+					{"mid2", &groupInstanceId, ErrUnknownMemberId},
+				},
+			},
+		},
+		{
+			"v5",
+			5,
+			leaveGroupResponseV5NoError,
+			&LeaveGroupResponse{
+				Version:      5,
 				ThrottleTime: 100,
 				Err:          ErrNoError,
 				Members: []MemberResponse{

--- a/request_test.go
+++ b/request_test.go
@@ -380,6 +380,12 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 			},
 		},
 		{
+			V3_2_0_0,
+			map[int16]int16{
+				apiKeyLeaveGroup: 5, // up from 4
+			},
+		},
+		{
 			saramaMaxVersions, // placeholder version for current maximums implemented by Sarama
 			map[int16]int16{
 				apiKeyProduce:            maxVersion(&ProduceRequest{}),


### PR DESCRIPTION
Adds the v5 Reason field on MemberIdentity. Response v5 is wire-identical to v4. Negotiates v5 when configured Version is at least V3_2_0_0.

Protocol supported needed for [KIP-800: Add reason to JoinGroupRequest and LeaveGroupRequest](https://cwiki.apache.org/confluence/display/KAFKA/KIP-800%3A+Add+reason+to+JoinGroupRequest+and+LeaveGroupRequest)