### PR TITLE
feat(protocol): add support for DescribeConfigs v3 and v4

### DIFF
--- a/describe_configs_request.go
+++ b/describe_configs_request.go
@@ -1,9 +1,10 @@
 package sarama
 
 type DescribeConfigsRequest struct {
-	Version         int16
-	Resources       []*ConfigResource
-	IncludeSynonyms bool
+	Version              int16
+	Resources            []*ConfigResource
+	IncludeSynonyms      bool
+	IncludeDocumentation bool // v3
 }
 
 func (r *DescribeConfigsRequest) setVersion(v int16) {
@@ -28,17 +29,25 @@ func (r *DescribeConfigsRequest) encode(pe packetEncoder) error {
 		}
 
 		if len(c.ConfigNames) == 0 {
-			pe.putInt32(-1)
-			continue
-		}
-		if err := pe.putStringArray(c.ConfigNames); err != nil {
+			if err := pe.putArrayLength(-1); err != nil {
+				return err
+			}
+		} else if err := pe.putStringArray(c.ConfigNames); err != nil {
 			return err
 		}
+
+		pe.putEmptyTaggedFieldArray()
 	}
 
 	if r.Version >= 1 {
 		pe.putBool(r.IncludeSynonyms)
 	}
+
+	if r.Version >= 3 {
+		pe.putBool(r.IncludeDocumentation)
+	}
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -69,19 +78,21 @@ func (r *DescribeConfigsRequest) decode(pd packetDecoder, version int16) (err er
 			return err
 		}
 
-		if confLength == -1 {
-			continue
+		if confLength != -1 {
+			cfnames := make([]string, confLength)
+			for i := 0; i < confLength; i++ {
+				s, err := pd.getString()
+				if err != nil {
+					return err
+				}
+				cfnames[i] = s
+			}
+			r.Resources[i].ConfigNames = cfnames
 		}
 
-		cfnames := make([]string, confLength)
-		for i := 0; i < confLength; i++ {
-			s, err := pd.getString()
-			if err != nil {
-				return err
-			}
-			cfnames[i] = s
+		if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+			return err
 		}
-		r.Resources[i].ConfigNames = cfnames
 	}
 	r.Version = version
 	if r.Version >= 1 {
@@ -90,6 +101,18 @@ func (r *DescribeConfigsRequest) decode(pd packetDecoder, version int16) (err er
 			return err
 		}
 		r.IncludeSynonyms = b
+	}
+
+	if r.Version >= 3 {
+		b, err := pd.getBool()
+		if err != nil {
+			return err
+		}
+		r.IncludeDocumentation = b
+	}
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
 	}
 
 	return nil
