### PR TITLE
feat: add Kafka 4.3.0 version placeholder

### DIFF
--- a/.github/workflows/fvt-main.yml
+++ b/.github/workflows/fvt-main.yml
@@ -21,14 +21,19 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [stable]
-        kafka-version: [1.0.2, 2.0.1, 2.2.2, 2.6.3, 2.8.2, 3.0.2, 3.3.2, 3.6.2, 3.8.1, 3.9.2, 4.1.1, 4.2.0]
+        kafka-version:
+        - 1.0.2   # oldest baseline, lowest protocol versions
+        - 2.6.3   # accumulates many 2.x protocol bumps (KIP-227, KIP-320, KIP-345, KIP-429)
+        - 2.8.2   # KRaft experimental era (KIP-500)
+        - 3.0.2   # major deprecation wave, removed old message formats
+        - 3.3.2   # KRaft production-ready (KIP-833)
+        - 3.6.2   # mid-3.x representative
+        - 3.9.2   # last ZooKeeper-capable release
+        - 4.1.1   # stable KRaft-only (post-4.0 transition)
+        - 4.2.0   # latest
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11
-        - kafka-version: 2.0.1
-          scala-version: 2.12
-        - kafka-version: 2.2.2
-          scala-version: 2.12
         - kafka-version: 2.6.3
           scala-version: 2.12
         - kafka-version: 2.8.2
@@ -38,8 +43,6 @@ jobs:
         - kafka-version: 3.3.2
           scala-version: 2.13
         - kafka-version: 3.6.2
-          scala-version: 2.13
-        - kafka-version: 3.8.1
           scala-version: 2.13
         - kafka-version: 3.9.2
           scala-version: 2.13

--- a/.github/workflows/fvt-pr.yml
+++ b/.github/workflows/fvt-pr.yml
@@ -20,7 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [stable]
-        kafka-version: [1.0.2, 2.6.3, 3.6.2, 3.9.2, 4.1.1, 4.2.0]
+        kafka-version:
+        - 1.0.2   # oldest baseline, lowest protocol versions
+        - 2.6.3   # accumulates many 2.x protocol bumps (KIP-227, KIP-320, KIP-345, KIP-429)
+        - 3.6.2   # mid-3.x representative
+        - 3.9.2   # last ZooKeeper-capable release
+        - 4.1.1   # stable KRaft-only (post-4.0 transition)
+        - 4.2.0   # latest
         include:
         - kafka-version: 1.0.2
           scala-version: 2.11

--- a/.github/workflows/fvt.yml
+++ b/.github/workflows/fvt.yml
@@ -9,7 +9,7 @@ on:
       kafka-version:
         required: false
         type: string
-        default: "3.9.1"
+        default: "4.2.0"
       scala-version:
         required: false
         type: string

--- a/Dockerfile.kafka
+++ b/Dockerfile.kafka
@@ -17,7 +17,7 @@ RUN cd /etc/java/java-17-openjdk/*/conf/security \
  && echo 'networkaddress.cache.negative.ttl=0' >> java.security
 
 ARG SCALA_VERSION="2.13"
-ARG KAFKA_VERSION="3.9.1"
+ARG KAFKA_VERSION="4.2.0"
 
 WORKDIR /tmp
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,19 +13,19 @@ x-zookeeper-base: &zookeeper-base
     ZOO_4LW_COMMANDS_WHITELIST: 'mntr,conf,ruok'
 
 x-kafka-base: &kafka-base
-  image: 'sarama/fv-kafka-${KAFKA_VERSION:-3.9.1}'
+  image: 'sarama/fv-kafka-${KAFKA_VERSION:-4.2.0}'
   init: true
   build:
     context: .
     dockerfile: Dockerfile.kafka
     args:
-      KAFKA_VERSION: ${KAFKA_VERSION:-3.9.1}
+      KAFKA_VERSION: ${KAFKA_VERSION:-4.2.0}
       SCALA_VERSION: ${SCALA_VERSION:-2.13}
   depends_on:
     - toxiproxy
   restart: always
   environment: &kafka-base-env
-    KAFKA_VERSION: ${KAFKA_VERSION:-3.9.1}
+    KAFKA_VERSION: ${KAFKA_VERSION:-4.2.0}
     KAFKA_CFG_DEFAULT_REPLICATION_FACTOR: '2'
     KAFKA_CFG_OFFSETS_TOPIC_REPLICATION_FACTOR: '2'
     KAFKA_CFG_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '2'
@@ -72,7 +72,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-1'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-1:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-4.2.0}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-1:9091']
       interval: 5s
       timeout: 15s
       retries: 30
@@ -89,7 +89,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-2'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-2:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-4.2.0}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-2:9091']
       interval: 5s
       timeout: 15s
       retries: 30
@@ -106,7 +106,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-3'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-3:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-4.2.0}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-3:9091']
       interval: 5s
       timeout: 15s
       retries: 30
@@ -123,7 +123,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-4'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-4:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-4.2.0}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-4:9091']
       interval: 5s
       timeout: 15s
       retries: 30
@@ -140,7 +140,7 @@ services:
     <<: *kafka-base
     container_name: 'kafka-5'
     healthcheck:
-      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-3.9.1}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-5:9091']
+      test: ['CMD', '/opt/kafka-${KAFKA_VERSION:-4.2.0}/bin/kafka-broker-api-versions.sh', '--bootstrap-server', 'kafka-5:9091']
       interval: 5s
       timeout: 15s
       retries: 30

--- a/utils.go
+++ b/utils.go
@@ -221,6 +221,7 @@ var (
 	V4_1_0_0  = newKafkaVersion(4, 1, 0, 0)
 	V4_1_1_0  = newKafkaVersion(4, 1, 1, 0)
 	V4_2_0_0  = newKafkaVersion(4, 2, 0, 0)
+	V4_3_0_0  = newKafkaVersion(4, 3, 0, 0)
 
 	SupportedVersions = []KafkaVersion{
 		V0_8_2_0,
@@ -300,9 +301,10 @@ var (
 		V4_1_0_0,
 		V4_1_1_0,
 		V4_2_0_0,
+		V4_3_0_0,
 	}
 	MinVersion     = V0_8_2_0
-	MaxVersion     = V4_2_0_0
+	MaxVersion     = V4_3_0_0
 	DefaultVersion = V2_1_0_0
 )
 


### PR DESCRIPTION
Also tweak the fvt version spreads in preparation for eventually adding 4.3.0.
There isn't currently a .tgz for it at https://s3-us-west-2.amazonaws.com/kafka-packages/ so we won't add it to the FVT for now