### PR TITLE
feat(txn): add protocol support for TxnOffsetCommit v3

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -380,8 +380,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeySASLAuth:         2, // up from 1
 				apiKeyCreatePartitions: 2, // up from 1
 				apiKeySyncGroup:        5, // up from 4
-				// TODO: TxnOffsetCommitRequest v3 is not supported, but expected for KafkaVersion 2.5.0
-				// apiKeyTxnOffsetCommit:         3, // up from 2
+				apiKeyTxnOffsetCommit:  3, // up from 2
 			},
 		},
 		{

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -407,7 +407,14 @@ func (t *transactionManager) publishOffsetsToTxn(offsets topicPartitionOffsets, 
 			GroupID:         groupId,
 			Topics:          offsets.mapToRequest(),
 		}
-		if t.client.Config().Version.IsAtLeast(V2_1_0_0) {
+		if t.client.Config().Version.IsAtLeast(V2_5_0_0) {
+			// Version 3 adds the member ID, group instance ID and generation ID.
+			// We don't track the consumer group member metadata here, so send the
+			// protocol defaults (generation -1, empty member ID, null instance ID)
+			// which tell the broker to skip zombie fencing, matching v2 behavior.
+			request.Version = 3
+			request.GenerationID = GroupGenerationUndefined
+		} else if t.client.Config().Version.IsAtLeast(V2_1_0_0) {
 			// Version 2 adds the committed leader epoch.
 			request.Version = 2
 		} else if t.client.Config().Version.IsAtLeast(V2_0_0_0) {

--- a/txn_offset_commit_request.go
+++ b/txn_offset_commit_request.go
@@ -6,6 +6,9 @@ type TxnOffsetCommitRequest struct {
 	GroupID         string
 	ProducerID      int64
 	ProducerEpoch   int16
+	GenerationID    int32   // v3+, generation of the group or member epoch
+	MemberID        string  // v3+, member ID assigned by the group coordinator
+	GroupInstanceID *string // v3+, unique identifier of the consumer instance
 	Topics          map[string][]*PartitionOffsetMetadata
 }
 
@@ -23,6 +26,16 @@ func (t *TxnOffsetCommitRequest) encode(pe packetEncoder) error {
 	pe.putInt64(t.ProducerID)
 	pe.putInt16(t.ProducerEpoch)
 
+	if t.Version >= 3 {
+		pe.putInt32(t.GenerationID)
+		if err := pe.putString(t.MemberID); err != nil {
+			return err
+		}
+		if err := pe.putNullableString(t.GroupInstanceID); err != nil {
+			return err
+		}
+	}
+
 	if err := pe.putArrayLength(len(t.Topics)); err != nil {
 		return err
 	}
@@ -38,8 +51,10 @@ func (t *TxnOffsetCommitRequest) encode(pe packetEncoder) error {
 				return err
 			}
 		}
+		pe.putEmptyTaggedFieldArray()
 	}
 
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -56,6 +71,18 @@ func (t *TxnOffsetCommitRequest) decode(pd packetDecoder, version int16) (err er
 	}
 	if t.ProducerEpoch, err = pd.getInt16(); err != nil {
 		return err
+	}
+
+	if t.Version >= 3 {
+		if t.GenerationID, err = pd.getInt32(); err != nil {
+			return err
+		}
+		if t.MemberID, err = pd.getString(); err != nil {
+			return err
+		}
+		if t.GroupInstanceID, err = pd.getNullableString(); err != nil {
+			return err
+		}
 	}
 
 	n, err := pd.getArrayLength()
@@ -84,6 +111,14 @@ func (t *TxnOffsetCommitRequest) decode(pd packetDecoder, version int16) (err er
 			}
 			t.Topics[topic][j] = partitionOffsetMetadata
 		}
+
+		if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+			return err
+		}
+	}
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
 	}
 
 	return nil
