### PR TITLE
feat: add OnAssignmentBalanceStrategy, the onAssignment half of the assignor contract

### DIFF
--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -79,6 +79,39 @@ type SubscriptionUserDataBalanceStrategy interface {
 	SubscriptionUserData(topics []string) ([]byte, error)
 }
 
+// OnAssignmentBalanceStrategy is an optional extension of BalanceStrategy that
+// is notified of the assignment a member receives from the leader. When a
+// strategy implements this interface, Sarama invokes OnAssignment once per
+// rebalance, immediately after the member's SyncGroup response is processed,
+// passing the member's own assignment and the generation it belongs to.
+//
+// This is the downstream counterpart to SubscriptionUserDataBalanceStrategy:
+// SubscriptionUserData lets a strategy speak into its own subscription
+// (member -> leader), while OnAssignment lets it observe what the leader
+// decided (leader -> member). Together they let a stateful assignor carry
+// information across rebalances — for example, persisting the prior
+// assignment, or echoing leader-computed state (assignment.UserData) back in
+// the member's next SubscriptionUserData so it survives membership changes.
+//
+// OnAssignment is invoked synchronously on the consumer's rebalance path, so
+// it should return promptly (capture what it needs and return; do not perform
+// I/O or block). The synchronous call is deliberate: it guarantees that
+// OnAssignment for generation N completes before the member's
+// SubscriptionUserData for generation N+1, since the SyncGroup of one
+// generation completes before the JoinGroup of the next begins. A strategy
+// that echoes assignment state into its next subscription relies on this
+// ordering, which a background invocation would not provide.
+//
+// This mirrors Java's ConsumerPartitionAssignor.onAssignment(Assignment,
+// ConsumerGroupMetadata): the assignment argument corresponds to Java's
+// Assignment (partitions + userData), and generationID corresponds to the
+// generationId carried by ConsumerGroupMetadata.
+type OnAssignmentBalanceStrategy interface {
+	BalanceStrategy
+
+	OnAssignment(assignment *ConsumerGroupMemberAssignment, generationID int32)
+}
+
 // --------------------------------------------------------------------
 
 // NewBalanceStrategyRange returns a range balance strategy,

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -450,6 +450,12 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 			c.userData = c.config.Consumer.Group.Member.UserData
 		}
 
+		// Notify a stateful strategy of the assignment it just received, so it
+		// can carry leader-computed state into its next subscription.
+		if onAssign, ok := strategy.(OnAssignmentBalanceStrategy); ok {
+			onAssign.OnAssignment(members, join.GenerationId)
+		}
+
 		for _, partitions := range claims {
 			sort.Sort(int32Slice(partitions))
 		}


### PR DESCRIPTION
## Summary

`SubscriptionUserDataBalanceStrategy` (added in #3505) lets a `BalanceStrategy` inject per-cycle metadata into its own subscription — the member→leader half of the assignor contract. Its counterpart from the Java reference client, `ConsumerPartitionAssignor.onAssignment`, was never ported. Today a sarama assignor can speak into its subscription but cannot observe what the leader decided — so it cannot carry state across rebalances.

This adds `OnAssignmentBalanceStrategy`, an optional extension invoked once per rebalance immediately after a member processes its SyncGroup response.

## Upstream Java contract

`org.apache.kafka.clients.consumer.ConsumerPartitionAssignor` defines two complementary member-side hooks, both `default` methods on the interface. Quoting the reference client verbatim ([`ConsumerPartitionAssignor.java`, kafka 4.0.0](https://github.com/apache/kafka/blob/4.0.0/clients/src/main/java/org/apache/kafka/clients/consumer/ConsumerPartitionAssignor.java)):

```java
/**
 * Return serialized data that will be included in the {@link Subscription} sent to the leader
 * and can be leveraged in {@link #assign(Cluster, GroupSubscription)} ((e.g. local host/rack information)
 * @param topics Topics subscribed to through {@link org.apache.kafka.clients.consumer.KafkaConsumer#subscribe(java.util.Collection)} and variants
 * @return nullable subscription user data
 */
default ByteBuffer subscriptionUserData(Set topics) {
    return null;
}

/**
 * Callback which is invoked when a group member receives its assignment from the leader.
 * @param assignment The local member&#39;s assignment as provided by the leader in {@link #assign(Cluster, GroupSubscription)}
 * @param metadata Additional metadata on the consumer (optional)
 */
default void onAssignment(Assignment assignment, ConsumerGroupMetadata metadata) {
}
```

where the nested `Assignment` exposes:

```java
public List partitions() { ... }
public ByteBuffer userData() { ... }
```

`subscriptionUserData` is the member→leader direction (sarama landed it as `SubscriptionUserDataBalanceStrategy` in #3505). `onAssignment` is the leader→member direction, and is the half sarama is still missing. The `UserData` carried in both directions is opaque, assignor-defined bytes per the consumer group protocol (KIP-54, with the assignor-metadata wire format clarified by KIP-394/KIP-462); the reference assignors use this round-trip to carry assignor state across rebalances.

## This change

The new interface mirrors `onAssignment` 1:1:

```go
type OnAssignmentBalanceStrategy interface {
	BalanceStrategy

	OnAssignment(assignment *ConsumerGroupMemberAssignment, generationID int32)
}
```

- `assignment` is the existing `*ConsumerGroupMemberAssignment` (`Topics` + `UserData`) — the direct analog of Java&#39;s `Assignment` (`partitions()` + `userData()`).
- `generationID` is the field consumed here from Java&#39;s `ConsumerGroupMetadata` (`generationId()`); the full metadata object is not modeled in sarama, and the generation is what a stateful assignor needs to order state across rebalances. (A GitHub-wide search showed consumers either ignore `ConsumerGroupMetadata` or use only `generationId`, so the narrower signature is not a YAGNI risk; anything more can be encoded in `UserData`.)

Sarama invokes it synchronously from the consumer&#39;s rebalance path right after the SyncGroup response is processed (where `c.userData` is already updated from the assignment), via a no-op type assertion.

## Why

Together the two hooks let a stateful assignor carry information across rebalances — e.g. persist the prior assignment, or echo leader-computed state (`assignment.UserData`) back in the member&#39;s next `SubscriptionUserData` so it survives membership changes. This unblocks load-aware and other stateful custom assignors that need to round-trip data through the protocol rather than an external store.

## Ordering

`OnAssignment` for generation N is always invoked before the member&#39;s `SubscriptionUserData` for generation N+1, because the SyncGroup of one generation completes before the JoinGroup of the next begins. The synchronous (non-backgrounded) invocation is deliberate: a strategy that echoes assignment state into its next subscription relies on this ordering, which a goroutine would not guarantee. The interface documents that implementations should return promptly (capture and return; no I/O).

## Compatibility

Additive and backward compatible: the `BalanceStrategy` interface is unchanged, and strategies that do not implement the optional interface are unaffected (the call site is a no-op type assertion).

## Tests

No dedicated unit test: the dispatch is a trivial no-op type assertion at the call site, and per review a standalone test exercised more scaffolding than behavior. The hook is exercised end-to-end by downstream consumers that implement it.