@@ -104,15 +127,30 @@ func (r *DescribeConfigsRequest) version() int16 {
 }
 
 func (r *DescribeConfigsRequest) headerVersion() int16 {
+	if r.Version >= 4 {
+		return 2
+	}
 	return 1
 }
 
 func (r *DescribeConfigsRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 2
+	return r.Version >= 0 && r.Version <= 4
+}
+
+func (r *DescribeConfigsRequest) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *DescribeConfigsRequest) isFlexibleVersion(version int16) bool {
+	return version >= 4
 }
 
 func (r *DescribeConfigsRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 4:
+		return V2_8_0_0
+	case 3:
+		return V2_6_0_0
 	case 2:
 		return V2_0_0_0
 	case 1:

--- a/describe_configs_request_test.go
+++ b/describe_configs_request_test.go
@@ -48,6 +48,30 @@ var (
 		255, 255, 255, 255, // no configs
 		1, // synonyms
 	}
+
+	singleDescribeConfigsRequestv3 = []byte{
+		0, 0, 0, 1, // 1 config
+		2,                   // a topic
+		0, 3, 'f', 'o', 'o', // topic name: foo
+		0, 0, 0, 1, // 1 config name
+		0, 10, // 10 chars
+		's', 'e', 'g', 'm', 'e', 'n', 't', '.', 'm', 's',
+		1, // synonyms
+		1, // documentation
+	}
+
+	singleDescribeConfigsRequestv4 = []byte{
+		2,                // 1 config (compact array)
+		2,                // a topic
+		4, 'f', 'o', 'o', // topic name: foo (compact string)
+		2,  // 1 config name (compact array)
+		11, // 10 chars (compact string)
+		's', 'e', 'g', 'm', 'e', 'n', 't', '.', 'm', 's',
+		0, // resource tagged fields
+		1, // synonyms
+		1, // documentation
+		0, // request tagged fields
+	}
 )
 
 func TestDescribeConfigsRequestv0(t *testing.T) {
@@ -116,4 +140,38 @@ func TestDescribeConfigsRequestv1(t *testing.T) {
 	}
 
 	testRequest(t, "one topic, all configs", request, singleDescribeConfigsRequestAllConfigsv1)
+}
+
+func TestDescribeConfigsRequestv3(t *testing.T) {
+	request := &DescribeConfigsRequest{
+		Version: 3,
+		Resources: []*ConfigResource{
+			{
+				Type:        TopicResource,
+				Name:        "foo",
+				ConfigNames: []string{"segment.ms"},
+			},
+		},
+		IncludeSynonyms:      true,
+		IncludeDocumentation: true,
+	}
+
+	testRequest(t, "include synonyms and documentation", request, singleDescribeConfigsRequestv3)
+}
+
+func TestDescribeConfigsRequestv4(t *testing.T) {
+	request := &DescribeConfigsRequest{
+		Version: 4,
+		Resources: []*ConfigResource{
+			{
+				Type:        TopicResource,
+				Name:        "foo",
+				ConfigNames: []string{"segment.ms"},
+			},
+		},
+		IncludeSynonyms:      true,
+		IncludeDocumentation: true,
+	}
+
+	testRequest(t, "include synonyms and documentation", request, singleDescribeConfigsRequestv4)
 }

--- a/describe_configs_response.go
+++ b/describe_configs_response.go
@@ -34,6 +34,21 @@ const (
 	SourceDefault
 )
 
+type ConfigType int8
+
+const (
+	UnknownConfigType ConfigType = iota
+	BooleanConfigType
+	StringConfigType
+	IntConfigType
+	ShortConfigType
+	LongConfigType
+	DoubleConfigType
+	ListConfigType
+	ClassConfigType
+	PasswordConfigType
+)
+
 type DescribeConfigError struct {
 	Err    KError
 	ErrMsg string
@@ -70,13 +85,15 @@ type ResourceResponse struct {
 }
 
 type ConfigEntry struct {
-	Name      string
-	Value     string
-	ReadOnly  bool
-	Default   bool
-	Source    ConfigSource
-	Sensitive bool
-	Synonyms  []*ConfigSynonym
+	Name          string
+	Value         string
+	ReadOnly      bool
+	Default       bool
+	Source        ConfigSource
+	Sensitive     bool
+	Synonyms      []*ConfigSynonym
+	Type          ConfigType // v3
+	Documentation *string    // v3
 }
 
 type ConfigSynonym struct {
@@ -96,6 +113,8 @@ func (r *DescribeConfigsResponse) encode(pe packetEncoder) (err error) {
 			return err
 		}
 	}
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -120,6 +139,10 @@ func (r *DescribeConfigsResponse) decode(pd packetDecoder, version int16) (err e
 		r.Resources[i] = rr
 	}
 
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -132,15 +155,30 @@ func (r *DescribeConfigsResponse) version() int16 {
 }
 
 func (r *DescribeConfigsResponse) headerVersion() int16 {
+	if r.Version >= 4 {
+		return 1
+	}
 	return 0
 }
 
 func (r *DescribeConfigsResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 2
+	return r.Version >= 0 && r.Version <= 4
+}
+
+func (r *DescribeConfigsResponse) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *DescribeConfigsResponse) isFlexibleVersion(version int16) bool {
+	return version >= 4
 }
 
 func (r *DescribeConfigsResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 4:
+		return V2_8_0_0
+	case 3:
+		return V2_6_0_0
 	case 2:
 		return V2_0_0_0
 	case 1:
@@ -178,6 +216,9 @@ func (r *ResourceResponse) encode(pe packetEncoder, version int16) (err error) {
 			return err
 		}
 	}