@@ -98,15 +133,28 @@ func (a *TxnOffsetCommitRequest) version() int16 {
 }
 
 func (a *TxnOffsetCommitRequest) headerVersion() int16 {
+	if a.Version >= 3 {
+		return 2
+	}
 	return 1
 }
 
 func (a *TxnOffsetCommitRequest) isValidVersion() bool {
-	return a.Version >= 0 && a.Version <= 2
+	return a.Version >= 0 && a.Version <= 3
+}
+
+func (a *TxnOffsetCommitRequest) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *TxnOffsetCommitRequest) isFlexibleVersion(version int16) bool {
+	return version >= 3
 }
 
 func (a *TxnOffsetCommitRequest) requiredVersion() KafkaVersion {
 	switch a.Version {
+	case 3:
+		return V2_5_0_0
 	case 2:
 		return V2_1_0_0
 	case 1:
@@ -114,7 +162,7 @@ func (a *TxnOffsetCommitRequest) requiredVersion() KafkaVersion {
 	case 0:
 		return V0_11_0_0
 	default:
-		return V2_1_0_0
+		return V2_5_0_0
 	}
 }
 
@@ -141,6 +189,7 @@ func (p *PartitionOffsetMetadata) encode(pe packetEncoder, version int16) error 
 		return err
 	}
 
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -159,6 +208,10 @@ func (p *PartitionOffsetMetadata) decode(pd packetDecoder, version int16) (err e
 	}
 
 	if p.Metadata, err = pd.getNullableString(); err != nil {
+		return err
+	}
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
 		return err
 	}
 

--- a/txn_offset_commit_request_test.go
+++ b/txn_offset_commit_request_test.go
@@ -31,6 +31,26 @@ var (
 		0, 0, 0, 9, // leader epoch
 		255, 255, // no meta data
 	}
+
+	txnOffsetCommitRequestV3 = []byte{
+		4, 't', 'x', 'n', // transactional ID (compact string)
+		8, 'g', 'r', 'o', 'u', 'p', 'i', 'd', // group ID (compact string)
+		0, 0, 0, 0, 0, 0, 31, 64, // producer ID
+		0, 1, // producer epoch
+		0, 0, 0, 5, // generation ID
+		4, 'm', 'i', 'd', // member ID (compact string)
+		4, 'g', 'i', 'd', // group instance ID (compact nullable string)
+		2,                          // 1 topic (compact array)
+		6, 't', 'o', 'p', 'i', 'c', // topic name (compact string)
+		2,          // 1 partition (compact array)
+		0, 0, 0, 2, // partition no 2
+		0, 0, 0, 0, 0, 0, 0, 123, // committed offset
+		0, 0, 0, 9, // leader epoch
+		0, // no meta data (compact nullable string, null)
+		0, // partition tagged fields
+		0, // topic tagged fields
+		0, // request tagged fields
+	}
 )
 
 func TestTxnOffsetCommitRequest(t *testing.T) {
@@ -67,4 +87,27 @@ func TestTxnOffsetCommitRequestV2(t *testing.T) {
 	}
 
 	testRequest(t, "V2", req, txnOffsetCommitRequestV2)
+}
+
+func TestTxnOffsetCommitRequestV3(t *testing.T) {
+	groupInstanceID := "gid"
+	req := &TxnOffsetCommitRequest{
+		Version:         3,
+		TransactionalID: "txn",
+		GroupID:         "groupid",
+		ProducerID:      8000,
+		ProducerEpoch:   1,
+		GenerationID:    5,
+		MemberID:        "mid",
+		GroupInstanceID: &groupInstanceID,
+		Topics: map[string][]*PartitionOffsetMetadata{
+			"topic": {{
+				Offset:      123,
+				Partition:   2,
+				LeaderEpoch: 9,
+			}},
+		},
+	}
+
+	testRequest(t, "V3", req, txnOffsetCommitRequestV3)
 }

--- a/txn_offset_commit_response.go
+++ b/txn_offset_commit_response.go
@@ -31,9 +31,12 @@ func (t *TxnOffsetCommitResponse) encode(pe packetEncoder) error {
 			if err := partitionError.encode(pe); err != nil {
 				return err
 			}
+			pe.putEmptyTaggedFieldArray()
 		}
