### PR TITLE
chore: clean up Int32 array encode/decode

### DIFF
--- a/alter_partition_reassignments_request.go
+++ b/alter_partition_reassignments_request.go
@@ -14,7 +14,7 @@ func (b *alterPartitionReassignmentsBlock) encode(pe packetEncoder) error {
 }
 
 func (b *alterPartitionReassignmentsBlock) decode(pd packetDecoder) (err error) {
-	if b.replicas, err = pd.getInt32Array(); err != nil {
+	if b.replicas, err = pd.getNullableInt32Array(); err != nil {
 		return err
 	}
 	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {

--- a/elect_leaders_request.go
+++ b/elect_leaders_request.go
@@ -59,22 +59,9 @@ func (r *ElectLeadersRequest) decode(pd packetDecoder, version int16) (err error
 			if err != nil {
 				return err
 			}
-			partitionCount, err := pd.getArrayLength()
-			if err != nil {
+			if r.TopicPartitions[topic], err = pd.getInt32Array(); err != nil {
 				return err
 			}
-			if partitionCount < 0 {
-				return errInvalidArrayLength
-			}
-			partitions := make([]int32, partitionCount)
-			for j := 0; j < partitionCount; j++ {
-				partition, err := pd.getInt32()
-				if err != nil {
-					return err
-				}
-				partitions[j] = partition
-			}
-			r.TopicPartitions[topic] = partitions
 			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
 				return err
 			}

--- a/fetch_request.go
+++ b/fetch_request.go
@@ -1,7 +1,5 @@
 package sarama
 
-import "fmt"
-
 type fetchRequestBlock struct {
 	Version int16
 	// currentLeaderEpoch contains the current leader epoch of the partition.
@@ -161,12 +159,9 @@ func (r *FetchRequest) encode(pe packetEncoder) (err error) {
 			if err != nil {
 				return err
 			}
-			err = pe.putArrayLength(len(partitions))
+			err = pe.putInt32Array(partitions)
 			if err != nil {
 				return err
-			}
-			for _, partition := range partitions {
-				pe.putInt32(partition)
 			}
 			pe.putEmptyTaggedFieldArray()
 		}
@@ -270,21 +265,8 @@ func (r *FetchRequest) decode(pd packetDecoder, version int16) (err error) {
 			if err != nil {
 				return err
 			}
-			partitionCount, err := pd.getArrayLength()
-			if err != nil {
+			if r.forgotten[topic], err = pd.getInt32Array(); err != nil {
 				return err
-			}
-			if partitionCount < 0 {
-				return fmt.Errorf("partitionCount %d is invalid", partitionCount)
-			}
-			r.forgotten[topic] = make([]int32, partitionCount)
-
-			for j := 0; j < partitionCount; j++ {
-				partition, err := pd.getInt32()
-				if err != nil {
-					return err
-				}
-				r.forgotten[topic][j] = partition
 			}
 			if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
 				return err

--- a/list_partition_reassignments_request.go
+++ b/list_partition_reassignments_request.go
@@ -52,20 +52,8 @@ func (r *ListPartitionReassignmentsRequest) decode(pd packetDecoder, version int
 			if err != nil {
 				return err
 			}
-			partitionCount, err := pd.getArrayLength()
-			if err != nil {
+			if r.blocks[topic], err = pd.getInt32Array(); err != nil {
 				return err
-			}
-			if partitionCount < 0 {
-				return errInvalidArrayLength
-			}
-			r.blocks[topic] = make([]int32, partitionCount)
-			for j := 0; j < partitionCount; j++ {
-				partition, err := pd.getInt32()
-				if err != nil {
-					return err
-				}
-				r.blocks[topic][j] = partition
 			}
 			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
 				return err

--- a/packet_decoder.go
+++ b/packet_decoder.go
@@ -35,6 +35,7 @@ type packetDecoder interface {
 	getString() (string, error)
 	getNullableString() (*string, error)
 	getInt32Array() ([]int32, error)
+	getNullableInt32Array() ([]int32, error)
 	getInt64Array() ([]int64, error)
 	getStringArray() ([]string, error)
 

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -233,12 +233,15 @@ func (rd *realDecoder) getNullableString() (*string, error) {
 	return &tmpStr, err
 }
 
-func (rd *realDecoder) getInt32Array() ([]int32, error) {
+func (rd *realDecoder) getNullableInt32Array() ([]int32, error) {
 	n, err := rd.getArrayLength()
 	if err != nil {
 		return nil, err
 	}
-	if n <= 0 {
+	if n < -1 {
+		return nil, errInvalidArrayLength
+	}
+	if n == -1 {
 		return nil, nil
 	}
 
@@ -253,6 +256,14 @@ func (rd *realDecoder) getInt32Array() ([]int32, error) {
 		rd.off += 4
 	}
 	return ret, nil
+}
+
+func (rd *realDecoder) getInt32Array() ([]int32, error) {
+	ret, err := rd.getNullableInt32Array()
+	if ret == nil && err == nil {
+		return nil, errInvalidArrayLength
+	}
+	return ret, err
 }
 
 func (rd *realDecoder) getInt64Array() ([]int64, error) {
@@ -533,6 +544,14 @@ func (rd *realFlexibleDecoder) getNullableString() (*string, error) {
 }
 
 func (rd *realFlexibleDecoder) getInt32Array() ([]int32, error) {
+	ret, err := rd.getNullableInt32Array()
+	if ret == nil && err == nil {
+		return nil, errInvalidArrayLength
+	}
+	return ret, err
+}
+
+func (rd *realFlexibleDecoder) getNullableInt32Array() ([]int32, error) {
 	n, err := rd.getUVarint()
 	if err != nil {
 		return nil, err

--- a/real_decoder_test.go
+++ b/real_decoder_test.go
@@ -82,7 +82,179 @@ func makeInput(length int) []byte {
 	return input
 }
 
+func TestRealDecoderGetNullableInt32Array(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    []int32
+		wantErr error
+	}{
+		{
+			name:  "null array",
+			input: []byte{0xFF, 0xFF, 0xFF, 0xFF},
+		},
+		{
+			name:  "empty array",
+			input: []byte{0x00, 0x00, 0x00, 0x00},
+			want:  []int32{},
+		},
+		{
+			name:  "valid array",
+			input: []byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02},
+			want:  []int32{1, 2},
+		},
+		{
+			name:    "insufficient data for length",
+			input:   []byte{0x00, 0x00, 0x00},
+			wantErr: ErrInsufficientData,
+		},
+		{
+			name:    "insufficient data for elements",
+			input:   []byte{0x00, 0x00, 0x00, 0x02},
+			wantErr: ErrInsufficientData,
+		},
+		{
+			name:    "invalid length",
+			input:   []byte{0x80, 0x00, 0x00, 0x00},
+			wantErr: errInvalidArrayLength,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rd := &realDecoder{raw: tt.input}
+			got, err := rd.getNullableInt32Array()
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRealDecoderGetInt32Array(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    []int32
+		wantErr error
+	}{
+		{
+			name:    "null array",
+			input:   []byte{0xFF, 0xFF, 0xFF, 0xFF},
+			wantErr: errInvalidArrayLength,
+		},
+		{
+			name:  "empty array",
+			input: []byte{0x00, 0x00, 0x00, 0x00},
+			want:  []int32{},
+		},
+		{
+			name:  "valid array",
+			input: []byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02},
+			want:  []int32{1, 2},
+		},
+		{
+			name:    "insufficient data for length",
+			input:   []byte{0x00, 0x00, 0x00},
+			wantErr: ErrInsufficientData,
+		},
+		{
+			name:    "insufficient data for elements",
+			input:   []byte{0x00, 0x00, 0x00, 0x02},
+			wantErr: ErrInsufficientData,
+		},
+		{
+			name:    "invalid length",
+			input:   []byte{0x80, 0x00, 0x00, 0x00},
+			wantErr: errInvalidArrayLength,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rd := &realDecoder{raw: tt.input}
+			got, err := rd.getInt32Array()
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestRealFlexibleDecoderGetNullableInt32Array(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    []int32
+		wantErr error
+	}{
+		{
+			name:  "null array",
+			input: []byte{0x00},
+		},
+		{
+			name:  "empty array",
+			input: []byte{0x01},
+			want:  []int32{},
+		},
+		{
+			name:  "valid array",
+			input: []byte{0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02},
+			want:  []int32{1, 2},
+		},
+		{
+			name:    "insufficient data",
+			input:   []byte{0x03},
+			wantErr: ErrInsufficientData,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rd := &realFlexibleDecoder{&realDecoder{raw: tt.input}}
+			got, err := rd.getNullableInt32Array()
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestRealFlexibleDecoderGetInt32Array(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    []int32
+		wantErr error
+	}{
+		{
+			name:    "null array",
+			input:   []byte{0x00},
+			wantErr: errInvalidArrayLength,
+		},
+		{
+			name:  "empty array",
+			input: []byte{0x01},
+			want:  []int32{},
+		},
+		{
+			name:    "valid array",
+			input:   []byte{0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02},
+			want:    []int32{1, 2},
+			wantErr: nil,
+		},
+		{
+			name:    "insufficient data",
+			input:   []byte{0x03},
+			wantErr: ErrInsufficientData,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rd := &realFlexibleDecoder{&realDecoder{raw: tt.input}}
+			got, err := rd.getInt32Array()
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 	t.Run("returns insufficient data for compact length exceeding int64", func(t *testing.T) {
 		var input [binary.MaxVarintLen64]byte
 		n := binary.PutUvarint(input[:], 1<<63)


### PR DESCRIPTION
Add explicit nullable version and ensure we use the helpers in a few more cases.

Compared to a recent PR, I made a different choice about lengths less than -1. I chose to make them an error rather than assuming the sender "meant" -1. There are lots of values of int16 < -1 giving lots of ways to accidentally be accepted if we don't treat them as errors and supposing we have a corrupt/incorrect packet, it will likely still error on subsequent data anyway so it is less confusing to fail on the first error and not accept the length < -1.