### PR TITLE
feat: support Fetch v12

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -1291,56 +1291,58 @@ func (bc *brokerConsumer) fetchNewMessages() (*FetchResponse, error) {
 		MinBytes:    bc.consumer.conf.Consumer.Fetch.Min,
 		MaxWaitTime: int32(bc.consumer.conf.Consumer.MaxWaitTime / time.Millisecond),
 	}
+	// pick the highest Fetch version supported by the negotiated Kafka version
+	switch {
+	// Version 12 adds flexible version support and last fetched epoch.
+	case bc.consumer.conf.Version.IsAtLeast(V2_7_0_0):
+		request.Version = 12
+	// Version 11 adds RackID for KIP-392 fetch from closest replica.
+	case bc.consumer.conf.Version.IsAtLeast(V2_3_0_0):
+		request.Version = 11
+	// Version 9 adds CurrentLeaderEpoch (KIP-320); version 10 allows the ZStd
+	// compression algorithm (KIP-110).
+	case bc.consumer.conf.Version.IsAtLeast(V2_1_0_0):
+		request.Version = 10
+	// Version 8 is the same as version 7.
+	case bc.consumer.conf.Version.IsAtLeast(V2_0_0_0):
+		request.Version = 8
+	// Version 7 adds incremental fetch request support.
+	case bc.consumer.conf.Version.IsAtLeast(V1_1_0_0):
+		request.Version = 7
+	// Version 6 is the same as version 5.
+	case bc.consumer.conf.Version.IsAtLeast(V1_0_0_0):
+		request.Version = 6
+	// Version 4 adds IsolationLevel and requires Kafka log message format
+	// version 2; version 5 adds LogStartOffset.
+	case bc.consumer.conf.Version.IsAtLeast(V0_11_0_0):
+		request.Version = 5
+	// Version 3 adds MaxBytes and makes partition ordering significant:
+	// partitions are processed in the order they appear in the request.
+	case bc.consumer.conf.Version.IsAtLeast(V0_10_1_0):
+		request.Version = 3
+	// Starting in version 2, the requestor must be able to handle Kafka log
+	// message format version 1.
+	case bc.consumer.conf.Version.IsAtLeast(V0_10_0_0):
+		request.Version = 2
 	// Version 1 is the same as version 0.
-	if bc.consumer.conf.Version.IsAtLeast(V0_9_0_0) {
+	case bc.consumer.conf.Version.IsAtLeast(V0_9_0_0):
 		request.Version = 1
 	}
-	// Starting in Version 2, the requestor must be able to handle Kafka Log
-	// Message format version 1.
-	if bc.consumer.conf.Version.IsAtLeast(V0_10_0_0) {
-		request.Version = 2
-	}
-	// Version 3 adds MaxBytes.  Starting in version 3, the partition ordering in
-	// the request is now relevant.  Partitions will be processed in the order
-	// they appear in the request.
-	if bc.consumer.conf.Version.IsAtLeast(V0_10_1_0) {
-		request.Version = 3
+
+	if request.Version >= 3 {
 		request.MaxBytes = bc.consumer.conf.Consumer.Fetch.MaxBytes
 	}
-	// Version 4 adds IsolationLevel.  Starting in version 4, the reqestor must be
-	// able to handle Kafka log message format version 2.
-	// Version 5 adds LogStartOffset to indicate the earliest available offset of
-	// partition data that can be consumed.
-	if bc.consumer.conf.Version.IsAtLeast(V0_11_0_0) {
-		request.Version = 5
+	if request.Version >= 4 {
 		request.Isolation = bc.consumer.conf.Consumer.IsolationLevel
 	}
-	// Version 6 is the same as version 5.
-	if bc.consumer.conf.Version.IsAtLeast(V1_0_0_0) {
-		request.Version = 6
-	}
-	// Version 7 adds incremental fetch request support.
-	if bc.consumer.conf.Version.IsAtLeast(V1_1_0_0) {
-		request.Version = 7
+	if request.Version >= 7 {
 		// We do not currently implement KIP-227 FetchSessions. Setting the id to 0
 		// and the epoch to -1 tells the broker not to generate as session ID we're going
 		// to just ignore anyway.
 		request.SessionID = 0
 		request.SessionEpoch = -1
 	}
-	// Version 8 is the same as version 7.
-	if bc.consumer.conf.Version.IsAtLeast(V2_0_0_0) {
-		request.Version = 8
-	}
-	// Version 9 adds CurrentLeaderEpoch, as described in KIP-320.
-	// Version 10 indicates that we can use the ZStd compression algorithm, as
-	// described in KIP-110.
-	if bc.consumer.conf.Version.IsAtLeast(V2_1_0_0) {
-		request.Version = 10
-	}
-	// Version 11 adds RackID for KIP-392 fetch from closest replica
-	if bc.consumer.conf.Version.IsAtLeast(V2_3_0_0) {
-		request.Version = 11
+	if request.Version >= 11 {
 		request.RackID = bc.consumer.conf.RackID
 	}
 

--- a/encoder_decoder_fuzz_test.go
+++ b/encoder_decoder_fuzz_test.go
@@ -42,6 +42,7 @@ func FuzzDecodeEncodeFetchRequest(f *testing.F) {
 		fetchRequestOneBlock,
 		fetchRequestOneBlockV4,
 		fetchRequestOneBlockV11,
+		fetchRequestOneBlockV12,
 	} {
 		f.Add(seed)
 	}

--- a/fetch_request.go
+++ b/fetch_request.go
@@ -8,6 +8,8 @@ type fetchRequestBlock struct {
 	currentLeaderEpoch int32
 	// fetchOffset contains the message offset.
 	fetchOffset int64
+	// lastFetchedEpoch contains the epoch of the last fetched record.
+	lastFetchedEpoch int32
 	// logStartOffset contains the earliest available offset of the follower
 	// replica.  The field is only used when the request is sent by the
 	// follower.
@@ -23,10 +25,14 @@ func (b *fetchRequestBlock) encode(pe packetEncoder, version int16) error {
 		pe.putInt32(b.currentLeaderEpoch)
 	}
 	pe.putInt64(b.fetchOffset)
+	if b.Version >= 12 {
+		pe.putInt32(b.lastFetchedEpoch)
+	}
 	if b.Version >= 5 {
 		pe.putInt64(b.logStartOffset)
 	}
 	pe.putInt32(b.maxBytes)
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -40,6 +46,11 @@ func (b *fetchRequestBlock) decode(pd packetDecoder, version int16) (err error) 
 	if b.fetchOffset, err = pd.getInt64(); err != nil {
 		return err
 	}
+	if b.Version >= 12 {
+		if b.lastFetchedEpoch, err = pd.getInt32(); err != nil {
+			return err
+		}
+	}
 	if b.Version >= 5 {
 		if b.logStartOffset, err = pd.getInt64(); err != nil {
 			return err
@@ -48,7 +59,8 @@ func (b *fetchRequestBlock) decode(pd packetDecoder, version int16) (err error) 
 	if b.maxBytes, err = pd.getInt32(); err != nil {
 		return err
 	}
-	return nil
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
 }
 
 // FetchRequest (API key 1) will fetch Kafka messages. Version 3 introduced the MaxBytes field. See
@@ -136,6 +148,7 @@ func (r *FetchRequest) encode(pe packetEncoder) (err error) {
 				return err
 			}
 		}
+		pe.putEmptyTaggedFieldArray()
 		getOrRegisterTopicMeter("consumer-fetch-rate", topic, metricRegistry).Mark(1)
 	}
 	if r.Version >= 7 {
@@ -155,6 +168,7 @@ func (r *FetchRequest) encode(pe packetEncoder) (err error) {
 			for _, partition := range partitions {
 				pe.putInt32(partition)
 			}
+			pe.putEmptyTaggedFieldArray()
 		}
 	}
 	if r.Version >= 11 {
@@ -164,6 +178,7 @@ func (r *FetchRequest) encode(pe packetEncoder) (err error) {
 		}
 	}
 
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -205,7 +220,7 @@ func (r *FetchRequest) decode(pd packetDecoder, version int16) (err error) {
 	if err != nil {
 		return err
 	}
-	if topicCount == 0 {
+	if topicCount == 0 && r.Version < 7 {
 		return nil
 	}
 	r.blocks = make(map[string]map[int32]*fetchRequestBlock)
@@ -229,6 +244,9 @@ func (r *FetchRequest) decode(pd packetDecoder, version int16) (err error) {
 				return err
 			}
 			r.blocks[topic][partition] = fetchBlock
+		}
+		if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+			return err
 		}
 	}
 
@@ -259,6 +277,9 @@ func (r *FetchRequest) decode(pd packetDecoder, version int16) (err error) {
 				}
 				r.forgotten[topic][j] = partition
 			}
+			if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -269,7 +290,8 @@ func (r *FetchRequest) decode(pd packetDecoder, version int16) (err error) {
 		}
 	}
 
-	return nil
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
 }
 
 func (r *FetchRequest) key() int16 {
@@ -281,15 +303,28 @@ func (r *FetchRequest) version() int16 {
 }
 
 func (r *FetchRequest) headerVersion() int16 {
+	if r.Version >= 12 {
+		return 2
+	}
 	return 1
 }
 
 func (r *FetchRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 11
+	return r.Version >= 0 && r.Version <= 12
+}
+
+func (r *FetchRequest) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *FetchRequest) isFlexibleVersion(version int16) bool {
+	return version >= 12
 }
 
 func (r *FetchRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 12:
+		return V2_7_0_0
 	case 11:
 		return V2_3_0_0
 	case 9, 10:
@@ -332,6 +367,9 @@ func (r *FetchRequest) AddBlock(topic string, partitionID int32, fetchOffset int
 	tmp.Version = r.Version
 	tmp.maxBytes = maxBytes
 	tmp.fetchOffset = fetchOffset
+	if r.Version >= 12 {
+		tmp.lastFetchedEpoch = -1
+	}
 	if r.Version >= 9 {
 		tmp.currentLeaderEpoch = leaderEpoch
 	}

--- a/fetch_request_test.go
+++ b/fetch_request_test.go
@@ -50,6 +50,30 @@ var (
 		0x00, 0x00, 0x00, 0x00,
 		0x00, 0x06, 'r', 'a', 'c', 'k', '0', '1', // rackID
 	}
+
+	fetchRequestOneBlockV12 = []byte{
+		0xFF, 0xFF, 0xFF, 0xFF, // replicaID
+		0x00, 0x00, 0x00, 0x00, // maxWaitTime
+		0x00, 0x00, 0x00, 0x00, // minBytes
+		0x00, 0x00, 0x00, 0xFF, // maxBytes
+		0x01,                   // isolation
+		0x00, 0x00, 0x00, 0xAA, // sessionID
+		0x00, 0x00, 0x00, 0xEE, // sessionEpoch
+		0x02,                          // topics
+		0x06, 't', 'o', 'p', 'i', 'c', // topic
+		0x02,                   // partitions
+		0x00, 0x00, 0x00, 0x12, // partitionID
+		0x00, 0x00, 0x00, 0x66, // currentLeaderEpoch
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x34, // fetchOffset
+		0xFF, 0xFF, 0xFF, 0xFF, // lastFetchedEpoch
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // logStartOffset
+		0x00, 0x00, 0x00, 0x56, // maxBytes
+		0x00,                               // partition tagged fields
+		0x00,                               // topic tagged fields
+		0x01,                               // forgotten topics
+		0x07, 'r', 'a', 'c', 'k', '0', '1', // rackID
+		0x00, // request tagged fields
+	}
 )
 
 func TestFetchRequest(t *testing.T) {
@@ -92,5 +116,17 @@ func TestFetchRequest(t *testing.T) {
 		request.AddBlock("topic", 0x12, 0x34, 0x56, 0x66)
 		request.RackID = "rack01"
 		testRequest(t, "one block v11 rackid", request, fetchRequestOneBlockV11)
+	})
+
+	t.Run("one block v12 flexible", func(t *testing.T) {
+		request := new(FetchRequest)
+		request.Version = 12
+		request.MaxBytes = 0xFF
+		request.Isolation = ReadCommitted
+		request.SessionID = 0xAA
+		request.SessionEpoch = 0xEE
+		request.AddBlock("topic", 0x12, 0x34, 0x56, 0x66)
+		request.RackID = "rack01"
+		testRequest(t, "one block v12 flexible", request, fetchRequestOneBlockV12)
 	})
 }

--- a/fetch_response.go
+++ b/fetch_response.go
@@ -29,13 +29,37 @@ func (t *AbortedTransaction) decode(pd packetDecoder) (err error) {
 		return err
 	}
 
-	return nil
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
 }
 
 func (t *AbortedTransaction) encode(pe packetEncoder) (err error) {
 	pe.putInt64(t.ProducerID)
 	pe.putInt64(t.FirstOffset)
 
+	pe.putEmptyTaggedFieldArray()
+
+	return nil
+}
+
+type FetchResponseDivergingEpoch struct {
+	Epoch     int32
+	EndOffset int64
+}
+
+type FetchResponseCurrentLeader struct {
+	LeaderID    int32
+	LeaderEpoch int32
+}
+
+type fetchRecordsSet []*Records
+
+func (r fetchRecordsSet) encode(pe packetEncoder) error {
+	for _, records := range r {
+		if err := records.encode(pe); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -51,6 +75,10 @@ type FetchResponseBlock struct {
 	LastStableOffset int64
 	// LogStartOffset contains the current log start offset.
 	LogStartOffset int64
+	// DivergingEpoch contains the largest epoch and end offset known to diverge.
+	DivergingEpoch *FetchResponseDivergingEpoch
+	// CurrentLeader contains the current partition leader and leader epoch.
+	CurrentLeader *FetchResponseCurrentLeader
 	// AbortedTransactions contains the aborted transactions.
 	AbortedTransactions []*AbortedTransaction
 	// PreferredReadReplica contains the preferred read replica for the
@@ -129,17 +157,31 @@ func (b *FetchResponseBlock) decode(pd packetDecoder, version int16) (err error)
 		b.PreferredReadReplica = -1
 	}
 
-	recordsSize, err := pd.getInt32()
-	if err != nil {
-		return err
-	}
-	if sizeMetric != nil {
-		sizeMetric.Update(int64(recordsSize))
-	}
+	var recordsDecoder packetDecoder
+	if version >= 12 {
+		recordsBytes, err := pd.getBytes()
+		if err != nil {
+			return err
+		}
+		if sizeMetric != nil {
+			sizeMetric.Update(int64(len(recordsBytes)))
+		}
+		// record batches are not flexible-encoded, so decode the payload with a
+		// plain realDecoder rather than the flexible parent
+		recordsDecoder = &realDecoder{raw: recordsBytes}
+	} else {
+		recordsSize, err := pd.getInt32()
+		if err != nil {
+			return err
+		}
+		if sizeMetric != nil {
+			sizeMetric.Update(int64(recordsSize))
+		}
 
-	recordsDecoder, err := pd.getSubset(int(recordsSize))
-	if err != nil {
-		return err
+		recordsDecoder, err = pd.getSubset(int(recordsSize))
+		if err != nil {
+			return err
+		}
 	}
 
 	b.RecordsSet = []*Records{}
@@ -197,7 +239,35 @@ func (b *FetchResponseBlock) decode(pd packetDecoder, version int16) (err error)
 		}
 	}
 
-	return nil
+	if version >= 12 {
+		err = pd.getTaggedFieldArray(taggedFieldDecoders{
+			0: func(pd packetDecoder) error {
+				epoch, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				endOffset, err := pd.getInt64()
+				if err != nil {
+					return err
+				}
+				b.DivergingEpoch = &FetchResponseDivergingEpoch{Epoch: epoch, EndOffset: endOffset}
+				return nil
+			},
+			1: func(pd packetDecoder) error {
+				leaderID, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				leaderEpoch, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				b.CurrentLeader = &FetchResponseCurrentLeader{LeaderID: leaderID, LeaderEpoch: leaderEpoch}
+				return nil
+			},
+		})
+	}
+	return err
 }
 
 func (b *FetchResponseBlock) numRecords() (int, error) {
@@ -253,6 +323,18 @@ func (b *FetchResponseBlock) encode(pe packetEncoder, version int16) (err error)
 		pe.putInt32(b.PreferredReadReplica)
 	}
 
