### PR TITLE
feat: support UpdateFeatures 

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -176,6 +176,10 @@ type ClusterAdmin interface {
 	// Upsert SCRAM users
 	UpsertUserScramCredentials(upsert []AlterUserScramCredentialsUpsert) ([]*AlterUserScramCredentialsResult, error)
 
+	// Update the maximum version level of finalized features.
+	// This operation is supported by brokers with version 2.7.0.0 or higher.
+	UpdateFeatures(featureUpdates []FeatureUpdate) ([]UpdatableFeatureResult, error)
+
 	// Get client quota configurations corresponding to the specified filter.
 	// This operation is supported by brokers with version 2.6.0.0 or higher.
 	DescribeClientQuotas(components []QuotaFilterComponent, strict bool) ([]DescribeClientQuotasEntry, error)
@@ -1608,6 +1612,43 @@ func (ca *clusterAdmin) AlterUserScramCredentials(u []AlterUserScramCredentialsU
 
 		rsp, err = b.AlterUserScramCredentials(req)
 		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return rsp.Results, nil
+}
+
+func (ca *clusterAdmin) UpdateFeatures(featureUpdates []FeatureUpdate) ([]UpdatableFeatureResult, error) {
+	request := &UpdateFeaturesRequest{
+		Timeout:        ca.conf.Admin.Timeout,
+		FeatureUpdates: featureUpdates,
+	}
+
+	var rsp *UpdateFeaturesResponse
+	err := ca.retryOnError(isRetriableControllerError, func() error {
+		b, err := ca.Controller()
+		if err != nil {
+			return err
+		}
+
+		rsp, err = b.UpdateFeatures(request)
+		if err != nil {
+			return err
+		}
+
+		if !errors.Is(rsp.ErrorCode, ErrNoError) {
+			if errors.Is(rsp.ErrorCode, ErrNotController) {
+				_, _ = ca.refreshController()
+			}
+			if rsp.ErrorMessage != nil {
+				return fmt.Errorf("%w - %s", rsp.ErrorCode, *rsp.ErrorMessage)
+			}
+			return rsp.ErrorCode
+		}
+
+		return nil
 	})
 	if err != nil {
 		return nil, err

--- a/admin_test.go
+++ b/admin_test.go
@@ -2648,3 +2648,31 @@ func Test_retryOnError(t *testing.T) {
 		}
 	})
 }
+
+func TestClusterAdminUpdateFeatures(t *testing.T) {
+	seedBroker := NewMockBroker(t, 1)
+	defer seedBroker.Close()
+
+	seedBroker.SetHandlerByMap(map[string]MockResponse{
+		"MetadataRequest": NewMockMetadataResponse(t).
+			SetController(seedBroker.BrokerID()).
+			SetBroker(seedBroker.Addr(), seedBroker.BrokerID()),
+		"UpdateFeaturesRequest": NewMockUpdateFeaturesResponse(t),
+	})
+
+	config := NewTestConfig()
+	config.Version = V2_7_0_0
+	admin, err := NewClusterAdmin([]string{seedBroker.Addr()}, config)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, admin.Close())
+	}()
+
+	t.Run("returns per-feature results", func(t *testing.T) {
+		results, err := admin.UpdateFeatures([]FeatureUpdate{
+			{Feature: "metadata.version", MaxVersionLevel: 2},
+		})
+		require.NoError(t, err)
+		require.Equal(t, []UpdatableFeatureResult{{Feature: "metadata.version"}}, results)
+	})
+}

--- a/api_versions.go
+++ b/api_versions.go
@@ -81,5 +81,6 @@ const (
 	apiKeyAlterClientQuotas            = 49
 	apiKeyDescribeUserScramCredentials = 50
 	apiKeyAlterUserScramCredentials    = 51
+	apiKeyUpdateFeatures               = 57
 	apiKeyDescribeCluster              = 60
 )

--- a/broker.go
+++ b/broker.go
@@ -1003,6 +1003,18 @@ func (b *Broker) AlterUserScramCredentials(req *AlterUserScramCredentialsRequest
 	return res, nil
 }
 
