### PR TITLE
fix: prevent len out of range panic on 32bit architectures

### DIFF
--- a/.github/workflows/i386.yml
+++ b/.github/workflows/i386.yml
@@ -45,3 +45,19 @@ jobs:
           git clone --depth=1 https://github.com/dominikh/go-tools /tmp/go-tools
           ( cd /tmp/go-tools/cmd/staticcheck && go build -o /tmp/staticcheck )
           /tmp/staticcheck -checks SA1027 ./...
+
+  test:
+    name: Unit Testing (i386)
+    runs-on: ubuntu-latest
+    env:
+      GOARCH: 386
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Setup Go
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+      with:
+        go-version: stable
+    - name: Test (Unit)
+      run: go test -timeout 2m ./...

--- a/broker.go
+++ b/broker.go
@@ -1693,7 +1693,11 @@ func (b *Broker) sendAndReceiveSASLSCRAMv0() error {
 			Logger.Printf("Failed to read response header while authenticating with SASL to broker %s: %s\n", b.addr, err.Error())
 			return err
 		}
-		payload := make([]byte, int32(binary.BigEndian.Uint32(header)))
+		payloadLength := binary.BigEndian.Uint32(header)
+		if int64(payloadLength) > int64(MaxResponseSize) {
+			return PacketDecodingError{fmt.Sprintf("SASL response of length %d too large", payloadLength)}
+		}
+		payload := make([]byte, int(payloadLength))
 		n, err := b.readFull(payload)
 		if err != nil {
 			b.addRequestInFlightMetrics(-1)

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -516,9 +516,9 @@ func (rd *realFlexibleDecoder) getInt32Array() ([]int32, error) {
 		return nil, nil
 	}
 
-	arrayLength := int(n) - 1
+	arrayLength := int64(n) - 1
 
-	if rd.remaining()/4 < arrayLength {
+	if int64(rd.remaining())/4 < arrayLength {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData
 	}

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -119,7 +119,9 @@ func (rd *realDecoder) getArrayLength() (int, error) {
 	// casting to int for ease of interop
 	tmp := int(int32(binary.BigEndian.Uint32(rd.raw[rd.off:])))
 	rd.off += 4
-	if tmp > rd.remaining() {
+	if tmp < -1 {
+		return -1, errInvalidArrayLength
+	} else if tmp > rd.remaining() {
 		rd.off = len(rd.raw)
 		return -1, ErrInsufficientData
 	} else if tmp > int(MaxResponseSize) {
@@ -181,6 +183,10 @@ func (rd *realDecoder) getVarintBytes() ([]byte, error) {
 	}
 	if tmp == -1 {
 		return nil, nil
+	}
+	if tmp > int64(rd.remaining()) {
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
 	}
 
 	return rd.getRawBytes(int(tmp))
@@ -382,7 +388,12 @@ func (rd *realFlexibleDecoder) getArrayLength() (int, error) {
 		return 0, nil
 	}
 
-	return int(n) - 1, nil
+	if n-1 > uint64(rd.remaining()) {
+		rd.off = len(rd.raw)
+		return 0, ErrInsufficientData
+	}
+
+	return int(n - 1), nil
 }
 
 func (rd *realFlexibleDecoder) getEmptyTaggedFieldArray() (int, error) {
@@ -402,6 +413,10 @@ func (rd *realFlexibleDecoder) getEmptyTaggedFieldArray() (int, error) {
 		length, err := rd.getUVarint()
 		if err != nil {
 			return 0, err
+		}
+		if length > uint64(rd.remaining()) {
+			rd.off = len(rd.raw)
+			return 0, ErrInsufficientData
 		}
 		if _, err := rd.getRawBytes(int(length)); err != nil {
 			return 0, err
@@ -433,6 +448,10 @@ func (rd *realFlexibleDecoder) getTaggedFieldArray(decoders taggedFieldDecoders)
 		if err != nil {
 			return err
 		}
+		if length > uint64(rd.remaining()) {
+			rd.off = len(rd.raw)
+			return ErrInsufficientData
+		}
 		bytes, err := rd.getRawBytes(int(length))
 		if err != nil {
 			return err
@@ -453,8 +472,12 @@ func (rd *realFlexibleDecoder) getBytes() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if n > 0 && n-1 > uint64(rd.remaining()) {
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
 
-	length := int(n - 1)
+	length := int(n) - 1
 	return rd.getRawBytes(length)
 }
 
@@ -463,15 +486,15 @@ func (rd *realFlexibleDecoder) getStringLength() (int, error) {
 	if err != nil {
 		return 0, err
 	}
-
-	n := int(length - 1)
-
-	switch {
-	case n < -1:
-		return 0, errInvalidStringLength
-	case n > rd.remaining():
+	if length > 0 && length-1 > uint64(rd.remaining()) {
 		rd.off = len(rd.raw)
 		return 0, ErrInsufficientData
+	}
+
+	n := int(length) - 1
+
+	if n < -1 {
+		return 0, errInvalidStringLength
 	}
 
 	return n, nil
@@ -516,14 +539,14 @@ func (rd *realFlexibleDecoder) getInt32Array() ([]int32, error) {
 		return nil, nil
 	}
 
-	arrayLength := int64(n) - 1
+	arrayLength := n - 1
 
-	if int64(rd.remaining())/4 < arrayLength {
+	if uint64(rd.remaining()/4) < arrayLength { //nolint:gosec // G115 - remaining() is non-negative
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData
 	}
 
-	ret := make([]int32, arrayLength)
+	ret := make([]int32, int(arrayLength)) //nolint:gosec // G115 - value bounded by remaining() above
 
 	for i := range ret {
 		ret[i] = int32(binary.BigEndian.Uint32(rd.raw[rd.off:]))

--- a/real_decoder_test.go
+++ b/real_decoder_test.go
@@ -4,6 +4,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRealDecoder_getArrayLength(t *testing.T) {
@@ -49,6 +52,12 @@ func TestRealDecoder_getArrayLength(t *testing.T) {
 			wantLen: -1,
 			wantErr: errInvalidArrayLength,
 		},
+		{
+			name:    "negative length other than null array",
+			input:   []byte{0x80, 0x00, 0x00, 0x00},
+			wantLen: -1,
+			wantErr: errInvalidArrayLength,
+		},
 	}
 
 	for _, tt := range tests {
@@ -71,4 +80,17 @@ func makeInput(length int) []byte {
 	input := make([]byte, 4+length)
 	binary.BigEndian.PutUint32(input, uint32(length)) // #nosec G115 - not going to exceed uint32
 	return input
+}
+
+func TestRealFlexibleDecoderGetInt32Array(t *testing.T) {
+	t.Run("returns insufficient data for compact length exceeding int64", func(t *testing.T) {
+		var input [binary.MaxVarintLen64]byte
+		n := binary.PutUvarint(input[:], 1<<63)
+
+		rd := &realFlexibleDecoder{&realDecoder{raw: input[:n]}}
+		array, err := rd.getInt32Array()
+
+		require.ErrorIs(t, err, ErrInsufficientData)
+		assert.Nil(t, array)
+	})
 }

--- a/record.go
+++ b/record.go
@@ -102,6 +102,9 @@ func (r *Record) decode(pd packetDecoder) (err error) {
 	}
 
 	if numHeaders >= 0 {
+		if numHeaders > int64(pd.remaining()) {
+			return ErrInsufficientData
+		}
 		r.Headers = make([]*RecordHeader, numHeaders)
 	}
 	for i := int64(0); i < numHeaders; i++ {


### PR DESCRIPTION
Currently, running the tests on a 32bit architecture produces a panic:

```
--- FAIL: TestFlexibleMetadataResponseInvalidInt32ArrayLengthOverflow (0.00s)
panic: runtime error: makeslice: len out of range [recovered, repanicked]

goroutine 7042 [running]:
testing.tRunner.func1.2({0x86a8d60, 0x875c2a8})
        /usr/lib/go-1.26/src/testing/testing.go:1974 +0x29b
testing.tRunner.func1()
        /usr/lib/go-1.26/src/testing/testing.go:1977 +0x409
panic({0x86a8d60, 0x875c2a8})
        /usr/lib/go-1.26/src/runtime/panic.go:860 +0x10b
github.com/IBM/sarama.(*realFlexibleDecoder).getInt32Array(0xd002850)
        /home/gibmat/pkgs/sarama/real_decoder.go:526 +0x8b
github.com/IBM/sarama.(*PartitionMetadata).decode(0xcbbc380, {0x87640b4, 0xd002850}, 0x9)
        /home/gibmat/pkgs/sarama/metadata_response.go:46 +0xe9
github.com/IBM/sarama.(*TopicMetadata).decode(0xce27ad0, {0x87640b4, 0xd002850}, 0x9)
        /home/gibmat/pkgs/sarama/metadata_response.go:153 +0x234
github.com/IBM/sarama.(*MetadataResponse).decode(0xce27a70, {0x87640b4, 0xd002850}, 0x9)
        /home/gibmat/pkgs/sarama/metadata_response.go:271 +0x315
github.com/IBM/sarama.versionedDecode({0xc990540, 0x28, 0x28}, {0x875da70, 0xce27a70}, 0x9, {0x0, 0x0})
        /home/gibmat/pkgs/sarama/encoder_decoder.go:94 +0xcb
github.com/IBM/sarama.TestFlexibleMetadataResponseInvalidInt32ArrayLengthOverflow(0xca883c8)
        /home/gibmat/pkgs/sarama/metadata_response_test.go:582 +0xc1
testing.tRunner(0xca883c8, 0x8758338)
        /usr/lib/go-1.26/src/testing/testing.go:2036 +0x114
created by testing.(*T).Run in goroutine 1
        /usr/lib/go-1.26/src/testing/testing.go:2101 +0x511
FAIL    github.com/IBM/sarama   32.545s
```

Explicitly using an `int64` for `arrayLength` fixes the issue, but I don't know if this might be masking other potential issues on 32bit systems.

Observed while updating this library's packaging for Debian, which still supports a couple of 32bit release architectures.