+	if version >= 12 {
+		recordsBytes, err := encode(fetchRecordsSet(b.RecordsSet), nil)
+		if err != nil {
+			return err
+		}
+		if err = pe.putBytes(recordsBytes); err != nil {
+			return err
+		}
+		b.encodeTaggedFields(pe)
+		return nil
+	}
+
 	pe.push(&lengthField{})
 	for _, records := range b.RecordsSet {
 		err = records.encode(pe)
@@ -261,6 +343,30 @@ func (b *FetchResponseBlock) encode(pe packetEncoder, version int16) (err error)
 		}
 	}
 	return pe.pop()
+}
+
+func (b *FetchResponseBlock) encodeTaggedFields(pe packetEncoder) {
+	var numTaggedFields uint64
+	if b.DivergingEpoch != nil {
+		numTaggedFields++
+	}
+	if b.CurrentLeader != nil {
+		numTaggedFields++
+	}
+
+	pe.putUVarint(numTaggedFields)
+	if b.DivergingEpoch != nil {
+		pe.putUVarint(0)
+		pe.putUVarint(12)
+		pe.putInt32(b.DivergingEpoch.Epoch)
+		pe.putInt64(b.DivergingEpoch.EndOffset)
+	}
+	if b.CurrentLeader != nil {
+		pe.putUVarint(1)
+		pe.putUVarint(8)
+		pe.putInt32(b.CurrentLeader.LeaderID)
+		pe.putInt32(b.CurrentLeader.LeaderEpoch)
+	}
 }
 
 func (b *FetchResponseBlock) getAbortedTransactions() []*AbortedTransaction {
@@ -348,9 +454,13 @@ func (r *FetchResponse) decode(pd packetDecoder, version int16) (err error) {
 			}
 			r.Blocks[name][id] = block
 		}
