### PR TITLE
feat(protocol): support JoinGroupRequest/Response v8 (KIP-800)

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -450,34 +450,32 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 		SessionTimeout: int32(c.config.Consumer.Group.Session.Timeout / time.Millisecond),
 		ProtocolType:   "consumer",
 	}
-	if c.config.Version.IsAtLeast(V0_10_1_0) {
-		req.Version = 1
-		req.RebalanceTimeout = int32(c.config.Consumer.Group.Rebalance.Timeout / time.Millisecond)
-	}
-	if c.config.Version.IsAtLeast(V0_11_0_0) {
-		req.Version = 2
-	}
-	if c.config.Version.IsAtLeast(V0_11_0_0) {
-		req.Version = 2
-	}
-	if c.config.Version.IsAtLeast(V2_0_0_0) {
-		req.Version = 3
-	}
 	// from JoinGroupRequest v4 onwards (due to KIP-394) the client will actually
 	// send two JoinGroupRequests, once with the empty member id, and then again
 	// with the assigned id from the first response. This is handled via the
 	// ErrMemberIdRequired case.
-	if c.config.Version.IsAtLeast(V2_2_0_0) {
-		req.Version = 4
-	}
-	if c.config.Version.IsAtLeast(V2_3_0_0) {
+	if c.config.Version.IsAtLeast(V3_1_0_0) {
+		req.Version = 8
+	} else if c.config.Version.IsAtLeast(V2_5_0_0) {
+		req.Version = 7
+	} else if c.config.Version.IsAtLeast(V2_4_0_0) {
+		req.Version = 6
+	} else if c.config.Version.IsAtLeast(V2_3_0_0) {
 		req.Version = 5
+	} else if c.config.Version.IsAtLeast(V2_2_0_0) {
+		req.Version = 4
+	} else if c.config.Version.IsAtLeast(V2_0_0_0) {
+		req.Version = 3
+	} else if c.config.Version.IsAtLeast(V0_11_0_0) {
+		req.Version = 2
+	} else if c.config.Version.IsAtLeast(V0_10_1_0) {
+		req.Version = 1
+	}
+	if req.Version >= 1 {
+		req.RebalanceTimeout = int32(c.config.Consumer.Group.Rebalance.Timeout / time.Millisecond)
+	}
+	if req.Version >= 5 {
 		req.GroupInstanceId = c.groupInstanceId
-		if c.config.Version.IsAtLeast(V2_5_0_0) {
-			req.Version = 7
-		} else if c.config.Version.IsAtLeast(V2_4_0_0) {
-			req.Version = 6
-		}
 	}
 
 	if strategy := c.config.Consumer.Group.Rebalance.Strategy; strategy != nil {

--- a/join_group_request.go
+++ b/join_group_request.go
@@ -57,6 +57,8 @@ type JoinGroupRequest struct {
 	// OrderedGroupProtocols contains an ordered list of protocols that the member
 	// supports.
 	OrderedGroupProtocols []*GroupProtocol
+	// Reason contains the reason why the member (re-)joins the group (KIP-800).
+	Reason *string
 }
 
 func (r *JoinGroupRequest) setVersion(v int16) {
@@ -111,6 +113,12 @@ func (r *JoinGroupRequest) encode(pe packetEncoder) error {
 		}
 	}
 
+	if r.Version >= 8 {
+		if err := pe.putNullableString(r.Reason); err != nil {
+			return err
+		}
+	}
+
 	pe.putEmptyTaggedFieldArray()
 	return nil
 }
@@ -150,18 +158,23 @@ func (r *JoinGroupRequest) decode(pd packetDecoder, version int16) (err error) {
 	if err != nil {
 		return err
 	}
-	if n == 0 {
-		return nil
+
+	if n > 0 {
+		r.GroupProtocols = make(map[string][]byte)
+		for i := 0; i < n; i++ {
+			protocol := &GroupProtocol{}
+			if err := protocol.decode(pd); err != nil {
+				return err
+			}
+			r.GroupProtocols[protocol.Name] = protocol.Metadata
+			r.OrderedGroupProtocols = append(r.OrderedGroupProtocols, protocol)
+		}
 	}
 
-	r.GroupProtocols = make(map[string][]byte)
-	for i := 0; i < n; i++ {
-		protocol := &GroupProtocol{}
-		if err := protocol.decode(pd); err != nil {
+	if version >= 8 {
+		if r.Reason, err = pd.getNullableString(); err != nil {
 			return err
 		}
-		r.GroupProtocols[protocol.Name] = protocol.Metadata
-		r.OrderedGroupProtocols = append(r.OrderedGroupProtocols, protocol)
 	}
 
 	_, err = pd.getEmptyTaggedFieldArray()
@@ -184,7 +197,7 @@ func (r *JoinGroupRequest) headerVersion() int16 {
 }
 
 func (r *JoinGroupRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 8
 }
 
 func (r *JoinGroupRequest) isFlexible() bool {
@@ -197,6 +210,8 @@ func (r *JoinGroupRequest) isFlexibleVersion(version int16) bool {
 
 func (r *JoinGroupRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 8:
+		return V3_1_0_0
 	case 7:
 		return V2_5_0_0
 	case 6:

--- a/join_group_request_test.go
+++ b/join_group_request_test.go
@@ -113,10 +113,26 @@ var (
 		0, // empty tagged fields
 		0, // empty tagged fields
 	}
+
+	joinGroupRequestV8 = []byte{
+		10, 'T', 'e', 's', 't', 'G', 'r', 'o', 'u', 'p', // Group ID
+		0, 0, 0, 100, // Session timeout
+		0, 0, 0, 200, // Rebalance timeout
+		12, 'O', 'n', 'e', 'P', 'r', 'o', 't', 'o', 'c', 'o', 'l', // Member ID
+		4, 'g', 'i', 'd', // GroupInstanceId
+		9, 'c', 'o', 'n', 's', 'u', 'm', 'e', 'r', // Protocol Type
+		2,                // 1 group protocol
+		4, 'o', 'n', 'e', // Protocol name
+		4, 0x01, 0x02, 0x03, // protocol metadata
+		0,                               // empty tagged fields
+		7, 'r', 'e', 'j', 'o', 'i', 'n', // Reason
+		0, // empty tagged fields
+	}
 )
 
 func TestJoinGroupRequestV3plus(t *testing.T) {
 	groupInstanceId := "gid"
+	reason := "rejoin"
 	tests := []struct {
 		CaseName     string
 		Version      int16
@@ -161,6 +177,27 @@ func TestJoinGroupRequestV3plus(t *testing.T) {
 				OrderedGroupProtocols: []*GroupProtocol{
 					{Name: "one", Metadata: []byte{1, 2, 3}},
 				},
+			},
+		},
+		{
+			"v8",
+			8,
+			joinGroupRequestV8,
+			&JoinGroupRequest{
+				Version:          8,
+				GroupId:          "TestGroup",
+				SessionTimeout:   100,
+				RebalanceTimeout: 200,
+				MemberId:         "OneProtocol",
+				GroupInstanceId:  &groupInstanceId,
+				ProtocolType:     "consumer",
+				GroupProtocols: map[string][]byte{
+					"one": {1, 2, 3},
+				},
+				OrderedGroupProtocols: []*GroupProtocol{
+					{Name: "one", Metadata: []byte{1, 2, 3}},
+				},
+				Reason: &reason,
 			},
 		},
 	}

--- a/join_group_response.go
+++ b/join_group_response.go
@@ -196,7 +196,7 @@ func (r *JoinGroupResponse) headerVersion() int16 {
 }
 
 func (r *JoinGroupResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 7
+	return r.Version >= 0 && r.Version <= 8
 }
 
 func (r *JoinGroupResponse) isFlexible() bool {
@@ -209,6 +209,8 @@ func (r *JoinGroupResponse) isFlexibleVersion(version int16) bool {
 
 func (r *JoinGroupResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 8:
+		return V3_1_0_0
 	case 7:
 		return V2_5_0_0
 	case 6:

--- a/join_group_response_test.go
+++ b/join_group_response_test.go
@@ -232,6 +232,22 @@ var (
 		0, // empty tagged fields
 		0, // empty tagged fields
 	}
+
+	joinGroupResponseV8 = []byte{
+		0, 0, 0, 100, // ThrottleTimeMs
+		0x00, 0x00, // No error
+		0x00, 0x01, 0x02, 0x03, // Generation ID
+		9, 'c', 'o', 'n', 's', 'u', 'm', 'e', 'r', // Protocol Type
+		9, 'p', 'r', 'o', 't', 'o', 'c', 'o', 'l', // Protocol name chosen
+		4, 'f', 'o', 'o', // Leader ID
+		4, 'b', 'a', 'r', // Member ID
+		2,                // One member info
+		4, 'm', 'i', 'd', // memberId
+		4, 'g', 'i', 'd', // GroupInstanceId
+		4, 1, 2, 3, // Metadata
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
 )
 
 func TestJoinGroupResponse3plus(t *testing.T) {
@@ -298,6 +314,24 @@ func TestJoinGroupResponse3plus(t *testing.T) {
 			joinGroupResponseV7,
 			&JoinGroupResponse{
 				Version:       7,
+				ThrottleTime:  100,
+				Err:           ErrNoError,
+				GenerationId:  0x00010203,
+				ProtocolType:  &protocolType,
+				GroupProtocol: "protocol",
+				LeaderId:      "foo",
+				MemberId:      "bar",
+				Members: []GroupMember{
+					{"mid", &groupInstanceId, []byte{1, 2, 3}},
+				},
+			},
+		},
+		{
+			"v8",
+			8,
+			joinGroupResponseV8,
+			&JoinGroupResponse{
+				Version:       8,
 				ThrottleTime:  100,
 				Err:           ErrNoError,
 				GenerationId:  0x00010203,

--- a/request_test.go
+++ b/request_test.go
@@ -380,6 +380,12 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 			},
 		},
 		{
+			V3_1_0_0,
+			map[int16]int16{
+				apiKeyJoinGroup: 8, // up from 7
+			},
+		},
+		{
 			V3_2_0_0,
 			map[int16]int16{
 				apiKeyLeaveGroup: 5, // up from 4


### PR DESCRIPTION
Protocol supported needed for [KIP-800: Add reason to JoinGroupRequest and LeaveGroupRequest](https://cwiki.apache.org/confluence/display/KAFKA/KIP-800%3A+Add+reason+to+JoinGroupRequest+and+LeaveGroupRequest)