### PR TITLE
fix: handle errors gracefully instead of panicking in async producer

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -988,17 +988,11 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 			if err != nil {
 				// Count the in flight requests to know when we can close the pending channel safely
 				wg.Add(1)
-				// capture the muted set. unmuting is deferred to handleResponse.
-				mutedSet := set
-				sendResponse := func(response *ProduceResponse, err error) {
-					pending <- &brokerProducerResponse{
-						set: mutedSet,
-						err: err,
-						res: response,
-					}
-					wg.Done()
+				pending <- &brokerProducerResponse{
+					set: set,
+					err: err,
 				}
-				sendResponse(nil, err)
+				wg.Done()
 				continue
 			}
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -986,13 +986,10 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 		for set := range bridge {
 			request, err := set.buildRequest()
 			if err != nil {
-				// Count the in flight requests to know when we can close the pending channel safely
-				wg.Add(1)
 				pending <- &brokerProducerResponse{
 					set: set,
 					err: err,
 				}
-				wg.Done()
 				continue
 			}
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -984,7 +984,23 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 		var wg sync.WaitGroup
 
 		for set := range bridge {
-			request := set.buildRequest()
+			request, err := set.buildRequest()
+			if err != nil {
+				// Count the in flight requests to know when we can close the pending channel safely
+				wg.Add(1)
+				// capture the muted set. unmuting is deferred to handleResponse.
+				mutedSet := set
+				sendResponse := func(response *ProduceResponse, err error) {
+					pending <- &brokerProducerResponse{
+						set: mutedSet,
+						err: err,
+						res: response,
+					}
+					wg.Done()
+				}
+				sendResponse(nil, err)
+				continue
+			}
 
 			// Count the in flight requests to know when we can close the pending channel safely
 			wg.Add(1)
@@ -1013,7 +1029,7 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 			// Use AsyncProduce vs Produce to not block waiting for the response
 			// so that we can pipeline multiple produce requests and achieve higher throughput, see:
 			// https://kafka.apache.org/protocol#protocol_network
-			err := broker.AsyncProduce(request, sendResponse)
+			err = broker.AsyncProduce(request, sendResponse)
 			if err != nil {
 				// Request failed to be sent
 				sendResponse(nil, err)

--- a/produce_set.go
+++ b/produce_set.go
@@ -177,7 +177,7 @@ func (ps *produceSet) copyFunc(predicate func(topic string, partition int32) boo
 	return out
 }
 
-func (ps *produceSet) buildRequest() *ProduceRequest {
+func (ps *produceSet) buildRequest() (*ProduceRequest, error) {
 	req := &ProduceRequest{
 		RequiredAcks: ps.parent.conf.Producer.RequiredAcks,
 		Timeout:      int32(ps.parent.conf.Producer.Timeout / time.Millisecond),
@@ -245,15 +245,14 @@ func (ps *produceSet) buildRequest() *ProduceRequest {
 					// to the inner messages. This lets the broker avoid
 					// recompressing the message set.
 					// (See https://cwiki.apache.org/confluence/display/KAFKA/KIP-31+-+Move+to+relative+offsets+in+compressed+message+sets
-					// for details on relative offsets.)
+					//  for details on relative offsets.)
 					for i, msg := range set.recordsToSend.MsgSet.Messages {
 						msg.Offset = int64(i)
 					}
 				}
 				payload, err := encode(set.recordsToSend.MsgSet, ps.parent.metricsRegistry)
 				if err != nil {
-					Logger.Println(err) // if this happens, it's basically our fault.
-					panic(err)
+					return nil, PacketEncodingError{err.Error()}
 				}
 				compMsg := &Message{
 					Codec:            ps.parent.conf.Producer.Compression,
@@ -271,7 +270,7 @@ func (ps *produceSet) buildRequest() *ProduceRequest {
 		}
 	}
 
-	return req
+	return req, nil
 }
 
 func (ps *produceSet) eachPartition(cb func(topic string, partition int32, pSet *partitionSet)) {

--- a/produce_set_test.go
+++ b/produce_set_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func makeProduceSet() (*asyncProducer, *produceSet) {
@@ -158,7 +160,8 @@ func TestProduceSetRequestBuilding(t *testing.T) {
 		safeAddMessage(t, ps, msg)
 	}
 
-	req, _ := ps.buildRequest()
+	req, err := ps.buildRequest()
+	require.NoError(t, err)
 
 	if req.RequiredAcks != WaitForAll {
 		t.Error("RequiredAcks not set properly")
@@ -191,7 +194,8 @@ func TestProduceSetCompressedRequestBuilding(t *testing.T) {
 		safeAddMessage(t, ps, msg)
 	}
 
-	req, _ := ps.buildRequest()
+	req, err := ps.buildRequest()
+	require.NoError(t, err)
 
 	if req.Version != 2 {
 		t.Error("Wrong request version")
@@ -251,7 +255,8 @@ func TestProduceSetV3RequestBuilding(t *testing.T) {
 		msg.Timestamp = msg.Timestamp.Add(time.Second)
 	}
 
-	req, _ := ps.buildRequest()
+	req, err := ps.buildRequest()
+	require.NoError(t, err)
 
 	if req.Version != 3 {
 		t.Error("Wrong request version")
@@ -333,7 +338,8 @@ func TestProduceSetIdempotentRequestBuilding(t *testing.T) {
 		msg.Timestamp = msg.Timestamp.Add(time.Second)
 	}
 
-	req, _ := ps.buildRequest()
+	req, err := ps.buildRequest()
+	require.NoError(t, err)
 
 	if req.Version != 3 {
 		t.Error("Wrong request version")
@@ -409,7 +415,8 @@ func TestProduceSetConsistentTimestamps(t *testing.T) {
 
 	safeAddMessage(t, ps1, msg1)
 	safeAddMessage(t, ps1, msg3)
-	req1, _ := ps1.buildRequest()
+	req1, err := ps1.buildRequest()
+	require.NoError(t, err)
 	if req1.Version != 3 {
 		t.Error("Wrong request version")
 	}
@@ -419,7 +426,8 @@ func TestProduceSetConsistentTimestamps(t *testing.T) {
 
 	safeAddMessage(t, ps2, msg2)
 	safeAddMessage(t, ps2, msg3)
-	req2, _ := ps2.buildRequest()
+	req2, err := ps2.buildRequest()
+	require.NoError(t, err)
 	if req2.Version != 3 {
 		t.Error("Wrong request version")
 	}

--- a/produce_set_test.go
+++ b/produce_set_test.go
@@ -158,7 +158,7 @@ func TestProduceSetRequestBuilding(t *testing.T) {
 		safeAddMessage(t, ps, msg)
 	}
 
-	req := ps.buildRequest()
+	req, _ := ps.buildRequest()
 
 	if req.RequiredAcks != WaitForAll {
 		t.Error("RequiredAcks not set properly")
@@ -191,7 +191,7 @@ func TestProduceSetCompressedRequestBuilding(t *testing.T) {
 		safeAddMessage(t, ps, msg)
 	}
 
-	req := ps.buildRequest()
+	req, _ := ps.buildRequest()
 
 	if req.Version != 2 {
 		t.Error("Wrong request version")
@@ -251,7 +251,7 @@ func TestProduceSetV3RequestBuilding(t *testing.T) {
 		msg.Timestamp = msg.Timestamp.Add(time.Second)
 	}
 
-	req := ps.buildRequest()
+	req, _ := ps.buildRequest()
 
 	if req.Version != 3 {
 		t.Error("Wrong request version")
@@ -333,7 +333,7 @@ func TestProduceSetIdempotentRequestBuilding(t *testing.T) {
 		msg.Timestamp = msg.Timestamp.Add(time.Second)
 	}
 
-	req := ps.buildRequest()
+	req, _ := ps.buildRequest()
 
 	if req.Version != 3 {
 		t.Error("Wrong request version")
@@ -409,7 +409,7 @@ func TestProduceSetConsistentTimestamps(t *testing.T) {
 
 	safeAddMessage(t, ps1, msg1)
 	safeAddMessage(t, ps1, msg3)
-	req1 := ps1.buildRequest()
+	req1, _ := ps1.buildRequest()
 	if req1.Version != 3 {
 		t.Error("Wrong request version")
 	}
@@ -419,7 +419,7 @@ func TestProduceSetConsistentTimestamps(t *testing.T) {
 
 	safeAddMessage(t, ps2, msg2)
 	safeAddMessage(t, ps2, msg3)
-	req2 := ps2.buildRequest()
+	req2, _ := ps2.buildRequest()
 	if req2.Version != 3 {
 		t.Error("Wrong request version")
 	}


### PR DESCRIPTION
This PR replaces a panic in produce_set.go with a proper error return when message set encoding fails during produce request building