+
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
@@ -219,6 +260,11 @@ func (r *ResourceResponse) decode(pd packetDecoder, version int16) (err error) {
 		}
 		r.Configs[i] = c
 	}
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -249,6 +295,15 @@ func (r *ConfigEntry) encode(pe packetEncoder, version int16) (err error) {
 			}
 		}
 	}
+
+	if version >= 3 {
+		pe.putInt8(int8(r.Type))
+		if err = pe.putNullableString(r.Documentation); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -315,6 +370,24 @@ func (r *ConfigEntry) decode(pd packetDecoder, version int16) (err error) {
 			r.Synonyms[i] = s
 		}
 	}
+
+	if version >= 3 {
+		configType, err := pd.getInt8()
+		if err != nil {
+			return err
+		}
+		r.Type = ConfigType(configType)
+
+		r.Documentation, err = pd.getNullableString()
+		if err != nil {
+			return err
+		}
+	}
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -330,6 +403,8 @@ func (c *ConfigSynonym) encode(pe packetEncoder, version int16) (err error) {
 	}
 
 	pe.putInt8(int8(c.Source))
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -352,5 +427,10 @@ func (c *ConfigSynonym) decode(pd packetDecoder, version int16) error {
 		return err
 	}
 	c.Source = ConfigSource(source)
+
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/describe_configs_response_test.go
+++ b/describe_configs_response_test.go
@@ -93,6 +93,53 @@ var (
 		0,          // Sensitive
 		0, 0, 0, 0, // No Synonym
 	}
+
+	describeConfigsResponseWithDocumentationv3 = []byte{
+		0, 0, 0, 0, // throttle
+		0, 0, 0, 1, // response
+		0, 0, // errorcode
+		0, 0, // string
+		2, // topic
+		0, 3, 'f', 'o', 'o',
+		0, 0, 0, 1, // configs
+		0, 10, 's', 'e', 'g', 'm', 'e', 'n', 't', '.', 'm', 's',
+		0, 4, '1', '0', '0', '0',
+		0,          // ReadOnly
+		4,          // Source
+		0,          // Sensitive
+		0, 0, 0, 1, // 1 Synonym
+		0, 14, 'l', 'o', 'g', '.', 's', 'e', 'g', 'm', 'e', 'n', 't', '.', 'm', 's',
+		0, 4, '1', '0', '0', '0',
+		4,                                            // Source
+		3,                                            // ConfigType: INT
+		0, 8, 't', 'h', 'e', ' ', 'd', 'o', 'c', 's', // Documentation
+	}
+
+	describeConfigsResponseWithDocumentationv4 = []byte{
+		0, 0, 0, 0, // throttle
+		2,    // 1 response (compact array)
+		0, 0, // errorcode
+		1,                // empty error message (compact string)
+		2,                // topic
+		4, 'f', 'o', 'o', // resource name (compact string)
+		2,  // 1 config (compact array)
+		11, // segment.ms (compact string)
+		's', 'e', 'g', 'm', 'e', 'n', 't', '.', 'm', 's',
+		5, '1', '0', '0', '0', // value (compact string)
+		0,                                                                        // ReadOnly
+		4,                                                                        // Source
+		0,                                                                        // Sensitive
+		2,                                                                        // 1 Synonym (compact array)
+		15, 'l', 'o', 'g', '.', 's', 'e', 'g', 'm', 'e', 'n', 't', '.', 'm', 's', // synonym name (compact string)
+		5, '1', '0', '0', '0', // synonym value (compact string)
+		4,                                         // Source
+		0,                                         // synonym tagged fields
+		3,                                         // ConfigType: INT
+		9, 't', 'h', 'e', ' ', 'd', 'o', 'c', 's', // Documentation (compact string)
+		0, // config tagged fields
+		0, // resource tagged fields
+		0, // response tagged fields
+	}
 )
 
 func TestDescribeConfigsResponsev0(t *testing.T) {
@@ -275,6 +322,84 @@ func TestDescribeConfigsResponseWithDefaultv1(t *testing.T) {
 		},
 	}
 	testResponse(t, "response with error", response, describeConfigsResponseWithDefaultv1)
+}
+
+func TestDescribeConfigsResponseWithDocumentationv3(t *testing.T) {
+	var response *DescribeConfigsResponse
+
+	response = &DescribeConfigsResponse{
+		Resources: []*ResourceResponse{},
+	}
+	testVersionDecodable(t, "empty", response, describeConfigsResponseEmpty, 3)
+	if len(response.Resources) != 0 {
+		t.Error("Expected no groups")
+	}
+
+	response = &DescribeConfigsResponse{
+		Version: 3,
+		Resources: []*ResourceResponse{
+			{
+				ErrorCode: 0,
+				ErrorMsg:  "",
+				Type:      TopicResource,
+				Name:      "foo",
+				Configs: []*ConfigEntry{
+					{
+						Name:      "segment.ms",
+						Value:     "1000",
+						ReadOnly:  false,
+						Source:    SourceStaticBroker,
+						Default:   false,
+						Sensitive: false,
+						Synonyms: []*ConfigSynonym{
+							{
+								ConfigName:  "log.segment.ms",
+								ConfigValue: "1000",
+								Source:      SourceStaticBroker,
+							},
+						},
+						Type:          IntConfigType,
+						Documentation: nullString("the docs"),
+					},
+				},
+			},
+		},
+	}
+	testResponse(t, "response with documentation", response, describeConfigsResponseWithDocumentationv3)
+}
+
+func TestDescribeConfigsResponseWithDocumentationv4(t *testing.T) {
+	response := &DescribeConfigsResponse{
+		Version: 4,
+		Resources: []*ResourceResponse{
+			{
+				ErrorCode: 0,
+				ErrorMsg:  "",
+				Type:      TopicResource,
+				Name:      "foo",
+				Configs: []*ConfigEntry{
+					{
+						Name:      "segment.ms",
+						Value:     "1000",
+						ReadOnly:  false,
+						Source:    SourceStaticBroker,
+						Default:   false,
+						Sensitive: false,
+						Synonyms: []*ConfigSynonym{
+							{
+								ConfigName:  "log.segment.ms",
+								ConfigValue: "1000",
+								Source:      SourceStaticBroker,
+							},
+						},
+						Type:          IntConfigType,
+						Documentation: nullString("the docs"),
+					},
+				},
+			},
+		},
+	}
+	testResponse(t, "response with documentation", response, describeConfigsResponseWithDocumentationv4)
 }
 
 func TestDescribeConfigError(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -391,8 +391,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDescribeClientQuotas: 0, // new in 2.6
 				apiKeyAlterClientQuotas:    0, // new in 2.6
 				apiKeyDeleteRecords:        2, // up from 1
-				// TODO: DescribeConfigsRequest v3 is not supported, but expected for KafkaVersion 2.6.0
-				// apiKeyDescribeConfigs:   3, // up from 2
+				apiKeyDescribeConfigs:      3, // up from 2
 			},
 		},
 		{
@@ -420,6 +419,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyMetadata:             10, // up from 9
 				apiKeyDescribeClientQuotas: 1,  // up from 0
 				apiKeyDescribeCluster:      0,  // new in 2.8
+				apiKeyDescribeConfigs:      4,  // up from 3
 				// TODO: ProduceRequest v9 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyProduce:              9, // up from 8
 				// TODO: ListOffsetsRequest v6 is not supported, but expected for KafkaVersion 2.8.0


### PR DESCRIPTION
v3 (KIP-569) adds the IncludeDocumentation field to the request and ConfigType plus Documentation to each config entry on the response, from Kafka 2.6.0.

v4 makes the API flexible (compact types and tagged fields), from Kafka 2.8.0.

Note: this is protocol only for now, not yet exposing the extra fields in admin.go, that’ll come in a follow up PR