### PR TITLE
fix(consumer): don't panic on requeue after unref

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -267,7 +267,7 @@ func (c *consumer) unrefBrokerConsumer(brokerWorker *brokerConsumer) {
 	brokerWorker.refs--
 
 	if brokerWorker.refs == 0 {
-		close(brokerWorker.input)
+		brokerWorker.stopConsuming()
 		if c.brokerConsumers[brokerWorker.broker] == brokerWorker {
 			delete(c.brokerConsumers, brokerWorker.broker)
 		}
@@ -1066,10 +1066,7 @@ func (bc *brokerConsumer) subscriptionManager() {
 		select {
 		case <-bc.stop:
 			return
-		case subscription, ok := <-bc.input:
-			if !ok {
-				return
-			}
+		case subscription := <-bc.input:
 			subscriptions = append(subscriptions, subscription)
 		case bc.newSubscriptions <- nil:
 			continue
@@ -1077,18 +1074,12 @@ func (bc *brokerConsumer) subscriptionManager() {
 
 		// drain input of any further incoming subscriptions
 		timer := time.NewTimer(partitionConsumersBatchTimeout)
-		inputClosed := false
 		for batchComplete := false; !batchComplete; {
 			select {
 			case <-bc.stop:
 				stopping = true
 				batchComplete = true
-			case subscription, ok := <-bc.input:
-				if !ok {
-					inputClosed = true
-					batchComplete = true
-					continue
-				}
+			case subscription := <-bc.input:
 				subscriptions = append(subscriptions, subscription)
 			case <-timer.C:
 				batchComplete = true
@@ -1101,7 +1092,7 @@ func (bc *brokerConsumer) subscriptionManager() {
 			bc.broker.ID(), len(subscriptions))
 
 		bc.newSubscriptions <- subscriptions
-		if inputClosed || stopping {
+		if stopping {
 			return
 		}
 	}

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1735,7 +1735,7 @@ func TestPartitionConsumerDispatcherOrphanedClose(t *testing.T) {
 			children:        make(map[string]map[int32]*partitionConsumer),
 			brokerConsumers: make(map[*Broker]*brokerConsumer),
 		}
-		bc := &brokerConsumer{consumer: c, input: make(chan *brokerSubscription), refs: 1}
+		bc := &brokerConsumer{consumer: c, input: make(chan *brokerSubscription), refs: 1, stop: make(chan none)}
 		child := &partitionConsumer{
 			consumer:       c,
 			conf:           config,
@@ -2320,6 +2320,55 @@ func TestConsumerError(t *testing.T) {
 	if !errors.Is(err, ErrOutOfBrokers) {
 		t.Error("unexpected errors.Is")
 	}
+}
+
+func TestConsumerQueueSubscriptionAfterUnref(t *testing.T) {
+	metrics.UseNilMetrics = true
+	defer func() { metrics.UseNilMetrics = false }()
+
+	defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
+
+	config := NewTestConfig()
+
+	broker0 := NewMockBroker(t, 0)
+	defer broker0.Close()
+	broker0.SetHandlerByMap(map[string]MockResponse{
+		"MetadataRequest": NewMockMetadataResponse(t).
+			SetBroker(broker0.Addr(), broker0.BrokerID()),
+	})
+
+	client, err := NewClient([]string{broker0.Addr()}, config)
+	require.NoError(t, err)
+	defer client.Close()
+
+	c := &consumer{
+		client:          client,
+		conf:            config,
+		children:        make(map[string]map[int32]*partitionConsumer),
+		brokerConsumers: make(map[*Broker]*brokerConsumer),
+		metricRegistry:  newCleanupRegistry(config.MetricRegistry),
+	}
+
+	realBroker := client.Brokers()[0]
+
+	child := &partitionConsumer{
+		consumer:       c,
+		conf:           config,
+		topic:          "my_topic",
+		partition:      0,
+		trigger:        make(chan none, 1),
+		dying:          make(chan none),
+		dispatcherStop: make(chan none),
+	}
+
+	// a responseFeeder requeueing a timed-out subscription holds no ref on the
+	// brokerConsumer, so the requeue can arrive after the last unref
+	bc := c.refBrokerConsumer(realBroker)
+	c.unrefBrokerConsumer(bc)
+
+	require.NotPanics(t, func() {
+		require.False(t, bc.queueSubscription(newBrokerSubscription(child)))
+	})
 }
 
 // TestConsumerAbortNoGoroutineLeak verifies that brokerConsumer.abort() does


### PR DESCRIPTION
The responseFeeder doesn't hold a ref on the brokerConsumer it requeues a timed-out subscription onto, so it can lose the race with the final unref and end up sending on the (by then closed) input channel. That panic kills the feeder and every partition on the broker stalls.

Have unref signal shutdown through the stop channel and leave input open, so a late requeue just fails and redispatches as normal.