+		pe.putEmptyTaggedFieldArray()
 	}
 
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -70,7 +73,18 @@ func (t *TxnOffsetCommitResponse) decode(pd packetDecoder, version int16) (err e
 			if err := t.Topics[topic][j].decode(pd, version); err != nil {
 				return err
 			}
+			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+				return err
+			}
 		}
+
+		if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+			return err
+		}
+	}
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
 	}
 
 	return nil
@@ -85,15 +99,28 @@ func (a *TxnOffsetCommitResponse) version() int16 {
 }
 
 func (a *TxnOffsetCommitResponse) headerVersion() int16 {
+	if a.Version >= 3 {
+		return 1
+	}
 	return 0
 }
 
 func (a *TxnOffsetCommitResponse) isValidVersion() bool {
-	return a.Version >= 0 && a.Version <= 2
+	return a.Version >= 0 && a.Version <= 3
+}
+
+func (a *TxnOffsetCommitResponse) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *TxnOffsetCommitResponse) isFlexibleVersion(version int16) bool {
+	return version >= 3
 }
 
 func (a *TxnOffsetCommitResponse) requiredVersion() KafkaVersion {
 	switch a.Version {
+	case 3:
+		return V2_5_0_0
 	case 2:
 		return V2_1_0_0
 	case 1:
@@ -101,7 +128,7 @@ func (a *TxnOffsetCommitResponse) requiredVersion() KafkaVersion {
 	case 0:
 		return V0_11_0_0
 	default:
-		return V2_1_0_0
+		return V2_5_0_0
 	}
 }
 

--- a/txn_offset_commit_response_test.go
+++ b/txn_offset_commit_response_test.go
@@ -7,14 +7,28 @@ import (
 	"time"
 )
 
-var txnOffsetCommitResponse = []byte{
-	0, 0, 0, 100,
-	0, 0, 0, 1, // 1 topic
-	0, 5, 't', 'o', 'p', 'i', 'c',
-	0, 0, 0, 1, // 1 partition response
-	0, 0, 0, 2, // partition number 2
-	0, 47, // err
-}
+var (
+	txnOffsetCommitResponse = []byte{
+		0, 0, 0, 100,
+		0, 0, 0, 1, // 1 topic
+		0, 5, 't', 'o', 'p', 'i', 'c',
+		0, 0, 0, 1, // 1 partition response
+		0, 0, 0, 2, // partition number 2
+		0, 47, // err
+	}
+
+	txnOffsetCommitResponseV3 = []byte{
+		0, 0, 0, 100, // throttle time
+		2,                          // 1 topic (compact array)
+		6, 't', 'o', 'p', 'i', 'c', // topic name (compact string)
+		2,          // 1 partition response (compact array)
+		0, 0, 0, 2, // partition number 2
+		0, 47, // err
+		0, // partition tagged fields
+		0, // topic tagged fields
+		0, // response tagged fields
+	}
+)
 
 func TestTxnOffsetCommitResponse(t *testing.T) {
 	resp := &TxnOffsetCommitResponse{
@@ -28,4 +42,19 @@ func TestTxnOffsetCommitResponse(t *testing.T) {
 	}
 
 	testResponse(t, "", resp, txnOffsetCommitResponse)
+}
+
+func TestTxnOffsetCommitResponseV3(t *testing.T) {
+	resp := &TxnOffsetCommitResponse{
+		Version:      3,
+		ThrottleTime: 100 * time.Millisecond,
+		Topics: map[string][]*PartitionError{
+			"topic": {{
+				Partition: 2,
+				Err:       ErrInvalidProducerEpoch,
+			}},
+		},
+	}
+
+	testResponse(t, "V3", resp, txnOffsetCommitResponseV3)
 }


### PR DESCRIPTION
Wire up v3 of the txn offset commit API, the first flexible version, which adds the generation ID, member ID and group instance ID fields on the request.

This is protocol support only. The exposed producer API doesn't yet carry the consumer group member metadata, so the negotiated v3 request sends the protocol defaults (generation -1, empty member ID, null instance ID), which tell the broker to skip zombie fencing and keep the existing v2 behaviour. Extending the public func API to flow the real values through will be handled as a follow-on PR.

https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics