### PR TITLE
feat(consumer_group): send KIP-800 reason on JoinGroup and LeaveGroup

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -94,12 +94,13 @@ type ConsumerGroup interface {
 type consumerGroup struct {
 	client Client
 
-	config          *Config
-	consumer        Consumer
-	groupID         string
-	groupInstanceId *string
-	memberID        string
-	errors          chan error
+	config           *Config
+	consumer         Consumer
+	groupID          string
+	groupInstanceId  *string
+	memberID         string
+	lastSessionCause error
+	errors           chan error
 
 	lock       sync.Mutex
 	errorsLock sync.RWMutex
@@ -235,7 +236,17 @@ func (c *consumerGroup) Consume(ctx context.Context, topics []string, handler Co
 	}
 
 	// Gracefully release session claims
-	return sess.release(true)
+	err = sess.release(true)
+
+	// store the session cancellation cause so it can be sent as the reason
+	// on the next JoinGroup or LeaveGroup request
+	if cause := context.Cause(sess.ctx); !errors.Is(cause, context.Canceled) {
+		c.lastSessionCause = cause
+	} else {
+		c.lastSessionCause = nil
+	}
+
+	return err
 }
 
 // Pause implements ConsumerGroup.
@@ -491,6 +502,11 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 	if req.Version >= 5 {
 		req.GroupInstanceId = c.groupInstanceId
 	}
+	if req.Version >= 8 && c.lastSessionCause != nil {
+		reason := sessionCauseToReason(c.lastSessionCause)
+		req.Reason = &reason
+		c.lastSessionCause = nil
+	}
 
 	if strategy := c.config.Consumer.Group.Rebalance.Strategy; strategy != nil {
 		if err := req.AddGroupProtocolMetadata(strategy.Name(), c.subscriptionMetadata(strategy, topics)); err != nil {
@@ -687,9 +703,14 @@ func (c *consumerGroup) leave() error {
 		req.Version = 1
 	}
 	if req.Version >= 3 {
-		req.Members = append(req.Members, MemberIdentity{
+		member := MemberIdentity{
 			MemberId: c.memberID,
-		})
+		}
+		if req.Version >= 5 {
+			reason := "the consumer is being closed"
+			member.Reason = &reason
+		}
+		req.Members = append(req.Members, member)
 	}
 
 	resp, err := coordinator.LeaveGroup(req)
@@ -1166,6 +1187,27 @@ func (s *consumerGroupSession) heartbeatLoop() {
 		case <-s.hbDying:
 			return
 		}
+	}
+}
+
+func sessionCauseToReason(cause error) string {
+	switch {
+	case errors.Is(cause, ErrRebalanceInProgress):
+		return "group is rebalancing"
+	case errors.Is(cause, ErrUnknownMemberId):
+		return "member id is not known by the group coordinator"
+	case errors.Is(cause, ErrIllegalGeneration):
+		return "generation id is not current"
+	case errors.Is(cause, ErrFencedInstancedId):
+		return "group instance id has been fenced"
+	case errors.Is(cause, ErrSessionPartitionCountChanged):
+		return "partitions were added to a subscribed topic"
+	case errors.Is(cause, ErrSessionConsumeClaimExited):
+		return "a ConsumeClaim handler has exited"
+	case errors.Is(cause, ErrSessionHeartbeatFailed):
+		return "the heartbeat goroutine has stopped"
+	default:
+		return cause.Error()
 	}
 }
 

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -339,6 +339,17 @@ func TestSubscriptionMetadata(t *testing.T) {
 	})
 }
 
+// drainHandler is a ConsumerGroupHandler that drains messages without blocking.
+type drainHandler struct{}
+
+func (*drainHandler) Setup(_ ConsumerGroupSession) error   { return nil }
+func (*drainHandler) Cleanup(_ ConsumerGroupSession) error { return nil }
+func (*drainHandler) ConsumeClaim(_ ConsumerGroupSession, claim ConsumerGroupClaim) error {
+	for range claim.Messages() {
+	}
+	return nil
+}
+
 // causeHandler is a ConsumerGroupHandler that captures the context.Cause when
 // the session context is canceled.
 type causeHandler struct {
@@ -354,6 +365,55 @@ func (h *causeHandler) ConsumeClaim(sess ConsumerGroupSession, claim ConsumerGro
 	<-sess.Context().Done()
 	h.causeCh <- context.Cause(sess.Context())
 	return nil
+}
+
+// mockJoinGroupCapture wraps a MockJoinGroupResponse and records the Reason
+// from each incoming JoinGroupRequest.
+type mockJoinGroupCapture struct {
+	inner    MockResponse
+	mu       sync.Mutex
+	reasons  []*string
+	captured chan struct{} // closed when len(reasons) >= want
+	want     int
+}
+
+func (m *mockJoinGroupCapture) For(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*JoinGroupRequest)
+	m.mu.Lock()
+	m.reasons = append(m.reasons, req.Reason)
+	if len(m.reasons) >= m.want {
+		select {
+		case <-m.captured:
+		default:
+			close(m.captured)
+		}
+	}
+	m.mu.Unlock()
+	return m.inner.For(reqBody)
+}
+
+// mockLeaveGroupCapture wraps a MockLeaveGroupResponse and records the Reason
+// from each incoming LeaveGroupRequest member.
+type mockLeaveGroupCapture struct {
+	inner    MockResponse
+	mu       sync.Mutex
+	reasons  []*string
+	captured chan struct{} // closed after first LeaveGroup
+}
+
+func (m *mockLeaveGroupCapture) For(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*LeaveGroupRequest)
+	m.mu.Lock()
+	for _, member := range req.Members {
+		m.reasons = append(m.reasons, member.Reason)
+	}
+	select {
+	case <-m.captured:
+	default:
+		close(m.captured)
+	}
+	m.mu.Unlock()
+	return m.inner.For(reqBody)
 }
 
 // mockHeartbeatRebalanceResponse returns ErrNoError for the first N heartbeats,
