### PR TITLE
feat: expose broker features from ApiVersions v3

### DIFF
--- a/api_versions_response.go
+++ b/api_versions_response.go
@@ -49,6 +49,86 @@ func (a *ApiVersionsResponseKey) decode(pd packetDecoder, version int16) (err er
 	return err
 }
 
+// SupportedFeatureKey contains a feature supported by the broker.
+type SupportedFeatureKey struct {
+	// Name contains the name of the feature.
+	Name string
+	// MinVersion contains the minimum supported version for the feature.
+	MinVersion int16
+	// MaxVersion contains the maximum supported version for the feature.
+	MaxVersion int16
+}
+
+func (f *SupportedFeatureKey) encode(pe packetEncoder) error {
+	if err := pe.putString(f.Name); err != nil {
+		return err
+	}
+
+	pe.putInt16(f.MinVersion)
+
+	pe.putInt16(f.MaxVersion)
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (f *SupportedFeatureKey) decode(pd packetDecoder) (err error) {
+	if f.Name, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if f.MinVersion, err = pd.getInt16(); err != nil {
+		return err
+	}
+
+	if f.MaxVersion, err = pd.getInt16(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+// FinalizedFeatureKey contains a cluster-wide finalized feature.
+type FinalizedFeatureKey struct {
+	// Name contains the name of the feature.
+	Name string
+	// MaxVersionLevel contains the cluster-wide finalized max version level for the feature.
+	MaxVersionLevel int16
+	// MinVersionLevel contains the cluster-wide finalized min version level for the feature.
+	MinVersionLevel int16
+}
+
+func (f *FinalizedFeatureKey) encode(pe packetEncoder) error {
+	if err := pe.putString(f.Name); err != nil {
+		return err
+	}
+
+	pe.putInt16(f.MaxVersionLevel)
+
+	pe.putInt16(f.MinVersionLevel)
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (f *FinalizedFeatureKey) decode(pd packetDecoder) (err error) {
+	if f.Name, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if f.MaxVersionLevel, err = pd.getInt16(); err != nil {
+		return err
+	}
+
+	if f.MinVersionLevel, err = pd.getInt16(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
 type ApiVersionsResponse struct {
 	// Version defines the protocol version to use for encode and decode
 	Version int16
@@ -58,6 +138,12 @@ type ApiVersionsResponse struct {
 	ApiKeys []ApiVersionsResponseKey
 	// ThrottleTimeMs contains the duration in milliseconds for which the request was throttled due to a quota violation, or zero if the request did not violate any quota.
 	ThrottleTimeMs int32
+	// SupportedFeatures contains the features supported by the broker. (v3+, tag 0)
+	SupportedFeatures []SupportedFeatureKey
+	// FinalizedFeaturesEpoch contains the monotonically increasing epoch for the finalized features information, or -1 if unknown. (v3+, tag 1)
+	FinalizedFeaturesEpoch int64
+	// FinalizedFeatures contains the cluster-wide finalized features; the information is only valid if FinalizedFeaturesEpoch >= 0. (v3+, tag 2)
+	FinalizedFeatures []FinalizedFeatureKey
 }
 
 func (r *ApiVersionsResponse) setVersion(v int16) {
@@ -81,9 +167,79 @@ func (r *ApiVersionsResponse) encode(pe packetEncoder) (err error) {
 	}
 
 	if r.Version >= 3 {
-		pe.putEmptyTaggedFieldArray()
+		return r.encodeTaggedFields(pe)
 	}
 
+	return nil
+}
+
+func (r *ApiVersionsResponse) encodeTaggedFields(pe packetEncoder) error {
+	type taggedField struct {
+		tag   uint64
+		value []byte
+	}
+	var fields []taggedField
+
+	if len(r.SupportedFeatures) > 0 {
+		value, err := encode(taggedFieldValue(func(pe packetEncoder) error {
+			if err := pe.putArrayLength(len(r.SupportedFeatures)); err != nil {
+				return err
+			}
+			for i := range r.SupportedFeatures {
+				if err := r.SupportedFeatures[i].encode(pe); err != nil {
+					return err
+				}
+			}
+			return nil
+		}), nil)
+		if err != nil {
+			return err
+		}
+		fields = append(fields, taggedField{tag: 0, value: value})
+	}
+
+	if r.FinalizedFeaturesEpoch >= 0 {
+		value, err := encode(taggedFieldValue(func(pe packetEncoder) error {
+			pe.putInt64(r.FinalizedFeaturesEpoch)
+			return nil
+		}), nil)
+		if err != nil {
+			return err
+		}
+		fields = append(fields, taggedField{tag: 1, value: value})
+	}
+
+	if len(r.FinalizedFeatures) > 0 {
+		value, err := encode(taggedFieldValue(func(pe packetEncoder) error {
+			if err := pe.putArrayLength(len(r.FinalizedFeatures)); err != nil {
+				return err
+			}
+			for i := range r.FinalizedFeatures {
+				if err := r.FinalizedFeatures[i].encode(pe); err != nil {
+					return err
+				}
+			}
+			return nil
+		}), nil)
+		if err != nil {
+			return err
+		}
+		fields = append(fields, taggedField{tag: 2, value: value})
+	}
+
+	if len(fields) == 0 {
+		pe.putEmptyTaggedFieldArray()
+		return nil
+	}
+
+	pe.putUVarint(uint64(len(fields)))
+	for _, f := range fields {
+		pe.putUVarint(f.tag)
+		pe.putUVarint(uint64(len(f.value)))
+		if err := pe.putRawBytes(f.value); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -124,8 +280,49 @@ func (r *ApiVersionsResponse) decode(pd packetDecoder, version int16) (err error
 		}
 	}
 
-	_, err = pd.getEmptyTaggedFieldArray()
-	return err
+	if r.Version >= 3 {
+		r.FinalizedFeaturesEpoch = -1
+		return pd.getTaggedFieldArray(taggedFieldDecoders{
+			0: func(pd packetDecoder) error {
+				n, err := pd.getArrayLength()
+				if err != nil {
+					return err
+				}
+				if n < 0 {
+					return errInvalidArrayLength
+				}
+				r.SupportedFeatures = make([]SupportedFeatureKey, n)
+				for i := range n {
+					if err := r.SupportedFeatures[i].decode(pd); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			1: func(pd packetDecoder) (err error) {
+				r.FinalizedFeaturesEpoch, err = pd.getInt64()
+				return err
+			},
+			2: func(pd packetDecoder) error {
+				n, err := pd.getArrayLength()
+				if err != nil {
+					return err
+				}
+				if n < 0 {
+					return errInvalidArrayLength
+				}
+				r.FinalizedFeatures = make([]FinalizedFeatureKey, n)
+				for i := range n {
+					if err := r.FinalizedFeatures[i].decode(pd); err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+		})
+	}
+
+	return nil
 }
 
 func (r *ApiVersionsResponse) key() int16 {

--- a/api_versions_response_test.go
+++ b/api_versions_response_test.go
@@ -48,6 +48,29 @@ var (
 		0x00, // empty tagged fields
 	}
 
+	apiVersionResponseV3Features = []byte{
+		0x00, 0x00, // no error
+		0x02,                               // compact array length 1 (APIs)
+		0x00, 0x12, 0x00, 0x00, 0x00, 0x03, // API Version ApiVersions (v0-3)
+		0x00,                   // empty tagged fields
+		0x00, 0x00, 0x00, 0x80, // throttle time (128ms)
+		0x03,       // 3 tagged fields
+		0x00, 0x14, // tag 0 (supported_features), length 20
+		0x02,                                                                  // compact array length 1
+		0x0e, 's', 'h', 'a', 'r', 'e', '.', 'v', 'e', 'r', 's', 'i', 'o', 'n', // name
+		0x00, 0x00, // min version 0
+		0x00, 0x01, // max version 1
+		0x00,       // empty tagged fields
+		0x01, 0x08, // tag 1 (finalized_features_epoch), length 8
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x27, // epoch 39
+		0x02, 0x14, // tag 2 (finalized_features), length 20
+		0x02,                                                                  // compact array length 1
+		0x0e, 's', 'h', 'a', 'r', 'e', '.', 'v', 'e', 'r', 's', 'i', 'o', 'n', // name
+		0x00, 0x01, // max version level 1
+		0x00, 0x00, // min version level 0
+		0x00, // empty tagged fields
+	}
+
 	// unsupported version from kafka 0.10.2.1
 	apiVersionsResponseUnsupportedVersionV0 = []byte{
 		0x00, 0x23, // unsupported version error
@@ -122,6 +145,25 @@ func TestApiVersionsResponseV3(t *testing.T) {
 		{v, 5, 0, 2},  // API Version StopReplica (v0-2)
 	}, response.ApiKeys)
 	assert.Equal(t, int32(128), response.ThrottleTimeMs)
+	assert.Equal(t, int64(-1), response.FinalizedFeaturesEpoch)
+	assert.Empty(t, response.SupportedFeatures)
+	assert.Empty(t, response.FinalizedFeatures)
+
+	withFeatures := &ApiVersionsResponse{
+		Version: v,
+		ApiKeys: []ApiVersionsResponseKey{
+			{v, 18, 0, 3}, // API Version ApiVersions (v0-3)
+		},
+		ThrottleTimeMs: 128,
+		SupportedFeatures: []SupportedFeatureKey{
+			{Name: "share.version", MinVersion: 0, MaxVersion: 1},
+		},
+		FinalizedFeaturesEpoch: 39,
+		FinalizedFeatures: []FinalizedFeatureKey{
+			{Name: "share.version", MaxVersionLevel: 1, MinVersionLevel: 0},
+		},
+	}
+	testResponse(t, "with features V3", withFeatures, apiVersionResponseV3Features)
 }
 
 func TestApiVersionsResponseUnsupportedVersion(t *testing.T) {

--- a/encoder_decoder.go
+++ b/encoder_decoder.go
@@ -45,6 +45,16 @@ func encode(e encoder, metricRegistry metrics.Registry) ([]byte, error) {
 	return realEnc.raw, nil
 }
 
+// taggedFieldValue adapts an encode closure for encode(); tagged-field values
+// are always compact-encoded, so it reports itself as flexible
+type taggedFieldValue func(pe packetEncoder) error
+
+func (f taggedFieldValue) encode(pe packetEncoder) error { return f(pe) }
+
+func (f taggedFieldValue) isFlexible() bool { return true }
+
+func (f taggedFieldValue) isFlexibleVersion(int16) bool { return true }
+
 // decoder is the interface that wraps the basic Decode method.
 // Anything implementing Decoder can be extracted from bytes using Kafka's encoding rules.
 type decoder interface {


### PR DESCRIPTION
Parse the `SupportedFeatures`, `FinalizedFeaturesEpoch` and `FinalizedFeatures` tagged fields on the v3 ApiVersionsResponse, and re-encode them on round-trips. This gives clients the same view of broker features as the Java client's `describeFeatures` (KIP-584).

- `FinalizedFeaturesEpoch` defaults to `-1` (unknown) when the tag is absent, matching the Java client
- unknown tags (e.g. `ZkMigrationReady`) continue to be skipped
- adds a small `flexibleEncode` helper to size and emit variable-length tagged-field values through the existing two-pass encoder machinery

Since sarama already negotiates ApiVersions v3 on connection handshake, feature data from KRaft brokers flows into the response struct with no further changes. Follow-up: the `TestFuncAdminUpdateFeatures` FVT from #3632 can switch its version-window gate to a client-side precondition check using these fields.