+		if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+			return err
+		}
 	}
 
-	return nil
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
 }
 
 func (r *FetchResponse) encode(pe packetEncoder) (err error) {
@@ -386,7 +496,9 @@ func (r *FetchResponse) encode(pe packetEncoder) (err error) {
 				return err
 			}
 		}
+		pe.putEmptyTaggedFieldArray()
 	}
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
@@ -399,15 +511,28 @@ func (r *FetchResponse) version() int16 {
 }
 
 func (r *FetchResponse) headerVersion() int16 {
+	if r.Version >= 12 {
+		return 1
+	}
 	return 0
 }
 
 func (r *FetchResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 11
+	return r.Version >= 0 && r.Version <= 12
+}
+
+func (r *FetchResponse) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *FetchResponse) isFlexibleVersion(version int16) bool {
+	return version >= 12
 }
 
 func (r *FetchResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 12:
+		return V2_7_0_0
 	case 11:
 		return V2_3_0_0
 	case 9, 10:

--- a/fetch_response_test.go
+++ b/fetch_response_test.go
@@ -6,6 +6,9 @@ import (
 	"bytes"
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -201,6 +204,57 @@ var (
 		0x00,
 		0xFF, 0xFF, 0xFF, 0xFF,
 		0x00, 0x00, 0x00, 0x02, 0x00, 0xEE,
+	}
+
+	preferredReplicaFetchResponseV12 = []byte{
+		0x00, 0x00, 0x00, 0x00, // ThrottleTime
+		0x00, 0x02, // ErrorCode
+		0x00, 0x00, 0x00, 0xAC, // SessionID
+		0x02,                          // Topics
+		0x06, 't', 'o', 'p', 'i', 'c', // Topic
+		0x02,                   // Partitions
+		0x00, 0x00, 0x00, 0x05, // Partition
+		0x00, 0x01, // Error
+		0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10, 0x10, // High Watermark Offset
+		0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10, 0x09, // Last Stable Offset
+		0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, // Log Start Offset
+		0x01,                   // Aborted Transactions
+		0x00, 0x00, 0x00, 0x03, // Preferred Read Replica
+		0x01,                   // Records
+		0x02,                   // Partition tagged fields
+		0x00,                   // DivergingEpoch tag
+		0x0C,                   // DivergingEpoch tag size
+		0x00, 0x00, 0x00, 0x77, // DivergingEpoch epoch
+		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // DivergingEpoch end offset
+		0x01,                   // CurrentLeader tag
+		0x08,                   // CurrentLeader tag size
+		0x00, 0x00, 0x00, 0x09, // CurrentLeader leader ID
+		0x00, 0x00, 0x00, 0x88, // CurrentLeader leader epoch
+		0x00, // Topic tagged fields
+		0x00, // Response tagged fields
+	}
+
+	abortedTxnFetchResponseV12 = []byte{
+		0x00, 0x00, 0x00, 0x00, // ThrottleTime
+		0x00, 0x00, // ErrorCode
+		0x00, 0x00, 0x00, 0xAC, // SessionID
+		0x02,                          // Topics
+		0x06, 't', 'o', 'p', 'i', 'c', // Topic
+		0x02,                   // Partitions
+		0x00, 0x00, 0x00, 0x05, // Partition
+		0x00, 0x00, // Error
+		0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10, 0x10, // High Watermark Offset
+		0x00, 0x00, 0x00, 0x00, 0x10, 0x10, 0x10, 0x09, // Last Stable Offset
+		0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, // Log Start Offset
+		0x02,                                           // Aborted Transactions
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xE8, // ProducerID
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x42, // FirstOffset
+		0x00,                   // AbortedTransaction tagged fields
+		0xFF, 0xFF, 0xFF, 0xFF, // Preferred Read Replica
+		0x01, // Records
+		0x00, // Partition tagged fields
+		0x00, // Topic tagged fields
+		0x00, // Response tagged fields
 	}
 )
 
@@ -527,74 +581,147 @@ func TestOneMessageFetchResponseV4(t *testing.T) {
 	}
 }
 
