### PR TITLE
feat(consumer): option to cap decompressed batch size

### DIFF
--- a/decompress.go
+++ b/decompress.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"sync"
 
 	"github.com/klauspost/compress/gzip"
@@ -45,25 +46,24 @@ func newDecompressedBatchTooLargeError(cc CompressionCodec, limit int) error {
 // fully inflates. A non-positive limit disables the cap.
 func boundedDecompress(cc CompressionCodec, reader io.Reader, limit int) ([]byte, error) {
 	buffer := bufferPool.Get().(*bytes.Buffer)
-	var src io.Reader = reader
+	defer func() {
+		buffer.Reset()
+		bufferPool.Put(buffer)
+	}()
+
+	src := reader
 	if limit > 0 {
 		src = io.LimitReader(reader, int64(limit)+1)
 	}
+
 	n, err := buffer.ReadFrom(src)
-
-	var res []byte
-	switch {
-	case err != nil:
-	case limit > 0 && n > int64(limit):
-		err = newDecompressedBatchTooLargeError(cc, limit)
-	default:
-		res = make([]byte, buffer.Len())
-		copy(res, buffer.Bytes())
+	if err != nil {
+		return nil, err
 	}
-
-	buffer.Reset()
-	bufferPool.Put(buffer)
-	return res, err
+	if limit > 0 && n > int64(limit) {
+		return nil, newDecompressedBatchTooLargeError(cc, limit)
+	}
+	return slices.Clone(buffer.Bytes()), nil
 }
 
 // boundedSnappyDecode decodes xerial/snappy into a capped buffer grown on
@@ -77,11 +77,12 @@ func boundedSnappyDecode(cc CompressionCodec, data []byte, limit int) ([]byte, e
 
 	bufp := bytesPool.Get().(*[]byte)
 	buf := *bufp
+	defer func() {
+		*bufp = buf[:0]
+		bytesPool.Put(bufp)
+	}()
 
-	size := cap(buf)
-	if size < 1024 {
-		size = 1024
-	}
+	size := max(cap(buf), 1024)
 	var out []byte
 	var err error
 	for {
@@ -98,19 +99,14 @@ func boundedSnappyDecode(cc CompressionCodec, data []byte, limit int) ([]byte, e
 		size *= 2
 	}
 
-	var res []byte
 	switch {
 	case errors.Is(err, snappy.ErrDstTooSmall):
-		err = newDecompressedBatchTooLargeError(cc, limit)
+		return nil, newDecompressedBatchTooLargeError(cc, limit)
 	case err != nil:
+		return nil, err
 	default:
-		res = make([]byte, len(out))
-		copy(res, out)
+		return slices.Clone(out), nil
 	}
-
-	*bufp = buf[:0]
-	bytesPool.Put(bufp)
-	return res, err
 }
 
 // boundedZstdDecode decodes into a pooled buffer using a decoder whose max
@@ -118,20 +114,19 @@ func boundedSnappyDecode(cc CompressionCodec, data []byte, limit int) ([]byte, e
 // output. ErrDecoderSizeExceeded is translated into a too-large error.
 func boundedZstdDecode(cc CompressionCodec, data []byte, limit int) ([]byte, error) {
 	buffer := *bytesPool.Get().(*[]byte)
+	defer func() {
+		buffer = buffer[:0]
+		bytesPool.Put(&buffer)
+	}()
+
 	buffer, err := zstdDecompress(ZstdDecoderParams{}, buffer, data, limit)
 	if errors.Is(err, zstd.ErrDecoderSizeExceeded) {
-		err = newDecompressedBatchTooLargeError(cc, limit)
+		return nil, newDecompressedBatchTooLargeError(cc, limit)
 	}
-	var res []byte
-	if err == nil {
-		// copy the buffer to a new slice with the correct length and reuse buffer
-		res = make([]byte, len(buffer))
-		copy(res, buffer)
+	if err != nil {
+		return nil, err
 	}
-	buffer = buffer[:0]
-	bytesPool.Put(&buffer)
-
-	return res, err
+	return slices.Clone(buffer), nil
 }
 
 func decompress(cc CompressionCodec, data []byte) ([]byte, error) {

--- a/decompress.go
+++ b/decompress.go
@@ -2,11 +2,14 @@ package sarama
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io"
 	"sync"
 
 	"github.com/klauspost/compress/gzip"
 	snappy "github.com/klauspost/compress/snappy/xerial"
+	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 )
 
@@ -33,7 +36,107 @@ var (
 	}
 )
 
+func newDecompressedBatchTooLargeError(cc CompressionCodec, limit int) error {
+	return fmt.Errorf("%w: %s batch decompressed to more than %d bytes", ErrDecompressedBatchTooLarge, cc, limit)
+}
+
+// boundedDecompress reads from a streaming decompressor into a pooled buffer,
+// capping the read at limit+1 bytes so an oversized batch is caught before it
+// fully inflates. A non-positive limit disables the cap.
+func boundedDecompress(cc CompressionCodec, reader io.Reader, limit int) ([]byte, error) {
+	buffer := bufferPool.Get().(*bytes.Buffer)
+	var src io.Reader = reader
+	if limit > 0 {
+		src = io.LimitReader(reader, int64(limit)+1)
+	}
+	n, err := buffer.ReadFrom(src)
+
+	var res []byte
+	switch {
+	case err != nil:
+	case limit > 0 && n > int64(limit):
+		err = newDecompressedBatchTooLargeError(cc, limit)
+	default:
+		res = make([]byte, buffer.Len())
+		copy(res, buffer.Bytes())
+	}
+
+	buffer.Reset()
+	bufferPool.Put(buffer)
+	return res, err
+}
+
+// boundedSnappyDecode decodes xerial/snappy into a capped buffer grown on
+// demand up to limit. DecodeCapped returns ErrDstTooSmall rather than writing
+// past the buffer's capacity, which we translate into a too-large error once
+// the buffer reaches limit. A non-positive limit decodes in one shot, unbounded.
+func boundedSnappyDecode(cc CompressionCodec, data []byte, limit int) ([]byte, error) {
+	if limit <= 0 {
+		return snappy.Decode(data)
+	}
+
+	bufp := bytesPool.Get().(*[]byte)
+	buf := *bufp
+
+	size := cap(buf)
+	if size < 1024 {
+		size = 1024
+	}
+	var out []byte
+	var err error
+	for {
+		if size > limit {
+			size = limit
+		}
+		if cap(buf) < size {
+			buf = make([]byte, 0, size)
+		}
+		out, err = snappy.DecodeCapped(buf[:0:size], data)
+		if !errors.Is(err, snappy.ErrDstTooSmall) || size >= limit {
+			break
+		}
+		size *= 2
+	}
+
+	var res []byte
+	switch {
+	case errors.Is(err, snappy.ErrDstTooSmall):
+		err = newDecompressedBatchTooLargeError(cc, limit)
+	case err != nil:
+	default:
+		res = make([]byte, len(out))
+		copy(res, out)
+	}
+
+	*bufp = buf[:0]
+	bytesPool.Put(bufp)
+	return res, err
+}
+
+// boundedZstdDecode decodes into a pooled buffer using a decoder whose max
+// memory is capped at limit, so an oversized frame fails without allocating its
+// output. ErrDecoderSizeExceeded is translated into a too-large error.
+func boundedZstdDecode(cc CompressionCodec, data []byte, limit int) ([]byte, error) {
+	buffer := *bytesPool.Get().(*[]byte)
+	buffer, err := zstdDecompress(ZstdDecoderParams{}, buffer, data, limit)
+	if errors.Is(err, zstd.ErrDecoderSizeExceeded) {
+		err = newDecompressedBatchTooLargeError(cc, limit)
+	}
+	var res []byte
+	if err == nil {
+		// copy the buffer to a new slice with the correct length and reuse buffer
+		res = make([]byte, len(buffer))
+		copy(res, buffer)
+	}
+	buffer = buffer[:0]
+	bytesPool.Put(&buffer)
+
+	return res, err
+}
+
 func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
+	// 0 means unbounded
+	limit := int(MaxDecompressedBatchSize)
 	switch cc {
 	case CompressionNone:
 		return data, nil
@@ -50,19 +153,11 @@ func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
 			return nil, err
 		}
 
-		buffer := bufferPool.Get().(*bytes.Buffer)
-		_, err = buffer.ReadFrom(reader)
-		// copy the buffer to a new slice with the correct length
-		// reuse gzipReader and buffer
+		res, err := boundedDecompress(cc, reader, limit)
 		gzipReaderPool.Put(reader)
-		res := make([]byte, buffer.Len())
-		copy(res, buffer.Bytes())
-		buffer.Reset()
-		bufferPool.Put(buffer)
-
 		return res, err
 	case CompressionSnappy:
-		return snappy.Decode(data)
+		return boundedSnappyDecode(cc, data, limit)
 	case CompressionLZ4:
 		reader, ok := lz4ReaderPool.Get().(*lz4.Reader)
 		if !ok {
@@ -70,28 +165,12 @@ func decompress(cc CompressionCodec, data []byte) ([]byte, error) {
 		} else {
 			reader.Reset(bytes.NewReader(data))
 		}
-		buffer := bufferPool.Get().(*bytes.Buffer)
-		_, err := buffer.ReadFrom(reader)
-		// copy the buffer to a new slice with the correct length
-		// reuse lz4Reader and buffer
-		lz4ReaderPool.Put(reader)
-		res := make([]byte, buffer.Len())
-		copy(res, buffer.Bytes())
-		buffer.Reset()
-		bufferPool.Put(buffer)
 
+		res, err := boundedDecompress(cc, reader, limit)
+		lz4ReaderPool.Put(reader)
 		return res, err
 	case CompressionZSTD:
-		buffer := *bytesPool.Get().(*[]byte)
-		var err error
-		buffer, err = zstdDecompress(ZstdDecoderParams{}, buffer, data)
-		// copy the buffer to a new slice with the correct length and reuse buffer
-		res := make([]byte, len(buffer))
-		copy(res, buffer)
-		buffer = buffer[:0]
-		bytesPool.Put(&buffer)
-
-		return res, err
+		return boundedZstdDecode(cc, data, limit)
 	default:
 		return nil, PacketDecodingError{fmt.Sprintf("invalid compression specified (%d)", cc)}
 	}

--- a/decompress_test.go
+++ b/decompress_test.go
@@ -1,0 +1,99 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecompress(t *testing.T) {
+	codecs := []CompressionCodec{
+		CompressionGZIP,
+		CompressionSnappy,
+		CompressionLZ4,
+		CompressionZSTD,
+	}
+
+	const limit = 64 * 1024
+
+	withLimit := func(t *testing.T, v int32) {
+		t.Helper()
+		old := MaxDecompressedBatchSize
+		MaxDecompressedBatchSize = v
+		t.Cleanup(func() { MaxDecompressedBatchSize = old })
+	}
+
+	t.Run("rejects a compression bomb under the wire limit", func(t *testing.T) {
+		for _, cc := range codecs {
+			t.Run(cc.String(), func(t *testing.T) {
+				withLimit(t, limit)
+
+				// highly compressible input that decompresses well past the cap
+				payload := make([]byte, limit*8)
+				compressed, err := compress(cc, CompressionLevelDefault, payload)
+				require.NoError(t, err)
+				require.Less(t, len(compressed), int(MaxResponseSize))
+
+				out, err := decompress(cc, compressed)
+				require.ErrorIs(t, err, ErrDecompressedBatchTooLarge)
+				require.Empty(t, out)
+			})
+		}
+	})
+
+	t.Run("decodes a batch well under the cap", func(t *testing.T) {
+		for _, cc := range codecs {
+			t.Run(cc.String(), func(t *testing.T) {
+				withLimit(t, limit)
+
+				payload := bytes.Repeat([]byte("sarama"), 1000)
+				require.Less(t, len(payload), limit)
+
+				compressed, err := compress(cc, CompressionLevelDefault, payload)
+				require.NoError(t, err)
+
+				out, err := decompress(cc, compressed)
+				require.NoError(t, err)
+				require.Equal(t, payload, out)
+			})
+		}
+	})
+
+	t.Run("accepts exactly the cap and rejects one byte over", func(t *testing.T) {
+		for _, cc := range codecs {
+			t.Run(cc.String(), func(t *testing.T) {
+				withLimit(t, limit)
+
+				atLimit, err := compress(cc, CompressionLevelDefault, make([]byte, limit))
+				require.NoError(t, err)
+				out, err := decompress(cc, atLimit)
+				require.NoError(t, err)
+				require.Len(t, out, limit)
+
+				over, err := compress(cc, CompressionLevelDefault, make([]byte, limit+1))
+				require.NoError(t, err)
+				_, err = decompress(cc, over)
+				require.ErrorIs(t, err, ErrDecompressedBatchTooLarge)
+			})
+		}
+	})
+
+	t.Run("leaves decompression unbounded when unset", func(t *testing.T) {
+		for _, cc := range codecs {
+			t.Run(cc.String(), func(t *testing.T) {
+				withLimit(t, 0)
+
+				payload := make([]byte, limit*8)
+				compressed, err := compress(cc, CompressionLevelDefault, payload)
+				require.NoError(t, err)
+
+				out, err := decompress(cc, compressed)
+				require.NoError(t, err)
+				require.Len(t, out, len(payload))
+			})
+		}
+	})
+}

--- a/errors.go
+++ b/errors.go
@@ -41,6 +41,10 @@ var ErrShuttingDown = errors.New("kafka: message received by producer in process
 // ErrMessageTooLarge is returned when the next message to consume is larger than the configured Consumer.Fetch.Max
 var ErrMessageTooLarge = errors.New("kafka: message is larger than Consumer.Fetch.Max")
 
+// ErrDecompressedBatchTooLarge is returned when a compressed record batch decompresses
+// to more than the configured limit (see MaxDecompressedBatchSize).
+var ErrDecompressedBatchTooLarge = errors.New("kafka: decompressed record batch is larger than the configured limit")
+
 // ErrConsumerOffsetNotAdvanced is returned when a partition consumer didn't advance its offset after parsing
 // a RecordBatch.
 var ErrConsumerOffsetNotAdvanced = errors.New("kafka: consumer offset was not advanced after a RecordBatch")

--- a/sarama.go
+++ b/sarama.go
@@ -111,6 +111,16 @@ var (
 	// the size of responses they send. In particular, they can send arbitrarily large fetch responses to consumers
 	// (see https://issues.apache.org/jira/browse/KAFKA-2063).
 	MaxResponseSize int32 = 100 * 1024 * 1024
+
+	// MaxDecompressedBatchSize bounds the number of bytes a single compressed record
+	// batch may inflate to during consumer-side decompression. A small compressed payload
+	// can decompress into a much larger allocation (a "compression bomb"). When this is
+	// set and a batch decompresses to more than this many bytes, Sarama stops
+	// decompressing and returns ErrDecompressedBatchTooLarge instead of holding the full
+	// payload in memory.
+	//
+	// The default of 0 leaves decompression unbounded.
+	MaxDecompressedBatchSize int32 = 0
 )
 
 // StdLogger is used to log error messages.

--- a/zstd.go
+++ b/zstd.go
@@ -73,19 +73,32 @@ func releaseEncoder(params ZstdEncoderParams, enc *zstd.Encoder) {
 	}
 }
 
-func getDecoder(params ZstdDecoderParams) *zstd.Decoder {
-	if ret, ok := zstdDecMap.Load(params); ok {
+// zstdDecoderKey keys the decoder cache on maxDecodedSize as well as params,
+// since the size bound is fixed when the decoder is built and can't be changed
+// per call.
+type zstdDecoderKey struct {
+	ZstdDecoderParams
+	maxDecodedSize int
+}
+
+func getDecoder(params ZstdDecoderParams, maxDecodedSize int) *zstd.Decoder {
+	key := zstdDecoderKey{params, maxDecodedSize}
+	if ret, ok := zstdDecMap.Load(key); ok {
 		return ret.(*zstd.Decoder)
+	}
+	opts := []zstd.DOption{zstd.WithDecoderConcurrency(0)}
+	if maxDecodedSize > 0 {
+		opts = append(opts, zstd.WithDecoderMaxMemory(uint64(maxDecodedSize)))
 	}
 	// It's possible to race and create multiple new readers.
 	// Only one will survive GC after use.
-	zstdDec, _ := zstd.NewReader(nil, zstd.WithDecoderConcurrency(0))
-	zstdDecMap.Store(params, zstdDec)
+	zstdDec, _ := zstd.NewReader(nil, opts...)
+	zstdDecMap.Store(key, zstdDec)
 	return zstdDec
 }
 
-func zstdDecompress(params ZstdDecoderParams, dst, src []byte) ([]byte, error) {
-	return getDecoder(params).DecodeAll(src, dst)
+func zstdDecompress(params ZstdDecoderParams, dst, src []byte, maxDecodedSize int) ([]byte, error) {
+	return getDecoder(params, maxDecodedSize).DecodeAll(src, dst)
 }
 
 func zstdCompress(params ZstdEncoderParams, dst, src []byte) ([]byte, error) {

--- a/zstd.go
+++ b/zstd.go
@@ -13,7 +13,10 @@ type ZstdEncoderParams struct {
 type ZstdDecoderParams struct {
 }
 
-var zstdDecMap sync.Map
+var (
+	zstdDecMap        sync.Map
+	zstdDecoderInitMu sync.Mutex
+)
 
 var (
 	zstdAvailableEncoders sync.Map
@@ -86,12 +89,18 @@ func getDecoder(params ZstdDecoderParams, maxDecodedSize int) *zstd.Decoder {
 	if ret, ok := zstdDecMap.Load(key); ok {
 		return ret.(*zstd.Decoder)
 	}
+
+	zstdDecoderInitMu.Lock()
+	defer zstdDecoderInitMu.Unlock()
+
+	if ret, ok := zstdDecMap.Load(key); ok {
+		return ret.(*zstd.Decoder)
+	}
+
 	opts := []zstd.DOption{zstd.WithDecoderConcurrency(0)}
 	if maxDecodedSize > 0 {
 		opts = append(opts, zstd.WithDecoderMaxMemory(uint64(maxDecodedSize)))
 	}
-	// It's possible to race and create multiple new readers.
-	// Only one will survive GC after use.
 	zstdDec, _ := zstd.NewReader(nil, opts...)
 	zstdDecMap.Store(key, zstdDec)
 	return zstdDec


### PR DESCRIPTION
Add MaxDecompressedBatchSize to bound how far a single compressed record batch may inflate during decompression, guarding against compression bombs that turn a small payload into a large allocation.

The bound is applied while decompressing rather than after, so an oversized batch is rejected with ErrDecompressedBatchTooLarge before its output is fully allocated. The default of 0 leaves decompression unbounded, preserving existing behaviour.