@@ -435,4 +495,114 @@ func TestConsumerGroupSessionCancelCause_Rebalance(t *testing.T) {
 	}
 	assert.Len(t, causes, 1, "expected exactly one cancellation cause")
 	assert.ErrorIs(t, causes[0], ErrRebalanceInProgress)
+}
+
+func TestConsumerGroupReason(t *testing.T) {
+	setup := func(t *testing.T, overrides map[string]MockResponse) (*MockBroker, ConsumerGroup) {
+		t.Helper()
+		config := NewTestConfig()
+		config.ClientID = t.Name()
+		config.Version = V3_2_0_0
+		config.Consumer.Return.Errors = true
+		config.Consumer.Group.Rebalance.Retry.Max = 0
+		config.Consumer.Group.Rebalance.Retry.Backoff = 0
+		config.Consumer.Offsets.AutoCommit.Enable = false
+		config.Consumer.Group.Heartbeat.Interval = 50 * time.Millisecond
+
+		broker0 := NewMockBroker(t, 0)
+		handlers := map[string]MockResponse{
+			"MetadataRequest": NewMockMetadataResponse(t).
+				SetBroker(broker0.Addr(), broker0.BrokerID()).
+				SetLeader("my-topic", 0, broker0.BrokerID()),
+			"OffsetRequest": NewMockOffsetResponse(t).
+				SetOffset("my-topic", 0, OffsetOldest, 0).
+				SetOffset("my-topic", 0, OffsetNewest, 1),
+			"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).
+				SetCoordinator(CoordinatorGroup, "my-group", broker0),
+			"HeartbeatRequest": &mockHeartbeatRebalanceResponse{t: t, successLeft: 1},
+			"JoinGroupRequest": NewMockJoinGroupResponse(t).
+				SetGroupProtocol(RangeBalanceStrategyName).
+				SetMemberId("test-member"),
+			"SyncGroupRequest": NewMockSyncGroupResponse(t).SetMemberAssignment(
+				&ConsumerGroupMemberAssignment{
+					Version: 0,
+					Topics:  map[string][]int32{"my-topic": {0}},
+				}),
+			"LeaveGroupRequest": NewMockLeaveGroupResponse(t),
+			"OffsetFetchRequest": NewMockOffsetFetchResponse(t).SetOffset(
+				"my-group", "my-topic", 0, 0, "", ErrNoError,
+			).SetError(ErrNoError),
+			"FetchRequest": NewMockFetchResponse(t, 1).
+				SetMessage("my-topic", 0, 0, StringEncoder("foo")),
+		}
+		for k, v := range overrides {
+			handlers[k] = v
+		}
+		broker0.SetHandlerByMap(handlers)
+
+		group, err := NewConsumerGroup([]string{broker0.Addr()}, "my-group", config)
+		assert.NoError(t, err)
+		return broker0, group
+	}
+
+	t.Run("JoinGroup carries reason from previous session", func(t *testing.T) {
+		joinCapture := &mockJoinGroupCapture{
+			inner: NewMockJoinGroupResponse(t).
+				SetGroupProtocol(RangeBalanceStrategyName).
+				SetMemberId("test-member"),
+			captured: make(chan struct{}),
+			want:     2,
+		}
+		broker0, group := setup(t, map[string]MockResponse{
+			"JoinGroupRequest": joinCapture,
+		})
+		defer broker0.Close()
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			for i := 0; i < 2; i++ {
+				_ = group.Consume(ctx, []string{"my-topic"}, &drainHandler{})
+			}
+		}()
+
+		select {
+		case <-joinCapture.captured:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for second JoinGroup")
+		}
+		cancel()
+		<-done
+		_ = group.Close()
+
+		joinCapture.mu.Lock()
+		defer joinCapture.mu.Unlock()
+		assert.Len(t, joinCapture.reasons, 2)
+		assert.Nil(t, joinCapture.reasons[0], "first JoinGroup should have no reason")
+		assert.NotNil(t, joinCapture.reasons[1], "second JoinGroup should carry reason")
+		assert.Equal(t, "group is rebalancing", *joinCapture.reasons[1])
+	})
+
+	t.Run("LeaveGroup sends closing reason", func(t *testing.T) {
+		leaveCapture := &mockLeaveGroupCapture{
+			inner:    NewMockLeaveGroupResponse(t),
+			captured: make(chan struct{}),
+		}
+		broker0, group := setup(t, map[string]MockResponse{
+			"LeaveGroupRequest": leaveCapture,
+		})
+		defer broker0.Close()
+
+		_ = group.Consume(t.Context(), []string{"my-topic"}, &drainHandler{})
+		_ = group.Close()
+
+		leaveCapture.mu.Lock()
+		defer leaveCapture.mu.Unlock()
+		assert.Len(t, leaveCapture.reasons, 1)
+		assert.NotNil(t, leaveCapture.reasons[0], "LeaveGroup should carry reason")
+		assert.Equal(t, "the consumer is being closed", *leaveCapture.reasons[0])
+	})
 }


### PR DESCRIPTION
Mirror the Java client's KIP-800 implementation by populating the reason field on JoinGroup v8+ and LeaveGroup v5+ requests. Session cancellation causes are mapped to descriptive strings matching the Java client conventions, and LeaveGroup always sends "the consumer is being closed".