### PR TITLE
feat(consumer): add support for SyncGroupRequest/Response v5 (KIP-559)

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -574,20 +574,26 @@ func (c *consumerGroup) syncGroupRequest(
 		GenerationId: generationID,
 	}
 
-	// Versions 1 and 2 are the same as version 0.
-	if c.config.Version.IsAtLeast(V0_11_0_0) {
+	if c.config.Version.IsAtLeast(V2_5_0_0) {
+		req.Version = 5
+	} else if c.config.Version.IsAtLeast(V2_4_0_0) {
+		req.Version = 4
+	} else if c.config.Version.IsAtLeast(V2_3_0_0) {
+		req.Version = 3
+	} else if c.config.Version.IsAtLeast(V2_0_0_0) {
+		req.Version = 2
+	} else if c.config.Version.IsAtLeast(V0_11_0_0) {
 		req.Version = 1
 	}
-	if c.config.Version.IsAtLeast(V2_0_0_0) {
-		req.Version = 2
-	}
 	// Starting from version 3, we add a new field called groupInstanceId to indicate member identity across restarts.
-	if c.config.Version.IsAtLeast(V2_3_0_0) {
-		req.Version = 3
+	if req.Version >= 3 {
 		req.GroupInstanceId = c.groupInstanceId
-		if c.config.Version.IsAtLeast(V2_4_0_0) {
-			req.Version = 4
-		}
+	}
+	if req.Version >= 5 {
+		protocolType := "consumer"
+		protocolName := strategy.Name()
+		req.ProtocolType = &protocolType
+		req.ProtocolName = &protocolName
 	}
 
 	for memberID, topics := range plan {

--- a/request_test.go
+++ b/request_test.go
@@ -379,8 +379,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDeleteAcls:       2, // up from 1
 				apiKeySASLAuth:         2, // up from 1
 				apiKeyCreatePartitions: 2, // up from 1
-				// TODO: SyncGroupRequest v5 is not supported, but expected for KafkaVersion 2.5.0
-				// apiKeySyncGroup:               5, // up from 4
+				apiKeySyncGroup:        5, // up from 4
 				// TODO: TxnOffsetCommitRequest v3 is not supported, but expected for KafkaVersion 2.5.0
 				// apiKeyTxnOffsetCommit:         3, // up from 2
 			},

--- a/sync_group_request.go
+++ b/sync_group_request.go
@@ -44,6 +44,10 @@ type SyncGroupRequest struct {
 	MemberId string
 	// GroupInstanceId contains the unique identifier of the consumer instance provided by end user.
 	GroupInstanceId *string
+	// ProtocolType contains the group protocol type.
+	ProtocolType *string
+	// ProtocolName contains the group protocol name.
+	ProtocolName *string
 	// GroupAssignments contains each assignment.
 	GroupAssignments []SyncGroupRequestAssignment
 }
@@ -65,6 +69,15 @@ func (s *SyncGroupRequest) encode(pe packetEncoder) (err error) {
 
 	if s.Version >= 3 {
 		if err := pe.putNullableString(s.GroupInstanceId); err != nil {
+			return err
+		}
+	}
+
+	if s.Version >= 5 {
+		if err := pe.putNullableString(s.ProtocolType); err != nil {
+			return err
+		}
+		if err := pe.putNullableString(s.ProtocolName); err != nil {
 			return err
 		}
 	}
@@ -102,6 +115,15 @@ func (s *SyncGroupRequest) decode(pd packetDecoder, version int16) (err error) {
 		}
 	}
 
+	if s.Version >= 5 {
+		if s.ProtocolType, err = pd.getNullableString(); err != nil {
+			return err
+		}
+		if s.ProtocolName, err = pd.getNullableString(); err != nil {
+			return err
+		}
+	}
+
 	if numAssignments, err := pd.getArrayLength(); err != nil {
 		return err
 	} else if numAssignments > 0 {
@@ -135,7 +157,7 @@ func (r *SyncGroupRequest) headerVersion() int16 {
 }
 
 func (r *SyncGroupRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 4
+	return r.Version >= 0 && r.Version <= 5
 }
 
 func (r *SyncGroupRequest) isFlexible() bool {
@@ -148,6 +170,8 @@ func (r *SyncGroupRequest) isFlexibleVersion(version int16) bool {
 
 func (r *SyncGroupRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 5:
+		return V2_5_0_0
 	case 4:
 		return V2_4_0_0
 	case 3:

--- a/sync_group_request_test.go
+++ b/sync_group_request_test.go
@@ -63,10 +63,26 @@ var (
 		0, // empty tagged fields
 		0, // empty tagged fields
 	}
+
+	populatedSyncGroupRequestV5 = []byte{
+		4, 'f', 'o', 'o', // Group ID
+		0x00, 0x01, 0x02, 0x03, // Generation ID
+		4, 'b', 'a', 'z', // Member ID
+		4, 'g', 'i', 'd', // GroupInstance ID
+		9, 'c', 'o', 'n', 's', 'u', 'm', 'e', 'r', // ProtocolType
+		6, 'r', 'a', 'n', 'g', 'e', // ProtocolName
+		2,                // 1 + one assignment
+		4, 'b', 'a', 'z', // Member ID
+		4, 'f', 'o', 'o', // Member assignment
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
 )
 
 func TestSyncGroupRequestV3AndPlus(t *testing.T) {
 	groupInstanceId := "gid"
+	protocolType := "consumer"
+	protocolName := "range"
 	tests := []struct {
 		CaseName     string
 		Version      int16
@@ -101,6 +117,26 @@ func TestSyncGroupRequestV3AndPlus(t *testing.T) {
 				GenerationId:    0x00010203,
 				MemberId:        "baz",
 				GroupInstanceId: &groupInstanceId,
+				GroupAssignments: []SyncGroupRequestAssignment{
+					{
+						MemberId:   "baz",
+						Assignment: []byte("foo"),
+					},
+				},
+			},
+		},
+		{
+			"v5",
+			5,
+			populatedSyncGroupRequestV5,
+			&SyncGroupRequest{
+				Version:         5,
+				GroupId:         "foo",
+				GenerationId:    0x00010203,
+				MemberId:        "baz",
+				GroupInstanceId: &groupInstanceId,
+				ProtocolType:    &protocolType,
+				ProtocolName:    &protocolName,
 				GroupAssignments: []SyncGroupRequestAssignment{
 					{
 						MemberId:   "baz",

--- a/sync_group_response.go
+++ b/sync_group_response.go
@@ -11,6 +11,10 @@ type SyncGroupResponse struct {
 	ThrottleTime int32
 	// Err contains the error code, or 0 if there was no error.
 	Err KError
+	// ProtocolType contains the group protocol type.
+	ProtocolType *string
+	// ProtocolName contains the group protocol name.
+	ProtocolName *string
 	// MemberAssignment contains the member assignment.
 	MemberAssignment []byte
 }
@@ -30,6 +34,16 @@ func (r *SyncGroupResponse) encode(pe packetEncoder) error {
 		pe.putInt32(r.ThrottleTime)
 	}
 	pe.putKError(r.Err)
+
+	if r.Version >= 5 {
+		if err := pe.putNullableString(r.ProtocolType); err != nil {
+			return err
+		}
+		if err := pe.putNullableString(r.ProtocolName); err != nil {
+			return err
+		}
+	}
+
 	if err := pe.putBytes(r.MemberAssignment); err != nil {
 		return err
 	}
@@ -48,6 +62,15 @@ func (r *SyncGroupResponse) decode(pd packetDecoder, version int16) (err error) 
 	r.Err, err = pd.getKError()
 	if err != nil {
 		return err
+	}
+
+	if r.Version >= 5 {
+		if r.ProtocolType, err = pd.getNullableString(); err != nil {
+			return err
+		}
+		if r.ProtocolName, err = pd.getNullableString(); err != nil {
+			return err
+		}
 	}
 
 	r.MemberAssignment, err = pd.getBytes()
@@ -75,7 +98,7 @@ func (r *SyncGroupResponse) headerVersion() int16 {
 }
 
 func (r *SyncGroupResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 4
+	return r.Version >= 0 && r.Version <= 5
 }
 
 func (r *SyncGroupResponse) isFlexible() bool {
@@ -88,6 +111,8 @@ func (r *SyncGroupResponse) isFlexibleVersion(version int16) bool {
 
 func (r *SyncGroupResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 5:
+		return V2_5_0_0
 	case 4:
 		return V2_4_0_0
 	case 3:

--- a/sync_group_response_test.go
+++ b/sync_group_response_test.go
@@ -30,9 +30,20 @@ var (
 		4, 0x01, 0x02, 0x03, // Member assignment data
 		0, // empty tagged fields
 	}
+
+	syncGroupResponseV5NoError = []byte{
+		0, 0, 0, 100, // ThrottleTimeMs
+		0x00, 0x00, // No error
+		9, 'c', 'o', 'n', 's', 'u', 'm', 'e', 'r', // ProtocolType
+		6, 'r', 'a', 'n', 'g', 'e', // ProtocolName
+		4, 0x01, 0x02, 0x03, // Member assignment data
+		0, // empty tagged fields
+	}
 )
 
 func TestSyncGroupResponse(t *testing.T) {
+	protocolType := "consumer"
+	protocolName := "range"
 	tests := []struct {
 		CaseName     string
 		Version      int16
@@ -78,6 +89,19 @@ func TestSyncGroupResponse(t *testing.T) {
 				ThrottleTime:     100,
 				Version:          4,
 				Err:              ErrNoError,
+				MemberAssignment: []byte{1, 2, 3},
+			},
+		},
+		{
+			"v5-noErr",
+			5,
+			syncGroupResponseV5NoError,
+			&SyncGroupResponse{
+				ThrottleTime:     100,
+				Version:          5,
+				Err:              ErrNoError,
+				ProtocolType:     &protocolType,
+				ProtocolName:     &protocolName,
 				MemberAssignment: []byte{1, 2, 3},
 			},
 		},


### PR DESCRIPTION
Add ProtocolType and ProtocolName nullable string fields to both request and response, bump isValidVersion to 5

https://cwiki.apache.org/confluence/display/KAFKA/KIP-559%3A+Make+the+Kafka+Protocol+Friendlier+with+L7+Proxies

Also tidyup the syncGroupRequest version ladder to be descending, using a separate req.Version check for additional fields.