### PR TITLE
feat(admin): add protocol support for DeleteRecords v2 (KIP-482)

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -763,7 +763,9 @@ func (ca *clusterAdmin) DeleteRecords(topic string, partitionOffsets map[int32]i
 			Topics:  topics,
 			Timeout: ca.conf.Admin.Timeout,
 		}
-		if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+		if ca.conf.Version.IsAtLeast(V2_6_0_0) {
+			request.Version = 2
+		} else if ca.conf.Version.IsAtLeast(V2_0_0_0) {
 			request.Version = 1
 		}
 		rsp, err := broker.DeleteRecords(request)

--- a/delete_records_request.go
+++ b/delete_records_request.go
@@ -42,6 +42,8 @@ func (d *DeleteRecordsRequest) encode(pe packetEncoder) error {
 	}
 	pe.putInt32(int32(d.Timeout / time.Millisecond))
 
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
@@ -72,6 +74,10 @@ func (d *DeleteRecordsRequest) decode(pd packetDecoder, version int16) error {
 	}
 	d.Timeout = time.Duration(timeout) * time.Millisecond
 
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -84,20 +90,33 @@ func (d *DeleteRecordsRequest) version() int16 {
 }
 
 func (d *DeleteRecordsRequest) headerVersion() int16 {
+	if d.Version >= 2 {
+		return 2
+	}
 	return 1
 }
 
 func (d *DeleteRecordsRequest) isValidVersion() bool {
-	return d.Version >= 0 && d.Version <= 1
+	return d.Version >= 0 && d.Version <= 2
 }
 
 func (d *DeleteRecordsRequest) requiredVersion() KafkaVersion {
 	switch d.Version {
+	case 2:
+		return V2_6_0_0
 	case 1:
 		return V2_0_0_0
 	default:
 		return V0_11_0_0
 	}
+}
+
+func (d *DeleteRecordsRequest) isFlexible() bool {
+	return d.isFlexibleVersion(d.Version)
+}
+
+func (d *DeleteRecordsRequest) isFlexibleVersion(version int16) bool {
+	return version >= 2
 }
 
 type DeleteRecordsRequestTopic struct {
@@ -116,7 +135,9 @@ func (t *DeleteRecordsRequestTopic) encode(pe packetEncoder) error {
 	for _, partition := range keys {
 		pe.putInt32(partition)
 		pe.putInt64(t.PartitionOffsets[partition])
+		pe.putEmptyTaggedFieldArray()
 	}
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -138,7 +159,14 @@ func (t *DeleteRecordsRequestTopic) decode(pd packetDecoder, version int16) erro
 				return err
 			}
 			t.PartitionOffsets[partition] = offset
+			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+				return err
+			}
 		}
+	}
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
 	}
 
 	return nil

--- a/delete_records_request_test.go
+++ b/delete_records_request_test.go
@@ -20,19 +20,57 @@ var deleteRecordsRequest = []byte{
 	0, 0, 0, 100,
 }
 
-func TestDeleteRecordsRequest(t *testing.T) {
-	req := &DeleteRecordsRequest{
-		Topics: map[string]*DeleteRecordsRequestTopic{
-			"topic": {
-				PartitionOffsets: map[int32]int64{
-					19: 200,
-					20: 190,
-				},
-			},
-			"other": {},
-		},
-		Timeout: 100 * time.Millisecond,
-	}
+var deleteRecordsRequestV2 = []byte{
+	0x03,                          // Topics compact array length (2+1)
+	0x06, 'o', 't', 'h', 'e', 'r', // "other" compact string (5+1)
+	0x01,                          // Partitions compact array length (0+1, empty)
+	0x00,                          // topic tagged fields
+	0x06, 't', 'o', 'p', 'i', 'c', // "topic" compact string (5+1)
+	0x03,        // Partitions compact array length (2+1)
+	0, 0, 0, 19, // PartitionIndex 19
+	0, 0, 0, 0, 0, 0, 0, 200, // Offset 200
+	0x00,        // partition tagged fields
+	0, 0, 0, 20, // PartitionIndex 20
+	0, 0, 0, 0, 0, 0, 0, 190, // Offset 190
+	0x00,         // partition tagged fields
+	0x00,         // topic tagged fields
+	0, 0, 0, 100, // TimeoutMs 100
+	0x00, // request tagged fields
+}
 
-	testRequest(t, "", req, deleteRecordsRequest)
+func TestDeleteRecordsRequest(t *testing.T) {
+	t.Run("v0", func(t *testing.T) {
+		req := &DeleteRecordsRequest{
+			Topics: map[string]*DeleteRecordsRequestTopic{
+				"topic": {
+					PartitionOffsets: map[int32]int64{
+						19: 200,
+						20: 190,
+					},
+				},
+				"other": {},
+			},
+			Timeout: 100 * time.Millisecond,
+		}
+
+		testRequest(t, "", req, deleteRecordsRequest)
+	})
+
+	t.Run("v2 flexible", func(t *testing.T) {
+		req := &DeleteRecordsRequest{
+			Version: 2,
+			Topics: map[string]*DeleteRecordsRequestTopic{
+				"topic": {
+					PartitionOffsets: map[int32]int64{
+						19: 200,
+						20: 190,
+					},
+				},
+				"other": {},
+			},
+			Timeout: 100 * time.Millisecond,
+		}
+
+		testRequest(t, "", req, deleteRecordsRequestV2)
+	})
 }

--- a/delete_records_response.go
+++ b/delete_records_response.go
@@ -42,6 +42,9 @@ func (d *DeleteRecordsResponse) encode(pe packetEncoder) error {
 			return err
 		}
 	}