-func TestPreferredReplicaFetchResponseV11(t *testing.T) {
-	response := FetchResponse{}
-	testVersionDecodable(
-		t, "preferred replica fetch response v11", &response,
-		preferredReplicaFetchResponseV11, 11)
+func TestPreferredReplicaFetchResponse(t *testing.T) {
+	t.Run("decodes v11", func(t *testing.T) {
+		response := FetchResponse{}
+		testVersionDecodable(
+			t, "preferred replica fetch response v11", &response,
+			preferredReplicaFetchResponseV11, 11)
 
-	if response.ErrorCode != 0x0002 {
-		t.Fatal("Decoding produced incorrect error code.")
-	}
+		if response.ErrorCode != 0x0002 {
+			t.Fatal("Decoding produced incorrect error code.")
+		}
 
-	if response.SessionID != 0x000000AC {
-		t.Fatal("Decoding produced incorrect session ID.")
-	}
+		if response.SessionID != 0x000000AC {
+			t.Fatal("Decoding produced incorrect session ID.")
+		}
 
-	if len(response.Blocks) != 1 {
-		t.Fatal("Decoding produced incorrect number of topic blocks.")
-	}
+		if len(response.Blocks) != 1 {
+			t.Fatal("Decoding produced incorrect number of topic blocks.")
+		}
 
-	if len(response.Blocks["topic"]) != 1 {
-		t.Fatal("Decoding produced incorrect number of partition blocks for topic.")
-	}
+		if len(response.Blocks["topic"]) != 1 {
+			t.Fatal("Decoding produced incorrect number of partition blocks for topic.")
+		}
 
-	block := response.GetBlock("topic", 5)
-	if block == nil {
-		t.Fatal("GetBlock didn't return block.")
-	}
-	if !errors.Is(block.Err, ErrOffsetOutOfRange) {
-		t.Error("Decoding didn't produce correct error code.")
-	}
-	if block.HighWaterMarkOffset != 0x10101010 {
-		t.Error("Decoding didn't produce correct high water mark offset.")
-	}
-	if block.LastStableOffset != 0x10101009 {
-		t.Error("Decoding didn't produce correct last stable offset.")
-	}
-	if block.LogStartOffset != 0x01010101 {
-		t.Error("Decoding didn't produce correct log start offset.")
-	}
-	if block.PreferredReadReplica != 0x0003 {
-		t.Error("Decoding didn't produce correct preferred read replica.")
-	}
-	partial, err := block.isPartial()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if partial {
-		t.Error("Decoding detected a partial trailing record where there wasn't one.")
-	}
+		block := response.GetBlock("topic", 5)
+		if block == nil {
+			t.Fatal("GetBlock didn't return block.")
+		}
+		if !errors.Is(block.Err, ErrOffsetOutOfRange) {
+			t.Error("Decoding didn't produce correct error code.")
+		}
+		if block.HighWaterMarkOffset != 0x10101010 {
+			t.Error("Decoding didn't produce correct high water mark offset.")
+		}
+		if block.LastStableOffset != 0x10101009 {
+			t.Error("Decoding didn't produce correct last stable offset.")
+		}
+		if block.LogStartOffset != 0x01010101 {
+			t.Error("Decoding didn't produce correct log start offset.")
+		}
+		if block.PreferredReadReplica != 0x0003 {
+			t.Error("Decoding didn't produce correct preferred read replica.")
+		}
+		partial, err := block.isPartial()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if partial {
+			t.Error("Decoding detected a partial trailing record where there wasn't one.")
+		}
 
-	n, err := block.numRecords()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-	if n != 1 {
-		t.Fatal("Decoding produced incorrect number of records.")
-	}
-	msgBlock := block.RecordsSet[0].MsgSet.Messages[0]
-	if msgBlock.Offset != 0x550000 {
-		t.Error("Decoding produced incorrect message offset.")
-	}
-	msg := msgBlock.Msg
-	if msg.Codec != CompressionNone {
-		t.Error("Decoding produced incorrect message compression.")
-	}
-	if msg.Key != nil {
-		t.Error("Decoding produced message key where there was none.")
-	}
-	if !bytes.Equal(msg.Value, []byte{0x00, 0xEE}) {
-		t.Error("Decoding produced incorrect message value.")
-	}
+		n, err := block.numRecords()
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if n != 1 {
+			t.Fatal("Decoding produced incorrect number of records.")
+		}
+		msgBlock := block.RecordsSet[0].MsgSet.Messages[0]
+		if msgBlock.Offset != 0x550000 {
+			t.Error("Decoding produced incorrect message offset.")
+		}
+		msg := msgBlock.Msg
+		if msg.Codec != CompressionNone {
+			t.Error("Decoding produced incorrect message compression.")
+		}
+		if msg.Key != nil {
+			t.Error("Decoding produced message key where there was none.")
+		}
+		if !bytes.Equal(msg.Value, []byte{0x00, 0xEE}) {
+			t.Error("Decoding produced incorrect message value.")
+		}
+	})
+
+	t.Run("round trips v12 tagged fields", func(t *testing.T) {
+		response := &FetchResponse{
+			Version:   12,
+			ErrorCode: 0x0002,
+			SessionID: 0x000000AC,
+			Blocks: map[string]map[int32]*FetchResponseBlock{
+				"topic": {
+					5: {
+						Err:                  ErrOffsetOutOfRange,
+						HighWaterMarkOffset:  0x10101010,
+						LastStableOffset:     0x10101009,
+						LogStartOffset:       0x01010101,
+						AbortedTransactions:  []*AbortedTransaction{},
+						PreferredReadReplica: 0x0003,
+						RecordsSet:           []*Records{},
+						DivergingEpoch: &FetchResponseDivergingEpoch{
+							Epoch:     0x77,
+							EndOffset: 0x0102030405060708,
+						},
+						CurrentLeader: &FetchResponseCurrentLeader{
+							LeaderID:    0x09,
+							LeaderEpoch: 0x88,
+						},
+					},
+				},
+			},
+		}
+		testResponse(t, "preferred replica fetch response v12", response, preferredReplicaFetchResponseV12)
+
+		decoded := &FetchResponse{}
+		require.NoError(t, versionedDecode(preferredReplicaFetchResponseV12, decoded, 12, nil))
+		block := decoded.GetBlock("topic", 5)
+		require.NotNil(t, block)
+		require.NotNil(t, block.DivergingEpoch)
+		require.NotNil(t, block.CurrentLeader)
+		assert.Equal(t, int32(0x77), block.DivergingEpoch.Epoch)
+		assert.Equal(t, int64(0x0102030405060708), block.DivergingEpoch.EndOffset)
+		assert.Equal(t, int32(0x09), block.CurrentLeader.LeaderID)
+		assert.Equal(t, int32(0x88), block.CurrentLeader.LeaderEpoch)
+	})
+
+	t.Run("round trips v12 aborted transactions", func(t *testing.T) {
+		response := &FetchResponse{
+			Version:   12,
+			SessionID: 0x000000AC,
+			Blocks: map[string]map[int32]*FetchResponseBlock{
+				"topic": {
+					5: {
+						HighWaterMarkOffset: 0x10101010,
+						LastStableOffset:    0x10101009,
+						LogStartOffset:      0x01010101,
+						AbortedTransactions: []*AbortedTransaction{
+							{ProducerID: 1000, FirstOffset: 0x42},
+						},
+						PreferredReadReplica: -1,
+						RecordsSet:           []*Records{},
+					},
+				},
+			},
+		}
+		testResponse(t, "aborted txn fetch response v12", response, abortedTxnFetchResponseV12)
+
+		decoded := &FetchResponse{}
+		require.NoError(t, versionedDecode(abortedTxnFetchResponseV12, decoded, 12, nil))
+		block := decoded.GetBlock("topic", 5)
+		require.NotNil(t, block)
+		require.Len(t, block.AbortedTransactions, 1)
+		assert.Equal(t, int64(1000), block.AbortedTransactions[0].ProducerID)
+		assert.Equal(t, int64(0x42), block.AbortedTransactions[0].FirstOffset)
+	})
 }

--- a/prep_encoder.go
+++ b/prep_encoder.go
@@ -197,6 +197,10 @@ func (pe *prepFlexibleEncoder) putArrayLength(in int) error {
 }
 
 func (pe *prepFlexibleEncoder) putBytes(in []byte) error {
+	if in == nil {
+		pe.putUVarint(0)
+		return nil
+	}
 	pe.putUVarint(uint64(len(in) + 1))
 	return pe.putRawBytes(in)
 }

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -472,6 +472,9 @@ func (rd *realFlexibleDecoder) getBytes() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if n == 0 {
+		return nil, nil
+	}
 	if n > 0 && n-1 > uint64(rd.remaining()) {
 		rd.off = len(rd.raw)
 		return nil, ErrInsufficientData

--- a/real_encoder.go
+++ b/real_encoder.go
@@ -204,6 +204,10 @@ func (re *realFlexibleEncoder) putArrayLength(in int) error {
 }
 
 func (re *realFlexibleEncoder) putBytes(in []byte) error {
+	if in == nil {
+		re.putUVarint(0)
+		return nil
+	}
 	re.putUVarint(uint64(len(in) + 1))
 	return re.putRawBytes(in)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -397,14 +397,13 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V2_7_0_0,
 			map[int16]int16{
-				apiKeyInitProducerId:               4, // up from 3
-				apiKeyAddPartitionsToTxn:           2, // up from 1
-				apiKeyAddOffsetsToTxn:              2, // up from 1
-				apiKeyEndTxn:                       2, // up from 1
-				apiKeyDescribeUserScramCredentials: 0, // new in 2.7
-				apiKeyAlterUserScramCredentials:    0, // new in 2.7
-				// TODO: FetchRequest v12 is not supported, but expected for KafkaVersion 2.7.0
-				// apiKeyFetch:            12, // up from 11
+				apiKeyInitProducerId:               4,  // up from 3
+				apiKeyAddPartitionsToTxn:           2,  // up from 1
+				apiKeyAddOffsetsToTxn:              2,  // up from 1
+				apiKeyEndTxn:                       2,  // up from 1
+				apiKeyDescribeUserScramCredentials: 0,  // new in 2.7
+				apiKeyAlterUserScramCredentials:    0,  // new in 2.7
+				apiKeyFetch:                        12, // up from 11
 				// TODO: CreateTopicsRequest v6 is not supported, but expected for KafkaVersion 2.7.0
 				// apiKeyCreateTopics:     6, // up from 5
 				// TODO: DeleteTopicsRequest v5 is not supported, but expected for KafkaVersion 2.7.0


### PR DESCRIPTION
Add Kafka 2.7 Fetch protocol support with flexible encoding, request last-fetched epoch, and response diverging-epoch/current-leader tagged fields.

Also fix nil handling in the flexible bytes codec: a nil slice now encodes as a compact null (0x00) rather than an empty string (0x01), and zero-length compact bytes decode to nil. This affects all flexible messages passing nil through putBytes, not just Fetch.