### PR TITLE
chore: update default Kafka version to 2.6

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -305,7 +305,7 @@ var (
 	}
 	MinVersion     = V0_8_2_0
 	MaxVersion     = V4_3_0_0
-	DefaultVersion = V2_1_0_0
+	DefaultVersion = V2_6_0_0
 )
 
 var (


### PR DESCRIPTION
Now we support the full set of 2.6 protocols we can make it the default pin 