### PR TITLE
feat(txn): support consumer group metadata in TxnOffsetCommit v3

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -82,8 +82,18 @@ type AsyncProducer interface {
 	// AddOffsetsToTxn add associated offsets to current transaction.
 	AddOffsetsToTxn(offsets map[string][]*PartitionOffsetMetadata, groupId string) error
 
+	// AddOffsetsToTxnWithGroupMetadata adds associated offsets to the current
+	// transaction, carrying the consumer group member metadata so the broker
+	// can fence stale members (KIP-447).
+	AddOffsetsToTxnWithGroupMetadata(offsets map[string][]*PartitionOffsetMetadata, groupMetadata *ConsumerGroupMetadata) error
+
 	// AddMessageToTxn add message offsets to current transaction.
 	AddMessageToTxn(msg *ConsumerMessage, groupId string, metadata *string) error
+
+	// AddMessageToTxnWithGroupMetadata adds the message offset to the current
+	// transaction, carrying the consumer group member metadata so the broker
+	// can fence stale members (KIP-447).
+	AddMessageToTxnWithGroupMetadata(msg *ConsumerMessage, groupMetadata *ConsumerGroupMetadata, metadata *string) error
 }
 
 type asyncProducer struct {
@@ -437,6 +447,10 @@ func (p *asyncProducer) IsTransactional() bool {
 }
 
 func (p *asyncProducer) AddMessageToTxn(msg *ConsumerMessage, groupId string, metadata *string) error {
+	return p.AddMessageToTxnWithGroupMetadata(msg, NewConsumerGroupMetadata(groupId), metadata)
+}
+
+func (p *asyncProducer) AddMessageToTxnWithGroupMetadata(msg *ConsumerMessage, groupMetadata *ConsumerGroupMetadata, metadata *string) error {
 	offsets := make(map[string][]*PartitionOffsetMetadata)
 	offsets[msg.Topic] = []*PartitionOffsetMetadata{
 		{
@@ -445,10 +459,14 @@ func (p *asyncProducer) AddMessageToTxn(msg *ConsumerMessage, groupId string, me
 			Metadata:  metadata,
 		},
 	}
-	return p.AddOffsetsToTxn(offsets, groupId)
+	return p.AddOffsetsToTxnWithGroupMetadata(offsets, groupMetadata)
 }
 
 func (p *asyncProducer) AddOffsetsToTxn(offsets map[string][]*PartitionOffsetMetadata, groupId string) error {
+	return p.AddOffsetsToTxnWithGroupMetadata(offsets, NewConsumerGroupMetadata(groupId))
+}
+
+func (p *asyncProducer) AddOffsetsToTxnWithGroupMetadata(offsets map[string][]*PartitionOffsetMetadata, groupMetadata *ConsumerGroupMetadata) error {
 	p.txLock.Lock()
 	defer p.txLock.Unlock()
 
@@ -458,7 +476,7 @@ func (p *asyncProducer) AddOffsetsToTxn(offsets map[string][]*PartitionOffsetMet
 	}
 
 	DebugLogger.Printf("producer/txnmgr [%s] add offsets to transaction\n", p.txnmgr.transactionalID)
-	return p.txnmgr.addOffsetsToTxn(offsets, groupId)
+	return p.txnmgr.addOffsetsToTxn(offsets, groupMetadata)
 }
 
 func (p *asyncProducer) TxnStatus() ProducerTxnStatusFlag {

--- a/consumer_group_metadata.go
+++ b/consumer_group_metadata.go
@@ -1,0 +1,40 @@
+package sarama
+
+// ConsumerGroupMetadata identifies the consumer group, and optionally the
+// group member, on whose behalf offsets are committed within a transaction.
+//
+// When a group member supplies its MemberID, GenerationID and (for static
+// membership) GroupInstanceID, the broker can fence zombie or stale members
+// while committing transactional offsets (KIP-447). The zero value, or a
+// metadata built with NewConsumerGroupMetadata, leaves GenerationID at
+// GroupGenerationUndefined which tells the broker to skip that fencing.
+type ConsumerGroupMetadata struct {
+	GroupID         string
+	GenerationID    int32
+	MemberID        string
+	GroupInstanceID *string
+}
+
+// NewConsumerGroupMetadata returns metadata carrying only the group ID, with
+// GenerationID set to GroupGenerationUndefined so the broker performs no member
+// fencing. This reproduces the behavior of the group-ID-only transactional
+// offset commit APIs.
+func NewConsumerGroupMetadata(groupID string) *ConsumerGroupMetadata {
+	return &ConsumerGroupMetadata{
+		GroupID:      groupID,
+		GenerationID: GroupGenerationUndefined,
+	}
+}
+
+// NewConsumerGroupMetadataFromSession builds metadata from a live consumer
+// group session, copying the member ID and generation ID so the broker can
+// fence stale members. Pass the group instance ID when using static membership
+// (Config.Consumer.Group.InstanceId), otherwise nil.
+func NewConsumerGroupMetadataFromSession(session ConsumerGroupSession, groupID string, groupInstanceID *string) *ConsumerGroupMetadata {
+	return &ConsumerGroupMetadata{
+		GroupID:         groupID,
+		GenerationID:    session.GenerationID(),
+		MemberID:        session.MemberID(),
+		GroupInstanceID: groupInstanceID,
+	}
+}

--- a/examples/exactly_once/main.go
+++ b/examples/exactly_once/main.go
@@ -216,6 +216,11 @@ func (consumer *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 	// Do not move the code below to a goroutine.
 	// The `ConsumeClaim` itself is called within a goroutine, see:
 	// https://github.com/IBM/sarama/blob/main/consumer_group.go#L27-L2
+
+	// Carry the member ID and generation ID from this session so the broker can
+	// fence stale members when committing offsets within the transaction. Pass a
+	// non-nil group instance ID here when using static membership.
+	groupMetadata := sarama.NewConsumerGroupMetadataFromSession(session, consumer.groupId, nil)
 	for {
 		select {
 		case message, ok := <-claim.Messages():
@@ -243,11 +248,11 @@ func (consumer *Consumer) ConsumeClaim(session sarama.ConsumerGroupSession, clai
 				}
 
 				// You can add current message to this transaction
-				err = producer.AddMessageToTxn(message, consumer.groupId, nil)
+				err = producer.AddMessageToTxnWithGroupMetadata(message, groupMetadata, nil)
 				if err != nil {
 					log.Println("error on AddMessageToTxn")
 					consumer.handleTxnError(producer, message, session, err, func() error {
-						return producer.AddMessageToTxn(message, consumer.groupId, nil)
+						return producer.AddMessageToTxnWithGroupMetadata(message, groupMetadata, nil)
 					})
 					return
 				}

--- a/functional_producer_test.go
+++ b/functional_producer_test.go
@@ -364,7 +364,7 @@ func TestFuncInitProducerId3(t *testing.T) {
 
 type messageHandler struct {
 	*testing.T
-	h         func(*ConsumerMessage)
+	h         func(ConsumerGroupSession, *ConsumerMessage)
 	started   chan struct{}
 	startOnce sync.Once
 }
@@ -377,22 +377,59 @@ func (h *messageHandler) ConsumeClaim(sess ConsumerGroupSession, claim ConsumerG
 
 	for msg := range claim.Messages() {
 		h.Logf("consumed msg %v", msg)
-		h.h(msg)
+		h.h(sess, msg)
 	}
 	return nil
 }
 
 func TestFuncTxnProduceAndCommitOffset(t *testing.T) {
 	checkKafkaVersion(t, "0.11.0.0")
+
+	t.Run("legacy group ID", func(t *testing.T) {
+		testTxnProduceAndCommitOffset(t, MaxVersion, "TestFuncTxnProduceAndCommitOffset", "test-produce",
+			func(producer AsyncProducer, _ ConsumerGroupSession, msg *ConsumerMessage, groupID string) error {
+				return producer.AddMessageToTxn(msg, groupID, nil)
+			})
+	})
+
+	// test the v2/v3 TxnOffsetCommit protocol boundaries across broker versions
+	versions := []struct {
+		name     string
+		version  KafkaVersion
+		minKafka string
+	}{
+		{"v2", V2_1_0_0, "2.1.0"},
+		{"v3 with group metadata", V2_5_0_0, "2.5.0"},
+	}
+	for _, v := range versions {
+		t.Run(v.name, func(t *testing.T) {
+			checkKafkaVersion(t, v.minKafka)
+			groupID := "test-produce-" + v.version.String()
+			txnID := "TestFuncTxnProduceAndCommitOffset-" + v.version.String()
+			testTxnProduceAndCommitOffset(t, v.version, txnID, groupID,
+				func(producer AsyncProducer, sess ConsumerGroupSession, msg *ConsumerMessage, groupID string) error {
+					return producer.AddMessageToTxnWithGroupMetadata(msg, NewConsumerGroupMetadataFromSession(sess, groupID, nil), nil)
+				})
+		})
+	}
+}
+
+func testTxnProduceAndCommitOffset(
+	t *testing.T,
+	version KafkaVersion,
+	txnID, groupID string,
+	addOffsetToTxn func(producer AsyncProducer, sess ConsumerGroupSession, msg *ConsumerMessage, groupID string) error,
+) {
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
 
 	config := NewFunctionalTestConfig()
+	config.Version = version
 	config.ChannelBufferSize = 20
 	config.Producer.Flush.Frequency = 50 * time.Millisecond
 	config.Producer.Flush.Messages = 200
 	config.Producer.Idempotent = true
-	config.Producer.Transaction.ID = "TestFuncTxnProduceAndCommitOffset"
+	config.Producer.Transaction.ID = txnID
 	config.Producer.RequiredAcks = WaitForAll
 	config.Producer.Transaction.Retry.Max = 200
 	config.Consumer.IsolationLevel = ReadCommitted
@@ -411,7 +448,7 @@ func TestFuncTxnProduceAndCommitOffset(t *testing.T) {
 	require.NoError(t, err)
 	defer producer.Close()
 
-	cg, err := NewConsumerGroupFromClient("test-produce", client)
+	cg, err := NewConsumerGroupFromClient(groupID, client)
 	require.NoError(t, err)
 	defer cg.Close()
 
@@ -420,14 +457,11 @@ func TestFuncTxnProduceAndCommitOffset(t *testing.T) {
 
 	handler := &messageHandler{started: make(chan struct{})}
 	handler.T = t
-	handler.h = func(msg *ConsumerMessage) {
-		err := producer.BeginTxn()
-		require.NoError(t, err)
+	handler.h = func(sess ConsumerGroupSession, msg *ConsumerMessage) {
+		require.NoError(t, producer.BeginTxn())
 		producer.Input() <- &ProducerMessage{Topic: "test.1", Value: StringEncoder("test-prod")}
-		err = producer.AddMessageToTxn(msg, "test-produce", nil)
-		require.NoError(t, err)
-		err = producer.CommitTxn()
-		require.NoError(t, err)
+		require.NoError(t, addOffsetToTxn(producer, sess, msg, groupID))
+		require.NoError(t, producer.CommitTxn())
 	}
 
 	go func() {
@@ -465,7 +499,7 @@ func TestFuncTxnProduceAndCommitOffset(t *testing.T) {
 
 	topicPartitions := make(map[string][]int32)
 	topicPartitions["test.4"] = []int32{0, 1, 2, 3}
-	topicsDescription, err := admin.ListConsumerGroupOffsets("test-produce", topicPartitions)
+	topicsDescription, err := admin.ListConsumerGroupOffsets(groupID, topicPartitions)
 	require.NoError(t, err)
 
 	for _, partition := range topicPartitions["test.4"] {

--- a/mocks/async_producer.go
+++ b/mocks/async_producer.go
@@ -196,7 +196,15 @@ func (mp *AsyncProducer) AddOffsetsToTxn(offsets map[string][]*sarama.PartitionO
 	return nil
 }
 
+func (mp *AsyncProducer) AddOffsetsToTxnWithGroupMetadata(offsets map[string][]*sarama.PartitionOffsetMetadata, groupMetadata *sarama.ConsumerGroupMetadata) error {
+	return nil
+}
+
 func (mp *AsyncProducer) AddMessageToTxn(msg *sarama.ConsumerMessage, groupId string, metadata *string) error {
+	return nil
+}
+
+func (mp *AsyncProducer) AddMessageToTxnWithGroupMetadata(msg *sarama.ConsumerMessage, groupMetadata *sarama.ConsumerGroupMetadata, metadata *string) error {
 	return nil
 }
 

--- a/mocks/sync_producer.go
+++ b/mocks/sync_producer.go
@@ -260,6 +260,14 @@ func (sp *SyncProducer) AddOffsetsToTxn(offsets map[string][]*sarama.PartitionOf
 	return nil
 }
 
+func (sp *SyncProducer) AddOffsetsToTxnWithGroupMetadata(offsets map[string][]*sarama.PartitionOffsetMetadata, groupMetadata *sarama.ConsumerGroupMetadata) error {
+	return nil
+}
+
 func (sp *SyncProducer) AddMessageToTxn(msg *sarama.ConsumerMessage, groupId string, metadata *string) error {
+	return nil
+}
+
+func (sp *SyncProducer) AddMessageToTxnWithGroupMetadata(msg *sarama.ConsumerMessage, groupMetadata *sarama.ConsumerGroupMetadata, metadata *string) error {
 	return nil
 }

--- a/sync_producer.go
+++ b/sync_producer.go
@@ -54,8 +54,18 @@ type SyncProducer interface {
 	// AddOffsetsToTxn add associated offsets to current transaction.
 	AddOffsetsToTxn(offsets map[string][]*PartitionOffsetMetadata, groupId string) error
 
+	// AddOffsetsToTxnWithGroupMetadata adds associated offsets to the current
+	// transaction, carrying the consumer group member metadata so the broker
+	// can fence stale members (KIP-447).
+	AddOffsetsToTxnWithGroupMetadata(offsets map[string][]*PartitionOffsetMetadata, groupMetadata *ConsumerGroupMetadata) error
+
 	// AddMessageToTxn add message offsets to current transaction.
 	AddMessageToTxn(msg *ConsumerMessage, groupId string, metadata *string) error
+
+	// AddMessageToTxnWithGroupMetadata adds the message offset to the current
+	// transaction, carrying the consumer group member metadata so the broker
+	// can fence stale members (KIP-447).
+	AddMessageToTxnWithGroupMetadata(msg *ConsumerMessage, groupMetadata *ConsumerGroupMetadata, metadata *string) error
 }
 
 type syncProducer struct {
@@ -200,8 +210,16 @@ func (sp *syncProducer) AddOffsetsToTxn(offsets map[string][]*PartitionOffsetMet
 	return sp.producer.AddOffsetsToTxn(offsets, groupId)
 }
 
+func (sp *syncProducer) AddOffsetsToTxnWithGroupMetadata(offsets map[string][]*PartitionOffsetMetadata, groupMetadata *ConsumerGroupMetadata) error {
+	return sp.producer.AddOffsetsToTxnWithGroupMetadata(offsets, groupMetadata)
+}
+
 func (sp *syncProducer) AddMessageToTxn(msg *ConsumerMessage, groupId string, metadata *string) error {
 	return sp.producer.AddMessageToTxn(msg, groupId, metadata)
+}
+
+func (sp *syncProducer) AddMessageToTxnWithGroupMetadata(msg *ConsumerMessage, groupMetadata *ConsumerGroupMetadata, metadata *string) error {
+	return sp.producer.AddMessageToTxnWithGroupMetadata(msg, groupMetadata, metadata)
 }
 
 func (p *syncProducer) TxnStatus() ProducerTxnStatusFlag {

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -101,6 +101,10 @@ type transactionManager struct {
 
 	// Offsets to add to transaction.
 	offsetsInCurrentTxn map[string]topicPartitionOffsets
+
+	// Consumer group metadata per group whose offsets are added to the
+	// transaction, keyed by group ID.
+	groupMetadataInCurrentTxn map[string]*ConsumerGroupMetadata
 }
 
 const (
@@ -268,7 +272,7 @@ func (t *transactionManager) isTransactional() bool {
 }
 
 // add specified offsets to current transaction.
-func (t *transactionManager) addOffsetsToTxn(offsetsToAdd map[string][]*PartitionOffsetMetadata, groupId string) error {
+func (t *transactionManager) addOffsetsToTxn(offsetsToAdd map[string][]*PartitionOffsetMetadata, groupMetadata *ConsumerGroupMetadata) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -280,9 +284,11 @@ func (t *transactionManager) addOffsetsToTxn(offsetsToAdd map[string][]*Partitio
 		return t.lastError
 	}
 
+	groupId := groupMetadata.GroupID
 	if _, ok := t.offsetsInCurrentTxn[groupId]; !ok {
 		t.offsetsInCurrentTxn[groupId] = topicPartitionOffsets{}
 	}
+	t.groupMetadataInCurrentTxn[groupId] = groupMetadata
 
 	for topic, offsets := range offsetsToAdd {
 		for _, offset := range offsets {
@@ -294,7 +300,8 @@ func (t *transactionManager) addOffsetsToTxn(offsetsToAdd map[string][]*Partitio
 }
 
 // send txnmgnr save offsets to transaction coordinator.
-func (t *transactionManager) publishOffsetsToTxn(offsets topicPartitionOffsets, groupId string) (topicPartitionOffsets, error) {
+func (t *transactionManager) publishOffsetsToTxn(offsets topicPartitionOffsets, groupMetadata *ConsumerGroupMetadata) (topicPartitionOffsets, error) {
+	groupId := groupMetadata.GroupID
 	// First AddOffsetsToTxn
 	attemptsRemaining := t.client.Config().Producer.Transaction.Retry.Max
 	exec := func(run func() (bool, error), err error) error {
@@ -408,12 +415,14 @@ func (t *transactionManager) publishOffsetsToTxn(offsets topicPartitionOffsets, 
 			Topics:          offsets.mapToRequest(),
 		}
 		if t.client.Config().Version.IsAtLeast(V2_5_0_0) {
-			// Version 3 adds the member ID, group instance ID and generation ID.
-			// We don't track the consumer group member metadata here, so send the
-			// protocol defaults (generation -1, empty member ID, null instance ID)
-			// which tell the broker to skip zombie fencing, matching v2 behavior.
+			// Version 3 adds the member ID, group instance ID and generation ID,
+			// which let the broker fence stale group members. Callers that don't
+			// supply them get the protocol defaults (generation -1, empty member
+			// ID, null instance ID) which tell the broker to skip that fencing.
 			request.Version = 3
-			request.GenerationID = GroupGenerationUndefined
+			request.GenerationID = groupMetadata.GenerationID
+			request.MemberID = groupMetadata.MemberID
+			request.GroupInstanceID = groupMetadata.GroupInstanceID
 		} else if t.client.Config().Version.IsAtLeast(V2_1_0_0) {
 			// Version 2 adds the committed leader epoch.
 			request.Version = 2
@@ -618,6 +627,7 @@ func (t *transactionManager) completeTransaction() error {
 	t.partitionsInCurrentTxn = topicPartitionSet{}
 	t.pendingPartitionsInCurrentTxn = topicPartitionSet{}
 	t.offsetsInCurrentTxn = map[string]topicPartitionOffsets{}
+	t.groupMetadataInCurrentTxn = map[string]*ConsumerGroupMetadata{}
 
 	return nil
 }
@@ -719,12 +729,13 @@ func (t *transactionManager) finishTransaction(commit bool) error {
 	// If we're aborting the transaction, so there should be no need to add offsets.
 	if commit && len(t.offsetsInCurrentTxn) > 0 {
 		for group, offsets := range t.offsetsInCurrentTxn {
-			newOffsets, err := t.publishOffsetsToTxn(offsets, group)
+			newOffsets, err := t.publishOffsetsToTxn(offsets, t.groupMetadataInCurrentTxn[group])
 			if err != nil {
 				t.offsetsInCurrentTxn[group] = newOffsets
 				return err
 			}
 			delete(t.offsetsInCurrentTxn, group)
+			delete(t.groupMetadataInCurrentTxn, group)
 		}
 	}
 
@@ -909,6 +920,7 @@ func newTransactionManager(conf *Config, client Client) (*transactionManager, er
 		pendingPartitionsInCurrentTxn: topicPartitionSet{},
 		partitionsInCurrentTxn:        topicPartitionSet{},
 		offsetsInCurrentTxn:           make(map[string]topicPartitionOffsets),
+		groupMetadataInCurrentTxn:     make(map[string]*ConsumerGroupMetadata),
 		status:                        ProducerTxnFlagUninitialized,
 	}
 

--- a/transaction_manager_test.go
+++ b/transaction_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -265,13 +266,6 @@ func TestMaybeAddPartitionToCurrentTxn(t *testing.T) {
 	broker := NewMockBroker(t, 1)
 	defer broker.Close()
 
-	metadataLeader := new(MetadataResponse)
-	metadataLeader.Version = 4
-	metadataLeader.ControllerID = broker.brokerID
-	metadataLeader.AddBroker(broker.Addr(), broker.BrokerID())
-	metadataLeader.AddTopic("test-topic", ErrNoError)
-	metadataLeader.AddTopicPartition("test-topic", 0, broker.BrokerID(), nil, nil, nil, ErrNoError)
-
 	config := NewTestConfig()
 	config.Producer.Idempotent = true
 	config.Producer.Transaction.ID = "test"
@@ -283,28 +277,8 @@ func TestMaybeAddPartitionToCurrentTxn(t *testing.T) {
 
 	for _, tc := range testCases {
 		func() {
-			broker.Returns(metadataLeader)
-
-			client, err := NewClient([]string{broker.Addr()}, config)
-			require.NoError(t, err)
+			client, txmng := newMockTxnManager(t, broker, config)
 			defer client.Close()
-
-			findCoordinatorResponse := FindCoordinatorResponse{
-				Coordinator: client.Brokers()[0],
-				Err:         ErrNoError,
-				Version:     1,
-			}
-			broker.Returns(&findCoordinatorResponse)
-
-			producerIdResponse := &InitProducerIDResponse{
-				Err:           ErrNoError,
-				ProducerID:    1,
-				ProducerEpoch: 0,
-			}
-			broker.Returns(producerIdResponse)
-
-			txmng, err := newTransactionManager(config, client)
-			require.NoError(t, err)
 
 			txmng.partitionsInCurrentTxn = tc.initialPartitionsInCurrentTxn
 			txmng.pendingPartitionsInCurrentTxn = tc.initialPendingPartitionsInCurrentTxn
@@ -399,13 +373,6 @@ func TestAddOffsetsToTxn(t *testing.T) {
 	broker := NewMockBroker(t, 1)
 	defer broker.Close()
 
-	metadataLeader := new(MetadataResponse)
-	metadataLeader.Version = 4
-	metadataLeader.ControllerID = broker.brokerID
-	metadataLeader.AddBroker(broker.Addr(), broker.BrokerID())
-	metadataLeader.AddTopic("test-topic", ErrNoError)
-	metadataLeader.AddTopicPartition("test-topic", 0, broker.BrokerID(), nil, nil, nil, ErrNoError)
-
 	config := NewTestConfig()
 	config.Producer.Idempotent = true
 	config.Producer.Transaction.ID = "test"
@@ -424,29 +391,8 @@ func TestAddOffsetsToTxn(t *testing.T) {
 
 	for _, tc := range testCases {
 		func() {
-			broker.Returns(metadataLeader)
-
-			client, err := NewClient([]string{broker.Addr()}, config)
-			require.NoError(t, err)
-
+			client, txmng := newMockTxnManager(t, broker, config)
 			defer client.Close()
-
-			findCoordinatorResponse := FindCoordinatorResponse{
-				Coordinator: client.Brokers()[0],
-				Err:         ErrNoError,
-				Version:     1,
-			}
-			broker.Returns(&findCoordinatorResponse)
-
-			producerIdResponse := &InitProducerIDResponse{
-				Err:           ErrNoError,
-				ProducerID:    1,
-				ProducerEpoch: 0,
-			}
-			broker.Returns(producerIdResponse)
-
-			txmng, err := newTransactionManager(config, client)
-			require.NoError(t, err)
 
 			txmng.status = tc.initialFlags
 
@@ -482,7 +428,7 @@ func TestAddOffsetsToTxn(t *testing.T) {
 				})
 			}
 
-			newOffsets, err := txmng.publishOffsetsToTxn(offsets, "test-group")
+			newOffsets, err := txmng.publishOffsetsToTxn(offsets, NewConsumerGroupMetadata("test-group"))
 			if tc.expectedError != nil {
 				require.Equal(t, tc.expectedError.Error(), err.Error())
 			} else {
@@ -492,6 +438,82 @@ func TestAddOffsetsToTxn(t *testing.T) {
 			require.NotEqual(t, 0, tc.expectedFlags&txmng.status)
 		}()
 	}
+}
+
+// newMockTxnManager wires a transaction manager to broker using the standard
+// metadata, find-coordinator and init-producer-id handshake. The caller owns
+// closing the returned client.
+func newMockTxnManager(t *testing.T, broker *MockBroker, config *Config) (Client, *transactionManager) {
+	// the mock broker matches each response version to the request version, so
+	// MetadataResponse.Version is left at its zero value here
+	metadataLeader := new(MetadataResponse)
+	metadataLeader.ControllerID = broker.brokerID
+	metadataLeader.AddBroker(broker.Addr(), broker.BrokerID())
+	metadataLeader.AddTopic("test-topic", ErrNoError)
+	metadataLeader.AddTopicPartition("test-topic", 0, broker.BrokerID(), nil, nil, nil, ErrNoError)
+	broker.Returns(metadataLeader)
+
+	client, err := NewClient([]string{broker.Addr()}, config)
+	require.NoError(t, err)
+
+	broker.Returns(&FindCoordinatorResponse{Coordinator: client.Brokers()[0], Err: ErrNoError})
+	broker.Returns(&InitProducerIDResponse{Err: ErrNoError, ProducerID: 1, ProducerEpoch: 0})
+
+	txmng, err := newTransactionManager(config, client)
+	require.NoError(t, err)
+	return client, txmng
+}
+
+func TestTxnOffsetCommitGroupMetadata(t *testing.T) {
+	broker := NewMockBroker(t, 1)
+	defer broker.Close()
+
+	config := NewTestConfig()
+	config.Producer.Idempotent = true
+	config.Producer.Transaction.ID = "test"
+	config.Version = V2_5_0_0
+	config.Producer.RequiredAcks = WaitForAll
+	config.Net.MaxOpenRequests = 1
+
+	client, txmng := newMockTxnManager(t, broker, config)
+	defer client.Close()
+	txmng.status = ProducerTxnFlagInTransaction
+
+	broker.Returns(&AddOffsetsToTxnResponse{Err: ErrNoError})
+	broker.Returns(&FindCoordinatorResponse{Coordinator: client.Brokers()[0], Err: ErrNoError})
+	broker.Returns(&TxnOffsetCommitResponse{
+		Topics: map[string][]*PartitionError{
+			"test-topic": {{Partition: 0, Err: ErrNoError}},
+		},
+	})
+
+	instanceID := "instance-1"
+	groupMetadata := &ConsumerGroupMetadata{
+		GroupID:         "test-group",
+		GenerationID:    42,
+		MemberID:        "member-1",
+		GroupInstanceID: &instanceID,
+	}
+	offsets := topicPartitionOffsets{
+		topicPartition{topic: "test-topic", partition: 0}: {Partition: 0, Offset: 0},
+	}
+
+	_, err := txmng.publishOffsetsToTxn(offsets, groupMetadata)
+	require.NoError(t, err)
+
+	var committed *TxnOffsetCommitRequest
+	for _, rr := range broker.History() {
+		if req, ok := rr.Request.(*TxnOffsetCommitRequest); ok {
+			committed = req
+		}
+	}
+	require.NotNil(t, committed, "expected a TxnOffsetCommitRequest to reach the broker")
+	assert.EqualValues(t, 3, committed.Version)
+	assert.Equal(t, "test-group", committed.GroupID)
+	assert.EqualValues(t, 42, committed.GenerationID)
+	assert.Equal(t, "member-1", committed.MemberID)
+	require.NotNil(t, committed.GroupInstanceID)
+	assert.Equal(t, instanceID, *committed.GroupInstanceID)
 }
 
 func TestTxnOffsetsCommit(t *testing.T) {
@@ -656,37 +678,10 @@ func TestTxnOffsetsCommit(t *testing.T) {
 	config.Producer.Transaction.Retry.Max = 0
 	config.Producer.Transaction.Retry.Backoff = 0
 
-	metadataLeader := new(MetadataResponse)
-	metadataLeader.Version = 4
-	metadataLeader.ControllerID = broker.brokerID
-	metadataLeader.AddBroker(broker.Addr(), broker.BrokerID())
-	metadataLeader.AddTopic("test-topic", ErrNoError)
-	metadataLeader.AddTopicPartition("test-topic", 0, broker.BrokerID(), nil, nil, nil, ErrNoError)
-
 	for _, tc := range testCases {
 		func() {
-			broker.Returns(metadataLeader)
-
-			client, err := NewClient([]string{broker.Addr()}, config)
-			require.NoError(t, err)
+			client, txmng := newMockTxnManager(t, broker, config)
 			defer client.Close()
-
-			findCoordinatorResponse := FindCoordinatorResponse{
-				Coordinator: client.Brokers()[0],
-				Err:         ErrNoError,
-				Version:     1,
-			}
-			broker.Returns(&findCoordinatorResponse)
-
-			producerIdResponse := &InitProducerIDResponse{
-				Err:           ErrNoError,
-				ProducerID:    1,
-				ProducerEpoch: 0,
-			}
-			broker.Returns(producerIdResponse)
-
-			txmng, err := newTransactionManager(config, client)
-			require.NoError(t, err)
 
 			txmng.status = tc.initialFlags
 
@@ -719,7 +714,7 @@ func TestTxnOffsetsCommit(t *testing.T) {
 				})
 			}
 
-			newOffsets, err := txmng.publishOffsetsToTxn(tc.initialOffsets, "test-group")
+			newOffsets, err := txmng.publishOffsetsToTxn(tc.initialOffsets, NewConsumerGroupMetadata("test-group"))
 			if tc.expectedError != nil {
 				require.Equal(t, tc.expectedError.Error(), err.Error())
 			} else {
@@ -787,13 +782,6 @@ func TestEndTxn(t *testing.T) {
 	broker := NewMockBroker(t, 1)
 	defer broker.Close()
 
-	metadataLeader := new(MetadataResponse)
-	metadataLeader.Version = 4
-	metadataLeader.ControllerID = broker.brokerID
-	metadataLeader.AddBroker(broker.Addr(), broker.BrokerID())
-	metadataLeader.AddTopic("test-topic", ErrNoError)
-	metadataLeader.AddTopicPartition("test-topic", 0, broker.BrokerID(), nil, nil, nil, ErrNoError)
-
 	config := NewTestConfig()
 	config.Producer.Idempotent = true
 	config.Producer.Transaction.ID = "test"
@@ -805,28 +793,8 @@ func TestEndTxn(t *testing.T) {
 
 	for _, tc := range testCases {
 		func() {
-			broker.Returns(metadataLeader)
-
-			client, err := NewClient([]string{broker.Addr()}, config)
-			require.NoError(t, err)
+			client, txmng := newMockTxnManager(t, broker, config)
 			defer client.Close()
-
-			findCoordinatorResponse := FindCoordinatorResponse{
-				Coordinator: client.Brokers()[0],
-				Err:         ErrNoError,
-				Version:     1,
-			}
-			broker.Returns(&findCoordinatorResponse)
-
-			producerIdResponse := &InitProducerIDResponse{
-				Err:           ErrNoError,
-				ProducerID:    1,
-				ProducerEpoch: 0,
-			}
-			broker.Returns(producerIdResponse)
-
-			txmng, err := newTransactionManager(config, client)
-			require.NoError(t, err)
 
 			txmng.status = ProducerTxnFlagEndTransaction
 
@@ -846,7 +814,7 @@ func TestEndTxn(t *testing.T) {
 				})
 			}
 
-			err = txmng.endTxn(tc.commit)
+			err := txmng.endTxn(tc.commit)
 			require.Equal(t, tc.expectedError, err)
 			require.NotEqual(t, 0, txmng.currentTxnStatus()&tc.expectedFlags)
 		}()
@@ -952,13 +920,6 @@ func TestPublishPartitionToTxn(t *testing.T) {
 	broker := NewMockBroker(t, 1)
 	defer broker.Close()
 
-	metadataLeader := new(MetadataResponse)
-	metadataLeader.Version = 4
-	metadataLeader.ControllerID = broker.brokerID
-	metadataLeader.AddBroker(broker.Addr(), broker.BrokerID())
-	metadataLeader.AddTopic("test-topic", ErrNoError)
-	metadataLeader.AddTopicPartition("test-topic", 0, broker.BrokerID(), nil, nil, nil, ErrNoError)
-
 	config := NewTestConfig()
 	config.Producer.Idempotent = true
 	config.Producer.Transaction.ID = "test"
@@ -970,28 +931,8 @@ func TestPublishPartitionToTxn(t *testing.T) {
 
 	for _, tc := range testCases {
 		func() {
-			broker.Returns(metadataLeader)
-
-			client, err := NewClient([]string{broker.Addr()}, config)
-			require.NoError(t, err)
+			client, txmng := newMockTxnManager(t, broker, config)
 			defer client.Close()
-
-			findCoordinatorResponse := FindCoordinatorResponse{
-				Coordinator: client.Brokers()[0],
-				Err:         ErrNoError,
-				Version:     1,
-			}
-			broker.Returns(&findCoordinatorResponse)
-
-			producerIdResponse := &InitProducerIDResponse{
-				Err:           ErrNoError,
-				ProducerID:    1,
-				ProducerEpoch: 0,
-			}
-			broker.Returns(producerIdResponse)
-
-			txmng, err := newTransactionManager(config, client)
-			require.NoError(t, err)
 
 			txmng.status = ProducerTxnFlagInTransaction
 			txmng.pendingPartitionsInCurrentTxn = topicPartitionSet{
@@ -1019,7 +960,7 @@ func TestPublishPartitionToTxn(t *testing.T) {
 					Version:     1,
 				})
 			}
-			err = txmng.publishTxnPartitions()
+			err := txmng.publishTxnPartitions()
 			if tc.expectedError != nil {
 				require.Equal(t, tc.expectedError.Error(), err.Error(), tc)
 			} else {


### PR DESCRIPTION
Add ConsumerGroupMetadata along with AddOffsetsToTxnWithGroupMetadata and AddMessageToTxnWithGroupMetadata, so callers can pass the group member identity that v3 needs for broker-side fencing (KIP-447). The existing group-ID-only methods still work unchanged.