### PR TITLE
feat: support CreatePartitions v3

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -639,7 +639,9 @@ func (ca *clusterAdmin) CreatePartitions(topic string, count int32, assignment [
 		Timeout:         ca.conf.Admin.Timeout,
 		ValidateOnly:    validateOnly,
 	}
-	if ca.conf.Version.IsAtLeast(V2_5_0_0) {
+	if ca.conf.Version.IsAtLeast(V2_7_0_0) {
+		request.Version = 3
+	} else if ca.conf.Version.IsAtLeast(V2_5_0_0) {
 		request.Version = 2
 	} else if ca.conf.Version.IsAtLeast(V2_0_0_0) {
 		request.Version = 1

--- a/create_partitions_request.go
+++ b/create_partitions_request.go
@@ -85,7 +85,7 @@ func (r *CreatePartitionsRequest) headerVersion() int16 {
 }
 
 func (r *CreatePartitionsRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 2
+	return r.Version >= 0 && r.Version <= 3
 }
 
 func (r *CreatePartitionsRequest) isFlexible() bool {
@@ -98,6 +98,8 @@ func (r *CreatePartitionsRequest) isFlexibleVersion(version int16) bool {
 
 func (r *CreatePartitionsRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 3:
+		return V2_7_0_0
 	case 2:
 		return V2_5_0_0
 	case 1:

--- a/create_partitions_request_test.go
+++ b/create_partitions_request_test.go
@@ -70,4 +70,9 @@ func TestCreatePartitionsRequest(t *testing.T) {
 	req.Version = 2
 	buf = testRequestEncode(t, "assignment v2", req, createPartitionRequestAssignmentV2)
 	testRequestDecode(t, "assignment v2", req, buf)
+
+	// v3 wire format is identical to v2
+	req.Version = 3
+	buf = testRequestEncode(t, "assignment v3", req, createPartitionRequestAssignmentV2)
+	testRequestDecode(t, "assignment v3", req, buf)
 }

--- a/create_partitions_response.go
+++ b/create_partitions_response.go
@@ -80,7 +80,7 @@ func (r *CreatePartitionsResponse) headerVersion() int16 {
 }
 
 func (r *CreatePartitionsResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 2
+	return r.Version >= 0 && r.Version <= 3
 }
 
 func (r *CreatePartitionsResponse) isFlexible() bool {
@@ -93,6 +93,8 @@ func (r *CreatePartitionsResponse) isFlexibleVersion(version int16) bool {
 
 func (r *CreatePartitionsResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 3:
+		return V2_7_0_0
 	case 2:
 		return V2_5_0_0
 	case 1:

--- a/create_partitions_response_test.go
+++ b/create_partitions_response_test.go
@@ -101,4 +101,8 @@ func TestCreatePartitionsResponseV2(t *testing.T) {
 		},
 	}
 	testResponse(t, "success", resp, createPartitionResponseSuccessV2)
+
+	// v3 wire format is identical to v2
+	resp.Version = 3
+	testResponse(t, "success v3", resp, createPartitionResponseSuccessV2)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -310,8 +310,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyFetch:                        12, // up from 11
 				apiKeyCreateTopics:                 6,  // up from 5
 				apiKeyDeleteTopics:                 5,  // up from 4
-				// TODO: CreatePartitionsRequest v3 is not supported, but expected for KafkaVersion 2.7.0
-				// apiKeyCreatePartitions: 3, // up from 2
+				apiKeyCreatePartitions:             3,  // up from 2
 				// TODO: UpdateFeaturesRequest v0 is not supported, but expected for KafkaVersion 2.7.0
 				// apiKeyUpdateFeatures /* (57) */: 0, // new in 2.7
 			},


### PR DESCRIPTION
The v3 wire format is identical to v2; it signals that the client can handle THROTTLING_QUOTA_EXCEEDED errors from the broker (KIP-599, Kafka 2.7.0).