### PR TITLE
feat: support DeleteTopics v5

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -589,22 +589,11 @@ func (ca *clusterAdmin) DeleteTopic(topic string) error {
 		return ErrInvalidTopic
 	}
 
-	request := &DeleteTopicsRequest{
-		Topics:  []string{topic},
-		Timeout: ca.conf.Admin.Timeout,
-	}
-
-	// Versions 0, 1, 2, and 3 are the same.
-	// Version 4 is first flexible version.
-	if ca.conf.Version.IsAtLeast(V2_4_0_0) {
-		request.Version = 4
-	} else if ca.conf.Version.IsAtLeast(V2_1_0_0) {
-		request.Version = 3
-	} else if ca.conf.Version.IsAtLeast(V2_0_0_0) {
-		request.Version = 2
-	} else if ca.conf.Version.IsAtLeast(V0_11_0_0) {
-		request.Version = 1
-	}
+	request := NewDeleteTopicsRequest(
+		ca.conf.Version,
+		[]string{topic},
+		ca.conf.Admin.Timeout,
+	)
 
 	return ca.retryOnError(isRetriableControllerError, func() error {
 		b, err := ca.Controller()

--- a/delete_topics_request.go
+++ b/delete_topics_request.go
@@ -17,7 +17,12 @@ func NewDeleteTopicsRequest(version KafkaVersion, topics []string, timeout time.
 		Topics:  topics,
 		Timeout: timeout,
 	}
-	if version.IsAtLeast(V2_4_0_0) {
+	// Versions 0, 1, 2, and 3 are the same.
+	if version.IsAtLeast(V2_7_0_0) {
+		// version 5 may return THROTTLING_QUOTA_EXCEEDED
+		d.Version = 5
+	} else if version.IsAtLeast(V2_4_0_0) {
+		// Version 4 is first flexible version.
 		d.Version = 4
 	} else if version.IsAtLeast(V2_1_0_0) {
 		d.Version = 3
@@ -77,11 +82,13 @@ func (d *DeleteTopicsRequest) isFlexibleVersion(version int16) bool {
 }
 
 func (d *DeleteTopicsRequest) isValidVersion() bool {
-	return d.Version >= 0 && d.Version <= 4
+	return d.Version >= 0 && d.Version <= 5
 }
 
 func (d *DeleteTopicsRequest) requiredVersion() KafkaVersion {
 	switch d.Version {
+	case 5:
+		return V2_7_0_0
 	case 4:
 		return V2_4_0_0
 	case 3:

--- a/delete_topics_request_test.go
+++ b/delete_topics_request_test.go
@@ -21,6 +21,8 @@ var (
 		0, 0, 0, 100,
 		0, // empty tagged fields
 	}
+
+	deleteTopicsRequestV5 = deleteTopicsRequestV4
 )
 
 func TestDeleteTopicsRequestV0(t *testing.T) {
@@ -51,4 +53,14 @@ func TestDeleteTopicsRequestV4(t *testing.T) {
 	}
 
 	testRequest(t, "", req, deleteTopicsRequestV4)
+}
+
+func TestDeleteTopicsRequestV5(t *testing.T) {
+	req := &DeleteTopicsRequest{
+		Version: 5,
+		Topics:  []string{"topic", "other"},
+		Timeout: 100 * time.Millisecond,
+	}
+
+	testRequest(t, "", req, deleteTopicsRequestV5)
 }

--- a/delete_topics_response.go
+++ b/delete_topics_response.go
@@ -5,9 +5,10 @@ import (
 )
 
 type DeleteTopicsResponse struct {
-	Version         int16
-	ThrottleTime    time.Duration
-	TopicErrorCodes map[string]KError
+	Version            int16
+	ThrottleTime       time.Duration
+	TopicErrorCodes    map[string]KError
+	TopicErrorMessages map[string]*string // v5, ErrorMessage
 }
 
 func (d *DeleteTopicsResponse) setVersion(v int16) {
@@ -27,6 +28,11 @@ func (d *DeleteTopicsResponse) encode(pe packetEncoder) error {
 			return err
 		}
 		pe.putKError(errorCode)
+		if d.Version >= 5 {
+			if err := pe.putNullableString(d.TopicErrorMessages[topic]); err != nil {
+				return err
+			}
+		}
 		pe.putEmptyTaggedFieldArray()
 	}
 
@@ -52,6 +58,9 @@ func (d *DeleteTopicsResponse) decode(pd packetDecoder, version int16) (err erro
 	}
 
 	d.TopicErrorCodes = make(map[string]KError, n)
+	if version >= 5 {
+		d.TopicErrorMessages = make(map[string]*string, n)
+	}
 
 	for range n {
 		topic, err := pd.getString()
@@ -61,6 +70,11 @@ func (d *DeleteTopicsResponse) decode(pd packetDecoder, version int16) (err erro
 		d.TopicErrorCodes[topic], err = pd.getKError()
 		if err != nil {
 			return err
+		}
+		if version >= 5 {
+			if d.TopicErrorMessages[topic], err = pd.getNullableString(); err != nil {
+				return err
+			}
 		}
 
 		if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
@@ -96,11 +110,13 @@ func (d *DeleteTopicsResponse) isFlexibleVersion(version int16) bool {
 }
 
 func (d *DeleteTopicsResponse) isValidVersion() bool {
-	return d.Version >= 0 && d.Version <= 4
+	return d.Version >= 0 && d.Version <= 5
 }
 
 func (d *DeleteTopicsResponse) requiredVersion() KafkaVersion {
 	switch d.Version {
+	case 5:
+		return V2_7_0_0
 	case 4:
 		return V2_4_0_0
 	case 3:

--- a/delete_topics_response_test.go
+++ b/delete_topics_response_test.go
@@ -29,6 +29,16 @@ var (
 		0, // empty tagged fields
 		0, // empty tagged fields
 	}
+
+	deleteTopicsResponseV5 = []byte{
+		0, 0, 0, 100,
+		2,
+		6, 't', 'o', 'p', 'i', 'c',
+		0, 89, // throttling quota exceeded error
+		4, 'm', 's', 'g', // error message
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
 )
 
 func TestDeleteTopicsResponse(t *testing.T) {
@@ -47,4 +57,11 @@ func TestDeleteTopicsResponse(t *testing.T) {
 
 	resp.Version = 4
 	testResponse(t, "version 4", resp, deleteTopicsResponseV4)
+
+	resp.Version = 5
+	resp.TopicErrorCodes["topic"] = ErrThrottlingQuotaExceeded
+	resp.TopicErrorMessages = map[string]*string{
+		"topic": nullString("msg"),
+	}
+	testResponse(t, "version 5", resp, deleteTopicsResponseV5)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -309,8 +309,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyAlterUserScramCredentials:    0,  // new in 2.7
 				apiKeyFetch:                        12, // up from 11
 				apiKeyCreateTopics:                 6,  // up from 5
-				// TODO: DeleteTopicsRequest v5 is not supported, but expected for KafkaVersion 2.7.0
-				// apiKeyDeleteTopics:     5, // up from 4
+				apiKeyDeleteTopics:                 5,  // up from 4
 				// TODO: CreatePartitionsRequest v3 is not supported, but expected for KafkaVersion 2.7.0
 				// apiKeyCreatePartitions: 3, // up from 2
 				// TODO: UpdateFeaturesRequest v0 is not supported, but expected for KafkaVersion 2.7.0


### PR DESCRIPTION
This adds DeleteTopics v5 support for
[KIP-599](https://cwiki.apache.org/confluence/display/KAFKA/KIP-599%3A%2BThrottle%2BCreate%2BTopic%2C%2BCreate%2BPartition%2Band%2BDelete%2BTopic%2BOperations).

- request format is unchanged from v4
- response gains a nullable ErrorMessage per topic result; brokers can now return THROTTLING_QUOTA_EXCEEDED when topic deletion is throttled.
- tests cover the v5 fixtures, and admin DeleteTopic builds its request via NewDeleteTopicsRequest rather than a duplicate version ladder.