+// UpdateFeatures sends a request to update finalized feature versions
+func (b *Broker) UpdateFeatures(req *UpdateFeaturesRequest) (*UpdateFeaturesResponse, error) {
+	res := new(UpdateFeaturesResponse)
+
+	err := b.sendAndReceive(req, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 // DescribeClientQuotas sends a request to get the broker's quotas
 func (b *Broker) DescribeClientQuotas(request *DescribeClientQuotasRequest) (*DescribeClientQuotasResponse, error) {
 	response := new(DescribeClientQuotasResponse)

--- a/encoder_decoder_fuzz_test.go
+++ b/encoder_decoder_fuzz_test.go
@@ -63,6 +63,7 @@ func FuzzVersionedDecodeRequest(f *testing.F) {
 		{key: apiKeyAlterClientQuotas, version: 0, body: alterClientQuotasRequestSingleOp},
 		{key: apiKeyDescribeUserScramCredentials, version: 0, body: emptyDescribeUserScramCredentialsRequest},
 		{key: apiKeyAlterUserScramCredentials, version: 0, body: emptyAlterUserScramCredentialsRequest},
+		{key: apiKeyUpdateFeatures, version: 0, body: updateFeaturesRequestV0},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}
@@ -117,6 +118,7 @@ func FuzzVersionedDecodeResponse(f *testing.F) {
 		{key: apiKeyAlterClientQuotas, version: 0, body: alterClientQuotasResponseError},
 		{key: apiKeyDescribeUserScramCredentials, version: 0, body: emptyDescribeUserScramCredentialsResponse},
 		{key: apiKeyAlterUserScramCredentials, version: 0, body: emptyAlterUserScramCredentialsResponse},
+		{key: apiKeyUpdateFeatures, version: 0, body: updateFeaturesResponseV0},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}

--- a/errors.go
+++ b/errors.go
@@ -268,6 +268,7 @@ const (
 	ErrUnstableOffsetCommit               KError = 88 // Errors.UNSTABLE_OFFSET_COMMIT
 	ErrThrottlingQuotaExceeded            KError = 89 // Errors.THROTTLING_QUOTA_EXCEEDED
 	ErrProducerFenced                     KError = 90 // Errors.PRODUCER_FENCED
+	ErrInvalidUpdateVersion               KError = 95 // Errors.INVALID_UPDATE_VERSION
 )
 
 func (err KError) Error() string {
@@ -456,6 +457,8 @@ func (err KError) Error() string {
 		return "kafka server: There are unstable offsets that need to be cleared"
 	case ErrThrottlingQuotaExceeded:
 		return "kafka server: The throttling quota has been exceeded"
+	case ErrInvalidUpdateVersion:
+		return "kafka server: The given update version was invalid"
 	}
 
 	return fmt.Sprintf("Unknown error, how did this happen? Error code = %d", err)

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -1014,3 +1014,43 @@ func TestFuncAdminIncrementalAlterConfigs(t *testing.T) {
 		t.Fatalf("failed to alter config: %v", err)
 	}
 }
+
+func TestFuncAdminUpdateFeatures(t *testing.T) {
+	t.Parallel()
+	// feature updates need a KRaft cluster; ZooKeeper-mode brokers don't
+	// advertise any features
+	checkKafkaVersion(t, "4.0.0.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	kafkaVersion, err := ParseKafkaVersion(FunctionalTestEnv.KafkaVersion)
+	require.NoError(t, err)
+
+	config := NewFunctionalTestConfig()
+	config.Version = kafkaVersion
+	adminClient, err := NewClusterAdmin(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer safeClose(t, adminClient)
+
+	// an update for a made-up feature name should be rejected without
+	// touching cluster state; the controller fails the whole batch with
+	// INVALID_UPDATE_VERSION when every update in it failed
+	_, err = adminClient.UpdateFeatures([]FeatureUpdate{{
+		Feature:         "sarama.unsupported.feature",
+		MaxVersionLevel: 1,
+	}})
+	require.ErrorIs(t, err, ErrInvalidUpdateVersion)
+
+	// share.version (KIP-932) ships disabled on 4.1 (finalized 0, max 1),
+	// so we can do a real upgrade here
+	if kafkaVersion.IsAtLeast(V4_1_0_0) && !kafkaVersion.IsAtLeast(V4_2_0_0) {
+		results, err := adminClient.UpdateFeatures([]FeatureUpdate{{
+			Feature:         "share.version",
+			MaxVersionLevel: 1,
+		}})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "share.version", results[0].Feature)
+		assert.Equal(t, ErrNoError, results[0].ErrorCode)
+	}
+}

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -1547,3 +1547,22 @@ func (m *MockInitProducerIDResponse) For(reqBody versionedDecoder) encoderWithHe
 	}
 	return res
 }
+
+type MockUpdateFeaturesResponse struct {
+	t TestReporter
+}
+
+func NewMockUpdateFeaturesResponse(t TestReporter) *MockUpdateFeaturesResponse {
+	return &MockUpdateFeaturesResponse{t: t}
+}
+
+func (m *MockUpdateFeaturesResponse) For(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*UpdateFeaturesRequest)
+	res := &UpdateFeaturesResponse{Version: req.version()}
+	for i := range req.FeatureUpdates {
+		res.Results = append(res.Results, UpdatableFeatureResult{
+			Feature: req.FeatureUpdates[i].Feature,
+		})
+	}
+	return res
+}

--- a/request.go
+++ b/request.go
@@ -217,6 +217,8 @@ func allocateBody(key, version int16) protocolBody {
 		return &DescribeUserScramCredentialsRequest{Version: version}
 	case apiKeyAlterUserScramCredentials:
 		return &AlterUserScramCredentialsRequest{Version: version}
+	case apiKeyUpdateFeatures:
+		return &UpdateFeaturesRequest{Version: version}
 	case apiKeyDescribeCluster:
 		return &DescribeClusterRequest{Version: version}
 		// 52: VoteRequest
@@ -224,7 +226,6 @@ func allocateBody(key, version int16) protocolBody {
 		// 54: EndQuorumEpochRequest
 		// 55: DescribeQuorumRequest
 		// 56: AlterPartitionRequest
-		// 57: UpdateFeaturesRequest
 		// 58: EnvelopeRequest
 		// 59: FetchSnapshotRequest
 		// 60: DescribeClusterRequest
@@ -331,6 +332,8 @@ func allocateResponseBody(key, version int16) protocolBody {
 		return &DescribeUserScramCredentialsResponse{Version: version}
 	case apiKeyAlterUserScramCredentials:
 		return &AlterUserScramCredentialsResponse{Version: version}
+	case apiKeyUpdateFeatures:
+		return &UpdateFeaturesResponse{Version: version}
 	case apiKeyDescribeCluster:
 		return &DescribeClusterResponse{Version: version}
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -71,7 +71,7 @@ var names = map[int16]string{
 	54:                                 "EndQuorumEpochRequest",
 	55:                                 "DescribeQuorumRequest",
 	56:                                 "AlterPartitionRequest",
-	57:                                 "UpdateFeaturesRequest",
+	apiKeyUpdateFeatures:               "UpdateFeaturesRequest",
 	58:                                 "EnvelopeRequest",
 	59:                                 "FetchSnapshotRequest",
 	apiKeyDescribeCluster:              "DescribeClusterRequest",
@@ -311,8 +311,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyCreateTopics:                 6,  // up from 5
 				apiKeyDeleteTopics:                 5,  // up from 4
 				apiKeyCreatePartitions:             3,  // up from 2
-				// TODO: UpdateFeaturesRequest v0 is not supported, but expected for KafkaVersion 2.7.0
-				// apiKeyUpdateFeatures /* (57) */: 0, // new in 2.7
+				apiKeyUpdateFeatures:               0,  // new in 2.7
 			},
 		},
 		{
@@ -542,6 +541,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyAlterClientQuotas:            maxVersion(&AlterClientQuotasRequest{}),
 				apiKeyDescribeUserScramCredentials: maxVersion(&DescribeUserScramCredentialsRequest{}),
 				apiKeyAlterUserScramCredentials:    maxVersion(&AlterUserScramCredentialsRequest{}),
+				apiKeyUpdateFeatures:               maxVersion(&UpdateFeaturesRequest{}),
 				apiKeyDescribeCluster:              maxVersion(&DescribeClusterRequest{}),
 			},
 		},

--- a/update_features_request.go
+++ b/update_features_request.go
@@ -1,0 +1,128 @@
+package sarama
+
+import "time"
+
+type UpdateFeaturesRequest struct {
+	Version int16
+
+	// Timeout is how long to wait before timing out the request
+	Timeout time.Duration
+
+	// FeatureUpdates is the list of updates to finalized features
+	FeatureUpdates []FeatureUpdate
+}
+
+func (r *UpdateFeaturesRequest) setVersion(v int16) {
+	r.Version = v
+}
+
+type FeatureUpdate struct {
+	// Feature is the name of the finalized feature to update
+	Feature string
+
+	// MaxVersionLevel is the new maximum version level for the finalized
+	// feature; a value < 1 requests deletion of the finalized feature
+	MaxVersionLevel int16
+
+	// AllowDowngrade, when true, allows the finalized feature version level
+	// to be downgraded or deleted
+	AllowDowngrade bool
+}
+
+func (f *FeatureUpdate) encode(pe packetEncoder) error {
+	if err := pe.putString(f.Feature); err != nil {
+		return err
+	}
+
+	pe.putInt16(f.MaxVersionLevel)
+
+	pe.putBool(f.AllowDowngrade)
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (f *FeatureUpdate) decode(pd packetDecoder, version int16) (err error) {
+	if f.Feature, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if f.MaxVersionLevel, err = pd.getInt16(); err != nil {
+		return err
+	}
+
+	if f.AllowDowngrade, err = pd.getBool(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *UpdateFeaturesRequest) encode(pe packetEncoder) error {
+	pe.putDurationMs(r.Timeout)
+
+	if err := pe.putArrayLength(len(r.FeatureUpdates)); err != nil {
+		return err
+	}
+	for i := range r.FeatureUpdates {
+		if err := r.FeatureUpdates[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *UpdateFeaturesRequest) decode(pd packetDecoder, version int16) (err error) {
+	if r.Timeout, err = pd.getDurationMs(); err != nil {
+		return err
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	r.FeatureUpdates = make([]FeatureUpdate, n)
+	for i := range n {
+		if err := r.FeatureUpdates[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *UpdateFeaturesRequest) key() int16 {
+	return apiKeyUpdateFeatures
+}
+
+func (r *UpdateFeaturesRequest) version() int16 {
+	return r.Version
+}
+
+func (r *UpdateFeaturesRequest) headerVersion() int16 {
+	return 2
+}
+
+func (r *UpdateFeaturesRequest) isValidVersion() bool {
+	return r.Version == 0
+}
+
+func (r *UpdateFeaturesRequest) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *UpdateFeaturesRequest) isFlexibleVersion(version int16) bool {
+	return version >= 0
+}
+
+func (r *UpdateFeaturesRequest) requiredVersion() KafkaVersion {
+	return V2_7_0_0
+}

--- a/update_features_request_test.go
+++ b/update_features_request_test.go
@@ -1,0 +1,34 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+	"time"
+)
+
+var updateFeaturesRequestV0 = []byte{
+	0, 0, 0, 100, // timeoutMs
+	2,                                    // FeatureUpdates
+	8, 'f', 'e', 'a', 't', 'u', 'r', 'e', // feature
+	0, 2, // max version level
+	1, // allow downgrade
+	0, // empty tagged fields
+	0, // empty tagged fields
+}
+
+func TestUpdateFeaturesRequest(t *testing.T) {
+	request := &UpdateFeaturesRequest{
+		Version: 0,
+		Timeout: 100 * time.Millisecond,
+		FeatureUpdates: []FeatureUpdate{
+			{
+				Feature:         "feature",
+				MaxVersionLevel: 2,
+				AllowDowngrade:  true,
+			},
+		},
+	}
+
+	testRequest(t, "v0", request, updateFeaturesRequestV0)
+}

--- a/update_features_response.go
+++ b/update_features_response.go
@@ -1,0 +1,144 @@
+package sarama
+
+import "time"
+
+type UpdateFeaturesResponse struct {
+	Version int16
+
+	ThrottleTime time.Duration
+
+	ErrorCode    KError
+	ErrorMessage *string
+
+	// Results contains the per-feature update results
+	Results []UpdatableFeatureResult
+}
+
+func (r *UpdateFeaturesResponse) setVersion(v int16) {
+	r.Version = v
+}
+
+type UpdatableFeatureResult struct {
+	Feature string
+
+	ErrorCode    KError
+	ErrorMessage *string
+}
+
+func (u *UpdatableFeatureResult) encode(pe packetEncoder) error {
+	if err := pe.putString(u.Feature); err != nil {
+		return err
+	}
+
+	pe.putKError(u.ErrorCode)
+
+	if err := pe.putNullableString(u.ErrorMessage); err != nil {
+		return err
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (u *UpdatableFeatureResult) decode(pd packetDecoder, version int16) (err error) {
+	if u.Feature, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if u.ErrorCode, err = pd.getKError(); err != nil {
+		return err
+	}
+
+	if u.ErrorMessage, err = pd.getNullableString(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *UpdateFeaturesResponse) encode(pe packetEncoder) error {
+	pe.putDurationMs(r.ThrottleTime)
+
+	pe.putKError(r.ErrorCode)
+
+	if err := pe.putNullableString(r.ErrorMessage); err != nil {
+		return err
+	}
+
+	if err := pe.putArrayLength(len(r.Results)); err != nil {
+		return err
+	}
+	for i := range r.Results {
+		if err := r.Results[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *UpdateFeaturesResponse) decode(pd packetDecoder, version int16) (err error) {
+	if r.ThrottleTime, err = pd.getDurationMs(); err != nil {
+		return err
+	}
+
+	if r.ErrorCode, err = pd.getKError(); err != nil {
+		return err
+	}
+
+	if r.ErrorMessage, err = pd.getNullableString(); err != nil {
+		return err
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	r.Results = make([]UpdatableFeatureResult, n)
+	for i := range n {
+		if err := r.Results[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *UpdateFeaturesResponse) key() int16 {
+	return apiKeyUpdateFeatures
+}
+
+func (r *UpdateFeaturesResponse) version() int16 {
+	return r.Version
+}
+
+func (r *UpdateFeaturesResponse) headerVersion() int16 {
+	return 1
+}
+
+func (r *UpdateFeaturesResponse) isValidVersion() bool {
+	return r.Version == 0
+}
+
+func (r *UpdateFeaturesResponse) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *UpdateFeaturesResponse) isFlexibleVersion(version int16) bool {
+	return version >= 0
+}
+
+func (r *UpdateFeaturesResponse) requiredVersion() KafkaVersion {
+	return V2_7_0_0
+}
+
+func (r *UpdateFeaturesResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/update_features_response_test.go
+++ b/update_features_response_test.go
@@ -1,0 +1,37 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+	"time"
+)
+
+var updateFeaturesResponseV0 = []byte{
+	0, 0, 0, 100, // throttleTimeMs
+	0, 0, // error code
+	0,                                    // error message
+	2,                                    // Results
+	8, 'f', 'e', 'a', 't', 'u', 'r', 'e', // feature
+	0, 7, // error code
+	6, 'e', 'r', 'r', 'o', 'r', // error message
+	0, // empty tagged fields
+	0, // empty tagged fields
+}
+
+func TestUpdateFeaturesResponse(t *testing.T) {
+	errMsg := "error"
+	response := &UpdateFeaturesResponse{
+		Version:      0,
+		ThrottleTime: 100 * time.Millisecond,
+		Results: []UpdatableFeatureResult{
+			{
+				Feature:      "feature",
+				ErrorCode:    ErrRequestTimedOut,
+				ErrorMessage: &errMsg,
+			},
+		},
+	}
+
+	testResponse(t, "v0", response, updateFeaturesResponseV0)
+}


### PR DESCRIPTION
Add request/response types for the UpdateFeatures API (key 57, KIP-584, Kafka 2.7.0) along with a typed Broker method. Expose the UpdateFeatures API via ClusterAdmin, mirroring the Java AdminClient's updateFeatures

