### PR TITLE
feat(client): Re-use already connected broker without pending request to fetch metadata

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -346,6 +346,14 @@ func (b *Broker) Connected() (bool, error) {
 	return b.conn != nil, b.connErr
 }
 
+// status is the short and one lock version of (Connected(), ResponseSize()).
+func (b *Broker) status() (bool, int) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	return b.conn != nil, len(b.responses)
+}
+
 // TLSConnectionState returns the client's TLS connection state. The second return value is false if this is not a tls connection or the connection has not yet been established.
 func (b *Broker) TLSConnectionState() (state tls.ConnectionState, ok bool) {
 	b.lock.Lock()

--- a/client.go
+++ b/client.go
@@ -788,21 +788,50 @@ func (client *client) resurrectDeadBrokers() {
 }
 
 // LeastLoadedBroker returns the broker with the least pending requests.
-// Firstly, choose the broker from cached broker list. If the broker list is empty, choose from seed brokers.
+//
+// The aim is to choose the broker, from the cached broker list, that offers
+// the best balance between the lowest current load and the cost of a new connection,
+// in accordance with the following list of priorities:
+//
+//  1. Returns an already connected broker if and only if it is idle.
+//  2. Returns a broker that is not yet connected. Etablish a new connection
+//     before to return it.
+//  3. Returns the currently connected broker with the least number of pending requests.
+//  4. If the cached list of brokers is empty, returns a seed broker.
+//
+// As the order in which brokers are iterated is not stable, the broker
+// returned may vary from one call to the next if several brokers of the list
+// share the same selection criteria.
 func (client *client) LeastLoadedBroker() *Broker {
 	client.lock.RLock()
 	defer client.lock.RUnlock()
 
-	var leastLoadedBroker *Broker
-	pendingRequests := math.MaxInt
-	for _, broker := range client.brokers {
-		if pendingRequests > broker.ResponseSize() {
-			pendingRequests = broker.ResponseSize()
-			leastLoadedBroker = broker
+	var leastLoadedBroker, notConnectedBroker *Broker
+	leastPendingRequests := math.MaxInt
+
+	for _, b := range client.brokers {
+		isConnected, pendingRequests := b.status()
+		if !isConnected {
+			notConnectedBroker = b
+			continue
+		}
+
+		if pendingRequests == 0 {
+			return b
+		}
+
+		if pendingRequests < leastPendingRequests {
+			leastPendingRequests = pendingRequests
+			leastLoadedBroker = b
 		}
 	}
+
+	if notConnectedBroker != nil {
+		_ = notConnectedBroker.Open(client.conf)
+		return notConnectedBroker
+	}
+
 	if leastLoadedBroker != nil {
-		_ = leastLoadedBroker.Open(client.conf)
 		return leastLoadedBroker
 	}
 
@@ -811,7 +840,7 @@ func (client *client) LeastLoadedBroker() *Broker {
 		return client.seedBrokers[0]
 	}
 
-	return leastLoadedBroker
+	return nil
 }
 
 // private caching/lazy metadata helpers

--- a/client_test.go
+++ b/client_test.go
@@ -699,6 +699,152 @@ func TestClientGetBroker(t *testing.T) {
 	}
 }
 
+func TestClientLeastLoadedBroker(t *testing.T) {
+	createFakeBroker := func(t *testing.T, brokerID int32, connected bool, pendingRequests int) *Broker {
+		t.Helper()
+
+		mb := NewMockBroker(t, brokerID)
+		t.Cleanup(mb.Close)
+
+		broker := NewBroker(mb.Addr())
+		broker.id = brokerID
+
+		if connected {
+			conn, err := net.Dial("tcp", mb.listener.Addr().String())
+			require.NoErrorf(t, err, "Broker %d", brokerID)
+
+			broker.conn = conn.(*net.TCPConn)
+			broker.metricRegistry = metrics.NewRegistry()
+			broker.opened.Store(true)
+
+			if pendingRequests > 0 {
+				broker.responses = make(chan *responsePromise, pendingRequests)
+				for range pendingRequests {
+					broker.responses <- new(responsePromise)
+				}
+			}
+		}
+
+		return broker
+	}
+
+	createTestClient := func(t *testing.T, seedBrokers []*Broker, brokers []*Broker) Client {
+		t.Helper()
+
+		conf := NewTestConfig()
+		conf.ClientID = "test"
+		conf.Metadata.RefreshFrequency = 0
+		conf.Metadata.Full = false
+
+		ic, err := NewClient([]string{"fake-addr.local"}, conf)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			assert.NoError(t, ic.Close())
+		})
+
+		c := ic.(*client)
+		c.seedBrokers = seedBrokers
+
+		c.brokers = make(map[int32]*Broker, len(brokers))
+		for _, b := range brokers {
+			c.brokers[b.ID()] = b
+		}
+
+		return ic
+	}
+
+	getBrokerIdent := func(b *Broker) string {
+		return fmt.Sprintf("broker %d (%s)", b.ID(), b.Addr())
+	}
+
+	assertBrokerMatch := func(t *testing.T, expectedBrokers []*Broker, broker *Broker) {
+		t.Helper()
+
+		expectedBrokerAddrs := make([]string, len(expectedBrokers))
+		expectedBrokerIdents := make([]string, len(expectedBrokers))
+		for i, b := range expectedBrokers {
+			expectedBrokerAddrs[i] = b.Addr()
+			expectedBrokerIdents[i] = getBrokerIdent(b)
+		}
+
+		assert.Containsf(t, expectedBrokerAddrs, broker.Addr(),
+			"Expected: {%s}, Got: %s",
+			strings.Join(expectedBrokerIdents, ", "),
+			getBrokerIdent(broker),
+		)
+	}
+
+	t.Run("ensure idle connected broker is returned", func(t *testing.T) {
+		broker1 := createFakeBroker(t, 1, true, 5)  // Broker 1 - Connected with 5 pending requests
+		broker2 := createFakeBroker(t, 2, true, 0)  // Broker 2 - Connected and idle.
+		broker3 := createFakeBroker(t, 3, false, 0) // Broker 3 - Not Connected
+		broker4 := createFakeBroker(t, 4, true, 2)  // Broker 4 - Connected with 2 pending requests
+		broker5 := createFakeBroker(t, 5, false, 0) // Broker 5 - Not connected
+
+		seed1 := createFakeBroker(t, -1, false, 0) // Not connected
+		seed2 := createFakeBroker(t, -1, false, 0) // Not connected
+
+		c := createTestClient(t, []*Broker{
+			seed1, seed2,
+		}, []*Broker{
+			broker1, broker2, broker3, broker4, broker5,
+		})
+
+		broker := c.LeastLoadedBroker()
+		assertBrokerMatch(t, []*Broker{broker2}, broker)
+	})
+
+	t.Run("ensure not connected broker is returned", func(t *testing.T) {
+		broker1 := createFakeBroker(t, 1, true, 5) // Broker 1 - Connected with 5 pending requests
+
+		broker3 := createFakeBroker(t, 3, false, 0) // Broker 3 - Not Connected
+		broker4 := createFakeBroker(t, 4, true, 2)  // Broker 4 - Connected with 2 pending requests
+		broker5 := createFakeBroker(t, 5, false, 0) // Broker 5 - Not connected
+
+		seed1 := createFakeBroker(t, -1, false, 0) // Not connected
+		seed2 := createFakeBroker(t, -1, false, 0) // Not connected
+
+		c := createTestClient(t, []*Broker{
+			seed1, seed2,
+		}, []*Broker{
+			broker1, broker3, broker4, broker5,
+		})
+
+		broker := c.LeastLoadedBroker()
+		assertBrokerMatch(t, []*Broker{broker3, broker5}, broker)
+	})
+
+	t.Run("ensure least loaded connected broker is returned", func(t *testing.T) {
+		broker1 := createFakeBroker(t, 1, true, 5) // Broker 1 - Connected with 5 pending requests
+		broker4 := createFakeBroker(t, 4, true, 2) // Broker 4 - Connected with 2 pending requests
+
+		seed1 := createFakeBroker(t, -1, false, 0) // Not connected
+		seed2 := createFakeBroker(t, -1, false, 0) // Not connected
+
+		c := createTestClient(t, []*Broker{
+			seed1, seed2,
+		}, []*Broker{
+			broker1, broker4,
+		})
+
+		broker := c.LeastLoadedBroker()
+		assertBrokerMatch(t, []*Broker{broker4}, broker)
+	})
+
+	t.Run("ensure seed broker is returned", func(t *testing.T) {
+		seed1 := createFakeBroker(t, -1, false, 0) // Not connected
+		seed2 := createFakeBroker(t, -1, false, 0) // Not connected
+
+		c := createTestClient(t, []*Broker{
+			seed1, seed2,
+		}, nil)
+
+		broker := c.LeastLoadedBroker()
+		assertBrokerMatch(t, []*Broker{seed1, seed2}, broker)
+	})
+}
+
 func TestClientResurrectDeadSeeds(t *testing.T) {
 	initialSeed := NewMockBroker(t, 0)
 	metadataResponse := new(MetadataResponse)


### PR DESCRIPTION
When several brokers are not connected or connected and idle, `Client.LeastLoadedBroker()` could establish a new connection to a broker rather than favouring an already connected broker. This happends depending on the iteration order of the brokers's map which is not predictable.

This change makes a slight adjustment of this method to return the first connected and idle broker encountered, which may drastically reduce the total number of connection per broker when a same Kafka cluster is used by several thousand applications.