+
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
@@ -72,6 +75,10 @@ func (d *DeleteRecordsResponse) decode(pd packetDecoder, version int16) (err err
 		}
 	}
 
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -84,20 +91,33 @@ func (d *DeleteRecordsResponse) version() int16 {
 }
 
 func (d *DeleteRecordsResponse) headerVersion() int16 {
+	if d.Version >= 2 {
+		return 1
+	}
 	return 0
 }
 
 func (d *DeleteRecordsResponse) isValidVersion() bool {
-	return d.Version >= 0 && d.Version <= 1
+	return d.Version >= 0 && d.Version <= 2
 }
 
 func (d *DeleteRecordsResponse) requiredVersion() KafkaVersion {
 	switch d.Version {
+	case 2:
+		return V2_6_0_0
 	case 1:
 		return V2_0_0_0
 	default:
 		return V0_11_0_0
 	}
+}
+
+func (d *DeleteRecordsResponse) isFlexible() bool {
+	return d.isFlexibleVersion(d.Version)
+}
+
+func (d *DeleteRecordsResponse) isFlexibleVersion(version int16) bool {
+	return version >= 2
 }
 
 func (r *DeleteRecordsResponse) throttleTime() time.Duration {
@@ -123,6 +143,9 @@ func (t *DeleteRecordsResponseTopic) encode(pe packetEncoder) error {
 			return err
 		}
 	}
