### PR TITLE
feat: support CreateTopics v6

### DIFF
--- a/create_topics_request.go
+++ b/create_topics_request.go
@@ -32,6 +32,9 @@ func NewCreateTopicsRequest(
 		ValidateOnly: validateOnly,
 	}
 	switch {
+	case version.IsAtLeast(V2_7_0_0):
+		// version 6 may return THROTTLING_QUOTA_EXCEEDED
+		r.Version = 6
 	case version.IsAtLeast(V2_4_0_0):
 		// Version 5 is the first flexible version
 		// Version 4 makes partitions/replicationFactor optional even when assignments are not present (KIP-464)
@@ -136,11 +139,13 @@ func (c *CreateTopicsRequest) isFlexibleVersion(version int16) bool {
 }
 
 func (c *CreateTopicsRequest) isValidVersion() bool {
-	return c.Version >= 0 && c.Version <= 5
+	return c.Version >= 0 && c.Version <= 6
 }
 
 func (c *CreateTopicsRequest) requiredVersion() KafkaVersion {
 	switch c.Version {
+	case 6:
+		return V2_7_0_0
 	case 5:
 		return V2_4_0_0
 	case 4:

--- a/create_topics_request_test.go
+++ b/create_topics_request_test.go
@@ -41,6 +41,8 @@ var (
 		1,
 		0, // empty tagged fields
 	}
+
+	createTopicsRequestV6 = createTopicsRequestV5
 )
 
 func TestCreateTopicsRequest(t *testing.T) {
@@ -71,4 +73,7 @@ func TestCreateTopicsRequest(t *testing.T) {
 
 	req.Version = 5
 	testRequest(t, "version 5", req, createTopicsRequestV5)
+
+	req.Version = 6
+	testRequest(t, "version 6", req, createTopicsRequestV6)
 }

--- a/create_topics_response.go
+++ b/create_topics_response.go
@@ -119,11 +119,13 @@ func (c *CreateTopicsResponse) isFlexibleVersion(version int16) bool {
 }
 
 func (c *CreateTopicsResponse) isValidVersion() bool {
-	return c.Version >= 0 && c.Version <= 5
+	return c.Version >= 0 && c.Version <= 6
 }
 
 func (c *CreateTopicsResponse) requiredVersion() KafkaVersion {
 	switch c.Version {
+	case 6:
+		return V2_7_0_0
 	case 5:
 		return V2_4_0_0
 	case 4:

--- a/create_topics_response_test.go
+++ b/create_topics_response_test.go
@@ -49,6 +49,25 @@ var (
 		0, // empty tagged fields
 	}
 
+	createTopicsResponseV6 = []byte{
+		0, 0, 0, 100,
+		2,
+		6, 't', 'o', 'p', 'i', 'c',
+		0, 89, // throttling quota exceeded error
+		4, 'm', 's', 'g', // error message
+		0, 0, 0, 1, // num partitions
+		0, 2, // replication factor
+		2,                // 1 config
+		4, 'b', 'a', 'r', // name
+		4, 'b', 'a', 'z', // value
+		0, // read only
+		5, // source default
+		0, // is sensitive
+		0, // empty tagged fields
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
+
 	createTopicsResponseV5WithTopicConfigError = []byte{
 		0, 0, 0, 100,
 		2,
@@ -109,6 +128,12 @@ func TestCreateTopicsResponse(t *testing.T) {
 	}
 	testResponse(t, "version 5", resp, createTopicsResponseV5)
 
+	resp.Version = 6
+	resp.TopicErrors["topic"].Err = ErrThrottlingQuotaExceeded
+	testResponse(t, "version 6", resp, createTopicsResponseV6)
+
+	resp.Version = 5
+	resp.TopicErrors["topic"].Err = ErrInvalidRequest
 	resp.TopicResults["topic"].TopicConfigErrorCode = ErrTopicAuthorizationFailed
 	testResponse(t, "version 5", resp, createTopicsResponseV5WithTopicConfigError)
 }

--- a/errors.go
+++ b/errors.go
@@ -454,6 +454,8 @@ func (err KError) Error() string {
 		return "kafka server: This record has failed the validation on broker and hence will be rejected"
 	case ErrUnstableOffsetCommit:
 		return "kafka server: There are unstable offsets that need to be cleared"
+	case ErrThrottlingQuotaExceeded:
+		return "kafka server: The throttling quota has been exceeded"
 	}
 
 	return fmt.Sprintf("Unknown error, how did this happen? Error code = %d", err)

--- a/request_test.go
+++ b/request_test.go
@@ -308,8 +308,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDescribeUserScramCredentials: 0,  // new in 2.7
 				apiKeyAlterUserScramCredentials:    0,  // new in 2.7
 				apiKeyFetch:                        12, // up from 11
-				// TODO: CreateTopicsRequest v6 is not supported, but expected for KafkaVersion 2.7.0
-				// apiKeyCreateTopics:     6, // up from 5
+				apiKeyCreateTopics:                 6,  // up from 5
 				// TODO: DeleteTopicsRequest v5 is not supported, but expected for KafkaVersion 2.7.0
 				// apiKeyDeleteTopics:     5, // up from 4
 				// TODO: CreatePartitionsRequest v3 is not supported, but expected for KafkaVersion 2.7.0


### PR DESCRIPTION
This adds CreateTopics v6 support for [KIP-599](https://cwiki.apache.org/confluence/display/KAFKA/KIP-599%3A%2BThrottle%2BCreate%2BTopic%2C%2BCreate%2BPartition%2Band%2BDelete%2BTopic%2BOperations).

- request format is unchanged from v5
- response format is unchanged from v5; brokers can now return THROTTLING_QUOTA_EXCEEDED when topic creation is throttled.
- tests cover the v6 fixtures and the throttling quota error now has a readable message.