### PR TITLE
feat(admin): add DescribeConfigs for multiple resources

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -64,7 +64,22 @@ type ClusterAdmin interface {
 	// The value of config entries where Sensitive is true is always nil so
 	// sensitive information is not disclosed.
 	// This operation is supported by brokers with version 0.11.0.0 or higher.
+	//
+	// Deprecated: use DescribeConfigs, which describes multiple resources in a
+	// single call, returns per-resource errors, and accepts options to request
+	// synonyms and documentation.
 	DescribeConfig(resource ConfigResource) ([]ConfigEntry, error)
+
+	// Get the configuration for the specified resources.
+	// The returned configuration includes default values and the Default is true
+	// can be used to distinguish them from user supplied values.
+	// Config entries where ReadOnly is true cannot be updated.
+	// The value of config entries where Sensitive is true is always nil so
+	// sensitive information is not disclosed.
+	// Use the options to request the synonyms (Kafka 1.1.0+) or the type and
+	// documentation (Kafka 2.6.0+) for each config entry.
+	// This operation is supported by brokers with version 0.11.0.0 or higher.
+	DescribeConfigs(resources []ConfigResource, options DescribeConfigsOptions) ([]ConfigResourceResult, error)
 
 	// Update the configuration for the specified resources with the default options.
 	// This operation is supported by brokers with version 0.11.0.0 or higher.
@@ -526,12 +541,14 @@ func (ca *clusterAdmin) ListTopics() (map[string]TopicDetail, error) {
 			Resources: describeConfigsResources,
 		}
 
-		if ca.conf.Version.IsAtLeast(V1_1_0_0) {
-			describeConfigsReq.Version = 1
-		}
-
-		if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+		if ca.conf.Version.IsAtLeast(V2_8_0_0) {
+			describeConfigsReq.Version = 4
+		} else if ca.conf.Version.IsAtLeast(V2_6_0_0) {
+			describeConfigsReq.Version = 3
+		} else if ca.conf.Version.IsAtLeast(V2_0_0_0) {
 			describeConfigsReq.Version = 2
+		} else if ca.conf.Version.IsAtLeast(V1_1_0_0) {
+			describeConfigsReq.Version = 1
 		}
 
 		describeConfigsResp, err := b.DescribeConfigs(describeConfigsReq)
@@ -815,60 +832,130 @@ func dependsOnSpecificNode(resource ConfigResource) bool {
 		resource.Type == BrokerLoggerResource
 }
 
+// DescribeConfigsOptions holds the optional flags for DescribeConfigs.
+type DescribeConfigsOptions struct {
+	// IncludeSynonyms requests the synonyms for each config entry (Kafka 1.1.0+).
+	IncludeSynonyms bool
+	// IncludeDocumentation requests the type and documentation for each config
+	// entry (Kafka 2.6.0+).
+	IncludeDocumentation bool
+}
+
+// ConfigResourceResult is the described configuration for a single resource.
+type ConfigResourceResult struct {
+	Type      ConfigResourceType
+	Name      string
+	ErrorCode KError
+	ErrorMsg  string
+	Configs   []ConfigEntry
+}
+
+// Deprecated: use DescribeConfigs.
 func (ca *clusterAdmin) DescribeConfig(resource ConfigResource) ([]ConfigEntry, error) {
+	results, err := ca.DescribeConfigs([]ConfigResource{resource}, DescribeConfigsOptions{})
+	if err != nil {
+		return nil, err
+	}
+
 	var entries []ConfigEntry
-	var resources []*ConfigResource
-	resources = append(resources, &resource)
+	for _, result := range results {
+		if result.Name != resource.Name {
+			continue
+		}
+		if result.ErrorCode != 0 {
+			return nil, &DescribeConfigError{Err: result.ErrorCode, ErrMsg: result.ErrorMsg}
+		}
+		entries = append(entries, result.Configs...)
+	}
+	return entries, nil
+}
 
-	request := &DescribeConfigsRequest{
-		Resources: resources,
+func (ca *clusterAdmin) DescribeConfigs(resources []ConfigResource, options DescribeConfigsOptions) ([]ConfigResourceResult, error) {
+	if len(resources) == 0 {
+		return nil, nil
 	}
 
-	if ca.conf.Version.IsAtLeast(V1_1_0_0) {
-		request.Version = 1
+	// broker and broker-logger configs must be described on the specific node;
+	// everything else can be served by any broker, so group the resources by the
+	// broker that must handle them and send one request per broker
+	groups := make(map[*Broker][]*ConfigResource)
+	var anyBroker *Broker
+	for i := range resources {
+		resource := &resources[i]
+		var b *Broker
+		if dependsOnSpecificNode(*resource) {
+			id, err := strconv.ParseInt(resource.Name, 10, 32)
+			if err != nil {
+				return nil, err
+			}
+			b, err = ca.findBroker(int32(id))
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			if anyBroker == nil {
+				broker, err := ca.findAnyBroker()
+				if err != nil {
+					return nil, err
+				}
+				anyBroker = broker
+			}
+			b = anyBroker
+		}
+		groups[b] = append(groups[b], resource)
 	}
 
-	if ca.conf.Version.IsAtLeast(V2_0_0_0) {
-		request.Version = 2
+	type resourceKey struct {
+		Type ConfigResourceType
+		Name string
 	}
+	resultByKey := make(map[resourceKey]ConfigResourceResult)
+	for b, grouped := range groups {
+		request := &DescribeConfigsRequest{
+			Resources:            grouped,
+			IncludeSynonyms:      options.IncludeSynonyms,
+			IncludeDocumentation: options.IncludeDocumentation,
+		}
 
-	var (
-		b   *Broker
-		err error
-	)
+		if ca.conf.Version.IsAtLeast(V2_8_0_0) {
+			request.Version = 4
+		} else if ca.conf.Version.IsAtLeast(V2_6_0_0) {
+			request.Version = 3
+		} else if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+			request.Version = 2
+		} else if ca.conf.Version.IsAtLeast(V1_1_0_0) {
+			request.Version = 1
+		}
 
-	// DescribeConfig of broker/broker logger must be sent to the broker in question
-	if dependsOnSpecificNode(resource) {
-		var id int64
-		id, err = strconv.ParseInt(resource.Name, 10, 32)
+		_ = b.Open(ca.client.Config())
+		rsp, err := b.DescribeConfigs(request)
 		if err != nil {
 			return nil, err
 		}
-		b, err = ca.findBroker(int32(id))
-	} else {
-		b, err = ca.findAnyBroker()
-	}
-	if err != nil {
-		return nil, err
-	}
 
-	_ = b.Open(ca.client.Config())
-	rsp, err := b.DescribeConfigs(request)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, rspResource := range rsp.Resources {
-		if rspResource.Name == resource.Name {
-			if rspResource.ErrorCode != 0 {
-				return nil, &DescribeConfigError{Err: KError(rspResource.ErrorCode), ErrMsg: rspResource.ErrorMsg}
+		for _, rspResource := range rsp.Resources {
+			result := ConfigResourceResult{
+				Type:      rspResource.Type,
+				Name:      rspResource.Name,
+				ErrorCode: KError(rspResource.ErrorCode),
+				ErrorMsg:  rspResource.ErrorMsg,
 			}
 			for _, cfgEntry := range rspResource.Configs {
-				entries = append(entries, *cfgEntry)
+				result.Configs = append(result.Configs, *cfgEntry)
 			}
+			resultByKey[resourceKey{rspResource.Type, rspResource.Name}] = result
 		}
 	}
-	return entries, nil
+
+	// return the results in the order the resources were requested
+	results := make([]ConfigResourceResult, 0, len(resources))
+	for i := range resources {
+		key := resourceKey{resources[i].Type, resources[i].Name}
+		if result, ok := resultByKey[key]; ok {
+			results = append(results, result)
+		}
+	}
+	return results, nil
 }
 
 func (ca *clusterAdmin) AlterConfig(resourceType ConfigResourceType, name string, entries map[string]*string, validateOnly bool) error {

--- a/admin.go
+++ b/admin.go
@@ -79,7 +79,7 @@ type ClusterAdmin interface {
 	// Use the options to request the synonyms (Kafka 1.1.0+) or the type and
 	// documentation (Kafka 2.6.0+) for each config entry.
 	// This operation is supported by brokers with version 0.11.0.0 or higher.
-	DescribeConfigs(resources []ConfigResource, options DescribeConfigsOptions) ([]ConfigResourceResult, error)
+	DescribeConfigs(resources []*ConfigResource, options DescribeConfigsOptions) ([]*ConfigResourceResult, error)
 
 	// Update the configuration for the specified resources with the default options.
 	// This operation is supported by brokers with version 0.11.0.0 or higher.
@@ -827,7 +827,7 @@ func (ca *clusterAdmin) DeleteRecords(topic string, partitionOffsets map[int32]i
 
 // Returns a bool indicating whether the resource request needs to go to a
 // specific broker
-func dependsOnSpecificNode(resource ConfigResource) bool {
+func dependsOnSpecificNode(resource *ConfigResource) bool {
 	return (resource.Type == BrokerResource && resource.Name != "") ||
 		resource.Type == BrokerLoggerResource
 }
@@ -852,12 +852,12 @@ type ConfigResourceResult struct {
 
 // Deprecated: use DescribeConfigs.
 func (ca *clusterAdmin) DescribeConfig(resource ConfigResource) ([]ConfigEntry, error) {
-	results, err := ca.DescribeConfigs([]ConfigResource{resource}, DescribeConfigsOptions{})
+	results, err := ca.DescribeConfigs([]*ConfigResource{&resource}, DescribeConfigsOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	var entries []ConfigEntry
+	entries := make([]ConfigEntry, 0, len(results))
 	for _, result := range results {
 		if result.Name != resource.Name {
 			continue
@@ -870,7 +870,7 @@ func (ca *clusterAdmin) DescribeConfig(resource ConfigResource) ([]ConfigEntry, 
 	return entries, nil
 }
 
-func (ca *clusterAdmin) DescribeConfigs(resources []ConfigResource, options DescribeConfigsOptions) ([]ConfigResourceResult, error) {
+func (ca *clusterAdmin) DescribeConfigs(resources []*ConfigResource, options DescribeConfigsOptions) ([]*ConfigResourceResult, error) {
 	if len(resources) == 0 {
 		return nil, nil
 	}
@@ -880,10 +880,10 @@ func (ca *clusterAdmin) DescribeConfigs(resources []ConfigResource, options Desc
 	// broker that must handle them and send one request per broker
 	groups := make(map[*Broker][]*ConfigResource)
 	var anyBroker *Broker
-	for i := range resources {
-		resource := &resources[i]
+	for _, resource := range resources {
 		var b *Broker
-		if dependsOnSpecificNode(*resource) {
+		switch {
+		case dependsOnSpecificNode(resource):
 			id, err := strconv.ParseInt(resource.Name, 10, 32)
 			if err != nil {
 				return nil, err
@@ -892,14 +892,14 @@ func (ca *clusterAdmin) DescribeConfigs(resources []ConfigResource, options Desc
 			if err != nil {
 				return nil, err
 			}
-		} else {
-			if anyBroker == nil {
-				broker, err := ca.findAnyBroker()
-				if err != nil {
-					return nil, err
-				}
-				anyBroker = broker
+		case anyBroker == nil:
+			broker, err := ca.findAnyBroker()
+			if err != nil {
+				return nil, err
 			}
+			anyBroker = broker
+			fallthrough
+		default:
 			b = anyBroker
 		}
 		groups[b] = append(groups[b], resource)
@@ -909,10 +909,10 @@ func (ca *clusterAdmin) DescribeConfigs(resources []ConfigResource, options Desc
 		Type ConfigResourceType
 		Name string
 	}
-	resultByKey := make(map[resourceKey]ConfigResourceResult)
-	for b, grouped := range groups {
+	resultByKey := make(map[resourceKey]*ConfigResourceResult)
+	for b, group := range groups {
 		request := &DescribeConfigsRequest{
-			Resources:            grouped,
+			Resources:            group,
 			IncludeSynonyms:      options.IncludeSynonyms,
 			IncludeDocumentation: options.IncludeDocumentation,
 		}
@@ -933,24 +933,24 @@ func (ca *clusterAdmin) DescribeConfigs(resources []ConfigResource, options Desc
 			return nil, err
 		}
 
-		for _, rspResource := range rsp.Resources {
-			result := ConfigResourceResult{
-				Type:      rspResource.Type,
-				Name:      rspResource.Name,
-				ErrorCode: KError(rspResource.ErrorCode),
-				ErrorMsg:  rspResource.ErrorMsg,
+		for _, resource := range rsp.Resources {
+			result := &ConfigResourceResult{
+				Type:      resource.Type,
+				Name:      resource.Name,
+				ErrorCode: KError(resource.ErrorCode),
+				ErrorMsg:  resource.ErrorMsg,
 			}
-			for _, cfgEntry := range rspResource.Configs {
-				result.Configs = append(result.Configs, *cfgEntry)
+			for _, config := range resource.Configs {
+				result.Configs = append(result.Configs, *config)
 			}
-			resultByKey[resourceKey{rspResource.Type, rspResource.Name}] = result
+			resultByKey[resourceKey{resource.Type, resource.Name}] = result
 		}
 	}
 
 	// return the results in the order the resources were requested
-	results := make([]ConfigResourceResult, 0, len(resources))
-	for i := range resources {
-		key := resourceKey{resources[i].Type, resources[i].Name}
+	results := make([]*ConfigResourceResult, 0, len(resources))
+	for _, resource := range resources {
+		key := resourceKey{resource.Type, resource.Name}
 		if result, ok := resultByKey[key]; ok {
 			results = append(results, result)
 		}
@@ -980,7 +980,7 @@ func (ca *clusterAdmin) AlterConfig(resourceType ConfigResourceType, name string
 	)
 
 	// AlterConfig of broker/broker logger must be sent to the broker in question
-	if dependsOnSpecificNode(ConfigResource{Name: name, Type: resourceType}) {
+	if dependsOnSpecificNode(&ConfigResource{Name: name, Type: resourceType}) {
 		var id int64
 		id, err = strconv.ParseInt(name, 10, 32)
 		if err != nil {
@@ -1033,7 +1033,7 @@ func (ca *clusterAdmin) IncrementalAlterConfig(resourceType ConfigResourceType, 
 	)
 
 	// AlterConfig of broker/broker logger must be sent to the broker in question
-	if dependsOnSpecificNode(ConfigResource{Name: name, Type: resourceType}) {
+	if dependsOnSpecificNode(&ConfigResource{Name: name, Type: resourceType}) {
 		var id int64
 		id, err = strconv.ParseInt(name, 10, 32)
 		if err != nil {

--- a/admin_test.go
+++ b/admin_test.go
@@ -961,7 +961,7 @@ func TestClusterAdminDescribeConfigs(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = admin.Close() }()
 
-	resources := []ConfigResource{
+	resources := []*ConfigResource{
 		{Name: "r1", Type: TopicResource, ConfigNames: []string{"my_topic"}},
 		{Name: "r2", Type: TopicResource, ConfigNames: []string{"my_topic"}},
 	}

--- a/admin_test.go
+++ b/admin_test.go
@@ -894,6 +894,8 @@ func TestClusterAdminDescribeConfig(t *testing.T) {
 		{V1_1_0_0, 1, true},
 		{V1_1_1_0, 1, true},
 		{V2_0_0_0, 2, true},
+		{V2_6_0_0, 3, true},
+		{V2_8_0_0, 4, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.saramaVersion.String(), func(t *testing.T) {
@@ -940,6 +942,50 @@ func TestClusterAdminDescribeConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClusterAdminDescribeConfigs(t *testing.T) {
+	seedBroker := NewMockBroker(t, 1)
+	defer seedBroker.Close()
+
+	seedBroker.SetHandlerByMap(map[string]MockResponse{
+		"MetadataRequest": NewMockMetadataResponse(t).
+			SetController(seedBroker.BrokerID()).
+			SetBroker(seedBroker.Addr(), seedBroker.BrokerID()),
+		"DescribeConfigsRequest": NewMockDescribeConfigsResponse(t),
+	})
+
+	config := NewTestConfig()
+	config.Version = V2_8_0_0
+	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
+	require.NoError(t, err)
+	defer func() { _ = admin.Close() }()
+
+	resources := []ConfigResource{
+		{Name: "r1", Type: TopicResource, ConfigNames: []string{"my_topic"}},
+		{Name: "r2", Type: TopicResource, ConfigNames: []string{"my_topic"}},
+	}
+
+	results, err := admin.DescribeConfigs(resources, DescribeConfigsOptions{
+		IncludeSynonyms:      true,
+		IncludeDocumentation: true,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "r1", results[0].Name)
+	assert.Equal(t, "r2", results[1].Name)
+	for _, result := range results {
+		assert.Equal(t, ErrNoError, result.ErrorCode)
+		assert.NotEmpty(t, result.Configs)
+	}
+
+	history := seedBroker.History()
+	describeReq, ok := history[len(history)-1].Request.(*DescribeConfigsRequest)
+	require.True(t, ok, "failed to find DescribeConfigsRequest in mockBroker history")
+	assert.Equal(t, int16(4), describeReq.Version)
+	assert.True(t, describeReq.IncludeSynonyms)
+	assert.True(t, describeReq.IncludeDocumentation)
+	assert.Len(t, describeReq.Resources, 2)
 }
 
 func TestClusterAdminDescribeConfigWithErrorCode(t *testing.T) {

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -691,6 +691,64 @@ func TestFuncAdminDescribeLogDirs(t *testing.T) {
 	}
 }
 
+func TestFuncAdminDescribeConfig(t *testing.T) {
+	t.Parallel()
+	checkKafkaVersion(t, "0.11.0.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	kafkaVersion, err := ParseKafkaVersion(FunctionalTestEnv.KafkaVersion)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := NewFunctionalTestConfig()
+	adminClient, err := NewClusterAdmin(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer safeClose(t, adminClient)
+
+	// describe all broker configs (nil ConfigNames) to exercise the null
+	// compact-array path on the v4 flexible wire format
+	results, err := adminClient.DescribeConfigs(
+		[]ConfigResource{{Type: BrokerResource, Name: "1"}},
+		DescribeConfigsOptions{},
+	)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, ErrNoError, results[0].ErrorCode)
+	require.NotEmpty(t, results[0].Configs)
+
+	for _, entry := range results[0].Configs {
+		assert.NotEmpty(t, entry.Name)
+	}
+
+	// IncludeDocumentation, ConfigType and Documentation are available from v3
+	// (Kafka 2.6.0); request them via the DescribeConfigs options
+	if kafkaVersion.IsAtLeast(V2_6_0_0) {
+		documented, err := adminClient.DescribeConfigs(
+			[]ConfigResource{{Type: BrokerResource, Name: "1"}},
+			DescribeConfigsOptions{IncludeSynonyms: true, IncludeDocumentation: true},
+		)
+		require.NoError(t, err)
+		require.Len(t, documented, 1)
+		require.NotEmpty(t, documented[0].Configs)
+
+		var typed, hasDoc bool
+		for _, entry := range documented[0].Configs {
+			if entry.Type != UnknownConfigType {
+				typed = true
+			}
+			if entry.Documentation != nil && *entry.Documentation != "" {
+				hasDoc = true
+			}
+		}
+		assert.True(t, typed, "expected at least one config with a known ConfigType")
+		assert.True(t, hasDoc, "expected at least one config with Documentation")
+	}
+}
+
 func TestFuncAdminDeleteGroup(t *testing.T) {
 	t.Parallel()
 	checkKafkaVersion(t, "2.4.0")

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -712,7 +712,7 @@ func TestFuncAdminDescribeConfig(t *testing.T) {
 	// describe all broker configs (nil ConfigNames) to exercise the null
 	// compact-array path on the v4 flexible wire format
 	results, err := adminClient.DescribeConfigs(
-		[]ConfigResource{{Type: BrokerResource, Name: "1"}},
+		[]*ConfigResource{{Type: BrokerResource, Name: "1"}},
 		DescribeConfigsOptions{},
 	)
 	require.NoError(t, err)
@@ -728,7 +728,7 @@ func TestFuncAdminDescribeConfig(t *testing.T) {
 	// (Kafka 2.6.0); request them via the DescribeConfigs options
 	if kafkaVersion.IsAtLeast(V2_6_0_0) {
 		documented, err := adminClient.DescribeConfigs(
-			[]ConfigResource{{Type: BrokerResource, Name: "1"}},
+			[]*ConfigResource{{Type: BrokerResource, Name: "1"}},
 			DescribeConfigsOptions{IncludeSynonyms: true, IncludeDocumentation: true},
 		)
 		require.NoError(t, err)

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -868,6 +868,7 @@ func (mr *MockDescribeConfigsResponse) For(reqBody versionedDecoder) encoderWith
 			)
 			res.Resources = append(res.Resources, &ResourceResponse{
 				Name:    r.Name,
+				Type:    r.Type,
 				Configs: configEntries,
 			})
 		case BrokerLoggerResource:
@@ -881,6 +882,7 @@ func (mr *MockDescribeConfigsResponse) For(reqBody versionedDecoder) encoderWith
 			)
 			res.Resources = append(res.Resources, &ResourceResponse{
 				Name:    r.Name,
+				Type:    r.Type,
 				Configs: configEntries,
 			})
 		case TopicResource:
@@ -928,6 +930,7 @@ func (mr *MockDescribeConfigsResponse) For(reqBody versionedDecoder) encoderWith
 				configEntries, maxMessageBytes, retentionMs, password)
 			res.Resources = append(res.Resources, &ResourceResponse{
 				Name:    r.Name,
+				Type:    r.Type,
 				Configs: configEntries,
 			})
 		}


### PR DESCRIPTION
Add DescribeConfigs, which describes several resources in one call, returns per-resource errors, and takes options to request synonyms (Kafka 1.1.0+) and documentation (Kafka 2.6.0+). Resources are grouped by the broker that must serve them, so broker and broker-logger configs still reach the right node.

Negotiate DescribeConfigs v3 and v4 from the configured version, and deprecate the singular DescribeConfig in favour of the new method.