+
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
@@ -147,6 +170,10 @@ func (t *DeleteRecordsResponseTopic) decode(pd packetDecoder, version int16) err
 		}
 	}
 
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -158,6 +185,7 @@ type DeleteRecordsResponsePartition struct {
 func (t *DeleteRecordsResponsePartition) encode(pe packetEncoder) error {
 	pe.putInt64(t.LowWatermark)
 	pe.putKError(t.Err)
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -170,6 +198,10 @@ func (t *DeleteRecordsResponsePartition) decode(pd packetDecoder, version int16)
 
 	t.Err, err = pd.getKError()
 	if err != nil {
+		return err
+	}
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
 		return err
 	}
 

--- a/delete_records_response_test.go
+++ b/delete_records_response_test.go
@@ -22,20 +22,60 @@ var deleteRecordsResponse = []byte{
 	0, 3,
 }
 
-func TestDeleteRecordsResponse(t *testing.T) {
-	resp := &DeleteRecordsResponse{
-		Version:      0,
-		ThrottleTime: 100 * time.Millisecond,
-		Topics: map[string]*DeleteRecordsResponseTopic{
-			"topic": {
-				Partitions: map[int32]*DeleteRecordsResponsePartition{
-					19: {LowWatermark: 200, Err: 0},
-					20: {LowWatermark: -1, Err: 3},
-				},
-			},
-			"other": {},
-		},
-	}
+var deleteRecordsResponseV2 = []byte{
+	0, 0, 0, 100, // ThrottleTimeMs 100
+	0x03,                          // Topics compact array length (2+1)
+	0x06, 'o', 't', 'h', 'e', 'r', // "other" compact string (5+1)
+	0x01,                          // Partitions compact array length (0+1, empty)
+	0x00,                          // topic tagged fields
+	0x06, 't', 'o', 'p', 'i', 'c', // "topic" compact string (5+1)
+	0x03,        // Partitions compact array length (2+1)
+	0, 0, 0, 19, // PartitionIndex 19
+	0, 0, 0, 0, 0, 0, 0, 200, // LowWatermark 200
+	0, 0, // ErrorCode 0
+	0x00,        // partition tagged fields
+	0, 0, 0, 20, // PartitionIndex 20
+	255, 255, 255, 255, 255, 255, 255, 255, // LowWatermark -1
+	0, 3, // ErrorCode 3
+	0x00, // partition tagged fields
+	0x00, // topic tagged fields
+	0x00, // response tagged fields
+}
 
-	testResponse(t, "", resp, deleteRecordsResponse)
+func TestDeleteRecordsResponse(t *testing.T) {
+	t.Run("v0", func(t *testing.T) {
+		resp := &DeleteRecordsResponse{
+			Version:      0,
+			ThrottleTime: 100 * time.Millisecond,
+			Topics: map[string]*DeleteRecordsResponseTopic{
+				"topic": {
+					Partitions: map[int32]*DeleteRecordsResponsePartition{
+						19: {LowWatermark: 200, Err: 0},
+						20: {LowWatermark: -1, Err: 3},
+					},
+				},
+				"other": {},
+			},
+		}
+
+		testResponse(t, "", resp, deleteRecordsResponse)
+	})
+
+	t.Run("v2 flexible", func(t *testing.T) {
+		resp := &DeleteRecordsResponse{
+			Version:      2,
+			ThrottleTime: 100 * time.Millisecond,
+			Topics: map[string]*DeleteRecordsResponseTopic{
+				"topic": {
+					Partitions: map[int32]*DeleteRecordsResponsePartition{
+						19: {LowWatermark: 200, Err: 0},
+						20: {LowWatermark: -1, Err: 3},
+					},
+				},
+				"other": {},
+			},
+		}
+
+		testResponse(t, "", resp, deleteRecordsResponseV2)
+	})
 }

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -551,6 +551,52 @@ func TestFuncAdminListOffsets(t *testing.T) {
 	)
 }
 
+func TestFuncAdminDeleteRecords(t *testing.T) {
+	t.Parallel()
+	checkKafkaVersion(t, "0.11.0.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	const (
+		partitionsCount      = int32(1)
+		messagesPerPartition = 10
+		deleteBeforeOffset   = int64(5)
+	)
+
+	config := NewFunctionalTestConfig()
+	config.ClientID = t.Name()
+	config.Producer.Partitioner = NewManualPartitioner
+	config.Producer.Return.Successes = true
+
+	client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer safeClose(t, client)
+
+	adminClient, err := NewClusterAdminFromClient(client)
+	require.NoError(t, err)
+
+	topic, err := topicWithEvenLeaders(t, adminClient, client, partitionsCount)
+	require.NoError(t, err)
+
+	produceMessagesForPartitions(t, client, topic, partitionsCount, messagesPerPartition, time.Now().UnixMilli())
+
+	require.NoError(t, client.RefreshMetadata(topic))
+
+	err = adminClient.DeleteRecords(topic, map[int32]int64{0: deleteBeforeOffset})
+	require.NoError(t, err)
+
+	// truncating records before deleteBeforeOffset moves the partition low water mark there
+	listOffsetsAndValidate(
+		t,
+		adminClient,
+		topic,
+		partitionsCount,
+		OffsetOldest,
+		deleteBeforeOffset,
+		"earliest after delete",
+	)
+}
+
 func TestFuncAdminAlterConsumerGroupOffsets(t *testing.T) {
 	t.Parallel()
 	checkKafkaVersion(t, "2.1.0.0")

--- a/request_test.go
+++ b/request_test.go
@@ -390,8 +390,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDescribeLogDirs:      2, // up from 1
 				apiKeyDescribeClientQuotas: 0, // new in 2.6
 				apiKeyAlterClientQuotas:    0, // new in 2.6
-				// TODO: DeleteRecordsRequest v2 is not supported, but expected for KafkaVersion 2.6.0
-				// apiKeyDeleteRecords:     2, // up from 1
+				apiKeyDeleteRecords:        2, // up from 1
 				// TODO: DescribeConfigsRequest v3 is not supported, but expected for KafkaVersion 2.6.0
 				// apiKeyDescribeConfigs:   3, // up from 2
 			},


### PR DESCRIPTION
Add support for the first flexible version of DeleteRecords (Kafka 2.6.0).