### PR TITLE
fix: avoid makeslice panic in request decode too

### DIFF
--- a/acl_create_request.go
+++ b/acl_create_request.go
@@ -31,6 +31,9 @@ func (c *CreateAclsRequest) decode(pd packetDecoder, version int16) (err error) 
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	c.AclCreations = make([]*AclCreation, n)
 

--- a/acl_delete_request.go
+++ b/acl_delete_request.go
@@ -32,6 +32,9 @@ func (d *DeleteAclsRequest) decode(pd packetDecoder, version int16) (err error) 
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	d.Filters = make([]*AclFilter, n)
 	for i := 0; i < n; i++ {

--- a/add_partitions_to_txn_request.go
+++ b/add_partitions_to_txn_request.go
@@ -50,6 +50,9 @@ func (a *AddPartitionsToTxnRequest) decode(pd packetDecoder, version int16) (err
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	a.TopicPartitions = make(map[string][]int32)
 	for i := 0; i < n; i++ {

--- a/alter_client_quotas_request.go
+++ b/alter_client_quotas_request.go
@@ -55,6 +55,9 @@ func (a *AlterClientQuotasRequest) decode(pd packetDecoder, version int16) error
 	if err != nil {
 		return err
 	}
+	if entryCount < 0 {
+		return errInvalidArrayLength
+	}
 	if entryCount > 0 {
 		a.Entries = make([]AlterClientQuotasEntry, entryCount)
 		for i := range a.Entries {
@@ -108,6 +111,9 @@ func (a *AlterClientQuotasEntry) decode(pd packetDecoder, version int16) error {
 	if err != nil {
 		return err
 	}
+	if componentCount < 0 {
+		return errInvalidArrayLength
+	}
 	if componentCount > 0 {
 		a.Entity = make([]QuotaEntityComponent, componentCount)
 		for i := 0; i < componentCount; i++ {
@@ -125,6 +131,9 @@ func (a *AlterClientQuotasEntry) decode(pd packetDecoder, version int16) error {
 	opCount, err := pd.getArrayLength()
 	if err != nil {
 		return err
+	}
+	if opCount < 0 {
+		return errInvalidArrayLength
 	}
 	if opCount > 0 {
 		a.Ops = make([]ClientQuotasOp, opCount)

--- a/alter_configs_request.go
+++ b/alter_configs_request.go
@@ -101,6 +101,9 @@ func (a *AlterConfigsResource) decode(pd packetDecoder, version int16) error {
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	if n > 0 {
 		a.ConfigEntries = make(map[string]*string, n)

--- a/alter_configs_request.go
+++ b/alter_configs_request.go
@@ -38,6 +38,9 @@ func (a *AlterConfigsRequest) decode(pd packetDecoder, version int16) error {
 	if err != nil {
 		return err
 	}
+	if resourceCount < 0 {
+		return errInvalidArrayLength
+	}
 
 	a.Resources = make([]*AlterConfigsResource, resourceCount)
 	for i := range a.Resources {

--- a/alter_partition_reassignments_request.go
+++ b/alter_partition_reassignments_request.go
@@ -72,6 +72,9 @@ func (r *AlterPartitionReassignmentsRequest) decode(pd packetDecoder, version in
 	if err != nil {
 		return err
 	}
+	if topicCount < 0 {
+		return errInvalidArrayLength
+	}
 	if topicCount > 0 {
 		r.blocks = make(map[string]map[int32]*alterPartitionReassignmentsBlock)
 		for i := 0; i < topicCount; i++ {
@@ -82,6 +85,9 @@ func (r *AlterPartitionReassignmentsRequest) decode(pd packetDecoder, version in
 			partitionCount, err := pd.getArrayLength()
 			if err != nil {
 				return err
+			}
+			if partitionCount < 0 {
+				return errInvalidArrayLength
 			}
 			r.blocks[topic] = make(map[int32]*alterPartitionReassignmentsBlock)
 			for j := 0; j < partitionCount; j++ {

--- a/alter_user_scram_credentials_request.go
+++ b/alter_user_scram_credentials_request.go
@@ -79,6 +79,9 @@ func (r *AlterUserScramCredentialsRequest) decode(pd packetDecoder, version int1
 	if err != nil {
 		return err
 	}
+	if numDeletions < 0 {
+		return errInvalidArrayLength
+	}
 
 	r.Deletions = make([]AlterUserScramCredentialsDelete, numDeletions)
 	for i := 0; i < numDeletions; i++ {
@@ -99,6 +102,9 @@ func (r *AlterUserScramCredentialsRequest) decode(pd packetDecoder, version int1
 	numUpsertions, err := pd.getArrayLength()
 	if err != nil {
 		return err
+	}
+	if numUpsertions < 0 {
+		return errInvalidArrayLength
 	}
 
 	r.Upsertions = make([]AlterUserScramCredentialsUpsert, numUpsertions)

--- a/create_partitions_request.go
+++ b/create_partitions_request.go
@@ -40,6 +40,9 @@ func (c *CreatePartitionsRequest) decode(pd packetDecoder, version int16) (err e
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 	c.TopicPartitions = make(map[string]*TopicPartition, n)
 	for i := 0; i < n; i++ {
 		topic, err := pd.getString()

--- a/create_topics_request.go
+++ b/create_topics_request.go
@@ -77,6 +77,9 @@ func (c *CreateTopicsRequest) decode(pd packetDecoder, version int16) (err error
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	c.TopicDetails = make(map[string]*TopicDetail, n)
 
@@ -215,6 +218,9 @@ func (t *TopicDetail) decode(pd packetDecoder, version int16) (err error) {
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	if n > 0 {
 		t.ReplicaAssignment = make(map[int32][]int32, n)
@@ -235,6 +241,9 @@ func (t *TopicDetail) decode(pd packetDecoder, version int16) (err error) {
 	n, err = pd.getArrayLength()
 	if err != nil {
 		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
 	}
 
 	if n > 0 {

--- a/delete_records_request.go
+++ b/delete_records_request.go
@@ -52,6 +52,9 @@ func (d *DeleteRecordsRequest) decode(pd packetDecoder, version int16) error {
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	if n > 0 {
 		d.Topics = make(map[string]*DeleteRecordsRequestTopic, n)
@@ -145,6 +148,9 @@ func (t *DeleteRecordsRequestTopic) decode(pd packetDecoder, version int16) erro
 	n, err := pd.getArrayLength()
 	if err != nil {
 		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
 	}
 
 	if n > 0 {

--- a/describe_client_quotas_request.go
+++ b/describe_client_quotas_request.go
@@ -73,6 +73,9 @@ func (d *DescribeClientQuotasRequest) decode(pd packetDecoder, version int16) er
 	if err != nil {
 		return err
 	}
+	if componentCount < 0 {
+		return errInvalidArrayLength
+	}
 	if componentCount > 0 {
 		d.Components = make([]QuotaFilterComponent, componentCount)
 		for i := range d.Components {

--- a/describe_configs_request.go
+++ b/describe_configs_request.go
@@ -81,7 +81,7 @@ func (r *DescribeConfigsRequest) decode(pd packetDecoder, version int16) (err er
 			return err
 		}
 
-		if confLength != -1 {
+		if confLength >= 0 {
 			cfnames := make([]string, confLength)
 			for i := 0; i < confLength; i++ {
 				s, err := pd.getString()

--- a/describe_configs_request.go
+++ b/describe_configs_request.go
@@ -57,6 +57,9 @@ func (r *DescribeConfigsRequest) decode(pd packetDecoder, version int16) (err er
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	r.Resources = make([]*ConfigResource, n)
 

--- a/describe_log_dirs_request.go
+++ b/describe_log_dirs_request.go
@@ -51,7 +51,7 @@ func (r *DescribeLogDirsRequest) decode(pd packetDecoder, version int16) error {
 		return err
 	}
 
-	if n == -1 {
+	if n < 0 {
 		n = 0
 	}
 

--- a/describe_user_scram_credentials_request.go
+++ b/describe_user_scram_credentials_request.go
@@ -38,7 +38,7 @@ func (r *DescribeUserScramCredentialsRequest) decode(pd packetDecoder, version i
 	if err != nil {
 		return err
 	}
-	if n == -1 {
+	if n < 0 {
 		n = 0
 	}
 

--- a/elect_leaders_request.go
+++ b/elect_leaders_request.go
@@ -63,6 +63,9 @@ func (r *ElectLeadersRequest) decode(pd packetDecoder, version int16) (err error
 			if err != nil {
 				return err
 			}
+			if partitionCount < 0 {
+				return errInvalidArrayLength
+			}
 			partitions := make([]int32, partitionCount)
 			for j := 0; j < partitionCount; j++ {
 				partition, err := pd.getInt32()

--- a/fetch_request.go
+++ b/fetch_request.go
@@ -220,6 +220,9 @@ func (r *FetchRequest) decode(pd packetDecoder, version int16) (err error) {
 	if err != nil {
 		return err
 	}
+	if topicCount < 0 {
+		return errInvalidArrayLength
+	}
 	if topicCount == 0 && r.Version < 7 {
 		return nil
 	}
@@ -232,6 +235,9 @@ func (r *FetchRequest) decode(pd packetDecoder, version int16) (err error) {
 		partitionCount, err := pd.getArrayLength()
 		if err != nil {
 			return err
+		}
+		if partitionCount < 0 {
+			return errInvalidArrayLength
 		}
 		r.blocks[topic] = make(map[int32]*fetchRequestBlock)
 		for j := 0; j < partitionCount; j++ {
@@ -254,6 +260,9 @@ func (r *FetchRequest) decode(pd packetDecoder, version int16) (err error) {
 		forgottenCount, err := pd.getArrayLength()
 		if err != nil {
 			return err
+		}
+		if forgottenCount < 0 {
+			return errInvalidArrayLength
 		}
 		r.forgotten = make(map[string][]int32)
 		for i := 0; i < forgottenCount; i++ {

--- a/incremental_alter_configs_request.go
+++ b/incremental_alter_configs_request.go
@@ -53,6 +53,9 @@ func (a *IncrementalAlterConfigsRequest) decode(pd packetDecoder, version int16)
 	if err != nil {
 		return err
 	}
+	if resourceCount < 0 {
+		return errInvalidArrayLength
+	}
 
 	a.Resources = make([]*IncrementalAlterConfigsResource, resourceCount)
 	for i := range a.Resources {

--- a/incremental_alter_configs_request.go
+++ b/incremental_alter_configs_request.go
@@ -120,6 +120,9 @@ func (a *IncrementalAlterConfigsResource) decode(pd packetDecoder, version int16
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	if n > 0 {
 		a.ConfigEntries = make(map[string]IncrementalAlterConfigsEntry, n)

--- a/join_group_request.go
+++ b/join_group_request.go
@@ -158,6 +158,9 @@ func (r *JoinGroupRequest) decode(pd packetDecoder, version int16) (err error) {
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	if n > 0 {
 		r.GroupProtocols = make(map[string][]byte)

--- a/leave_group_request.go
+++ b/leave_group_request.go
@@ -65,6 +65,9 @@ func (r *LeaveGroupRequest) decode(pd packetDecoder, version int16) (err error) 
 		if err != nil {
 			return err
 		}
+		if memberCount < 0 {
+			return errInvalidArrayLength
+		}
 		r.Members = make([]MemberIdentity, memberCount)
 		for i := 0; i < memberCount; i++ {
 			memberIdentity := MemberIdentity{}

--- a/list_partition_reassignments_request.go
+++ b/list_partition_reassignments_request.go
@@ -56,6 +56,9 @@ func (r *ListPartitionReassignmentsRequest) decode(pd packetDecoder, version int
 			if err != nil {
 				return err
 			}
+			if partitionCount < 0 {
+				return errInvalidArrayLength
+			}
 			r.blocks[topic] = make([]int32, partitionCount)
 			for j := 0; j < partitionCount; j++ {
 				partition, err := pd.getInt32()

--- a/offset_commit_request.go
+++ b/offset_commit_request.go
@@ -217,6 +217,9 @@ func (r *OffsetCommitRequest) decode(pd packetDecoder, version int16) (err error
 	if err != nil {
 		return err
 	}
+	if topicCount < 0 {
+		return errInvalidArrayLength
+	}
 	if topicCount > 0 {
 		r.blocks = make(map[string]map[int32]*offsetCommitRequestBlock)
 		for i := 0; i < topicCount; i++ {
@@ -227,6 +230,9 @@ func (r *OffsetCommitRequest) decode(pd packetDecoder, version int16) (err error
 			partitionCount, err := pd.getArrayLength()
 			if err != nil {
 				return err
+			}
+			if partitionCount < 0 {
+				return errInvalidArrayLength
 			}
 			r.blocks[topic] = make(map[int32]*offsetCommitRequestBlock)
 			for j := 0; j < partitionCount; j++ {

--- a/offset_fetch_request.go
+++ b/offset_fetch_request.go
@@ -172,6 +172,9 @@ func (r *OffsetFetchRequest) decode(pd packetDecoder, version int16) (err error)
 		if err != nil {
 			return err
 		}
+		if groupCount < 0 {
+			return errInvalidArrayLength
+		}
 		if groupCount > 0 {
 			r.Groups = make([]OffsetFetchRequestGroup, groupCount)
 		}

--- a/offset_request.go
+++ b/offset_request.go
@@ -140,6 +140,9 @@ func (r *OffsetRequest) decode(pd packetDecoder, version int16) error {
 	if err != nil {
 		return err
 	}
+	if blockCount < 0 {
+		return errInvalidArrayLength
+	}
 	if blockCount == 0 {
 		return nil
 	}
@@ -152,6 +155,9 @@ func (r *OffsetRequest) decode(pd packetDecoder, version int16) error {
 		partitionCount, err := pd.getArrayLength()
 		if err != nil {
 			return err
+		}
+		if partitionCount < 0 {
+			return errInvalidArrayLength
 		}
 		r.blocks[topic] = make(map[int32]*offsetRequestBlock)
 		for j := 0; j < partitionCount; j++ {

--- a/produce_request.go
+++ b/produce_request.go
@@ -166,6 +166,9 @@ func (r *ProduceRequest) decode(pd packetDecoder, version int16) error {
 	if err != nil {
 		return err
 	}
+	if topicCount < 0 {
+		return errInvalidArrayLength
+	}
 	if topicCount == 0 {
 		return nil
 	}
@@ -179,6 +182,9 @@ func (r *ProduceRequest) decode(pd packetDecoder, version int16) error {
 		partitionCount, err := pd.getArrayLength()
 		if err != nil {
 			return err
+		}
+		if partitionCount < 0 {
+			return errInvalidArrayLength
 		}
 		r.records[topic] = make(map[int32]Records)
 

--- a/sync_group_request.go
+++ b/sync_group_request.go
@@ -126,6 +126,8 @@ func (s *SyncGroupRequest) decode(pd packetDecoder, version int16) (err error) {
 
 	if numAssignments, err := pd.getArrayLength(); err != nil {
 		return err
+	} else if numAssignments < 0 {
+		return errInvalidArrayLength
 	} else if numAssignments > 0 {
 		s.GroupAssignments = make([]SyncGroupRequestAssignment, numAssignments)
 		for i := 0; i < numAssignments; i++ {

--- a/txn_offset_commit_request.go
+++ b/txn_offset_commit_request.go
@@ -101,6 +101,9 @@ func (t *TxnOffsetCommitRequest) decode(pd packetDecoder, version int16) (err er
 		if err != nil {
 			return err
 		}
+		if m < 0 {
+			return errInvalidArrayLength
+		}
 
 		t.Topics[topic] = make([]*PartitionOffsetMetadata, m)
 

--- a/txn_offset_commit_request.go
+++ b/txn_offset_commit_request.go
@@ -89,6 +89,9 @@ func (t *TxnOffsetCommitRequest) decode(pd packetDecoder, version int16) (err er
 	if err != nil {
 		return err
 	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
 
 	t.Topics = make(map[string][]*PartitionOffsetMetadata)
 	for i := 0; i < n; i++ {


### PR DESCRIPTION
Commit 0931fbcf added this robustness check to the response decode, which are what sarama as a client to decode over-the-wire replies. We do currently have decode implemented also for our request structs, even though Sarama itself never needs to decode them outside of unittests, it makes sense to add the same robustness fix just for feature parity and for any 3rdparty using the decodes in wireshark or similar.