### PR TITLE
feat: support ApiVersions V4 and discover upgradable features in test

### DIFF
--- a/api_versions_request.go
+++ b/api_versions_request.go
@@ -60,7 +60,7 @@ func (r *ApiVersionsRequest) headerVersion() int16 {
 }
 
 func (r *ApiVersionsRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 3
+	return r.Version >= 0 && r.Version <= 4
 }
 
 func (r *ApiVersionsRequest) isFlexible() bool {
@@ -73,6 +73,8 @@ func (r *ApiVersionsRequest) isFlexibleVersion(version int16) bool {
 
 func (r *ApiVersionsRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 4:
+		return V3_9_0_0
 	case 3:
 		return V2_4_0_0
 	case 2:

--- a/api_versions_request_test.go
+++ b/api_versions_request_test.go
@@ -26,3 +26,12 @@ func TestApiVersionsRequestV3(t *testing.T) {
 	request.ClientSoftwareVersion = "0.10.0"
 	testRequest(t, "v3", request, apiVersionRequestV3)
 }
+
+func TestApiVersionsRequestV4(t *testing.T) {
+	// v4 shares the v3 wire format
+	request := new(ApiVersionsRequest)
+	request.Version = 4
+	request.ClientSoftwareName = "sarama"
+	request.ClientSoftwareVersion = "0.10.0"
+	testRequest(t, "v4", request, apiVersionRequestV3)
+}

--- a/api_versions_response.go
+++ b/api_versions_response.go
@@ -340,7 +340,7 @@ func (r *ApiVersionsResponse) headerVersion() int16 {
 }
 
 func (r *ApiVersionsResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 3
+	return r.Version >= 0 && r.Version <= 4
 }
 
 func (r *ApiVersionsResponse) isFlexible() bool {
@@ -353,6 +353,8 @@ func (r *ApiVersionsResponse) isFlexibleVersion(version int16) bool {
 
 func (r *ApiVersionsResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 4:
+		return V3_9_0_0
 	case 3:
 		return V2_4_0_0
 	case 2:

--- a/api_versions_response_test.go
+++ b/api_versions_response_test.go
@@ -149,21 +149,24 @@ func TestApiVersionsResponseV3(t *testing.T) {
 	assert.Empty(t, response.SupportedFeatures)
 	assert.Empty(t, response.FinalizedFeatures)
 
-	withFeatures := &ApiVersionsResponse{
-		Version: v,
-		ApiKeys: []ApiVersionsResponseKey{
-			{v, 18, 0, 3}, // API Version ApiVersions (v0-3)
-		},
-		ThrottleTimeMs: 128,
-		SupportedFeatures: []SupportedFeatureKey{
-			{Name: "share.version", MinVersion: 0, MaxVersion: 1},
-		},
-		FinalizedFeaturesEpoch: 39,
-		FinalizedFeatures: []FinalizedFeatureKey{
-			{Name: "share.version", MaxVersionLevel: 1, MinVersionLevel: 0},
-		},
+	// v4 shares the v3 wire format
+	for _, fv := range []int16{3, 4} {
+		withFeatures := &ApiVersionsResponse{
+			Version: fv,
+			ApiKeys: []ApiVersionsResponseKey{
+				{fv, 18, 0, 3}, // API Version ApiVersions (v0-3)
+			},
+			ThrottleTimeMs: 128,
+			SupportedFeatures: []SupportedFeatureKey{
+				{Name: "share.version", MinVersion: 0, MaxVersion: 1},
+			},
+			FinalizedFeaturesEpoch: 39,
+			FinalizedFeatures: []FinalizedFeatureKey{
+				{Name: "share.version", MaxVersionLevel: 1, MinVersionLevel: 0},
+			},
+		}
+		testResponse(t, "with features", withFeatures, apiVersionResponseV3Features)
 	}
-	testResponse(t, "with features V3", withFeatures, apiVersionResponseV3Features)
 }
 
 func TestApiVersionsResponseUnsupportedVersion(t *testing.T) {

--- a/broker.go
+++ b/broker.go
@@ -246,14 +246,20 @@ func (b *Broker) Open(conf *Config) error {
 		// It will be used to determine the supported API versions for each request.
 		// This should happen before SASL authentication: https://kafka.apache.org/42/design/protocol/#retrieving-supported-api-versions
 		if conf.ApiVersionsRequest {
-			apiVersionsResponse, err := b.sendAndReceiveApiVersions(3)
+			// v4 additionally includes supported features whose min version is 0,
+			// which v0-v3 omit from the response
+			apiVersionsVersion := int16(3)
+			if conf.Version.IsAtLeast(V3_9_0_0) {
+				apiVersionsVersion = 4
+			}
+			apiVersionsResponse, err := b.sendAndReceiveApiVersions(apiVersionsVersion)
 			if err != nil {
 				if b.maybeCloseLocked(err) {
 					// Open is async, so we can't return the error here; surface it via Connected().
 					return
 				}
 
-				Logger.Printf("Error while sending ApiVersionsRequest V3 to broker %s: %s\n", b.addr, err)
+				Logger.Printf("Error while sending ApiVersionsRequest V%d to broker %s: %s\n", apiVersionsVersion, b.addr, err)
 				// send a lower version request in case remote cluster is <= 2.4.0.0
 				maxVersion := int16(0)
 				if apiVersionsResponse != nil {

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -1041,16 +1041,59 @@ func TestFuncAdminUpdateFeatures(t *testing.T) {
 	}})
 	require.ErrorIs(t, err, ErrInvalidUpdateVersion)
 
-	// share.version (KIP-932) ships disabled on 4.1 (finalized 0, max 1),
-	// so we can do a real upgrade here
-	if kafkaVersion.IsAtLeast(V4_1_0_0) && !kafkaVersion.IsAtLeast(V4_2_0_0) {
-		results, err := adminClient.UpdateFeatures([]FeatureUpdate{{
-			Feature:         "share.version",
-			MaxVersionLevel: 1,
-		}})
+	controller, err := adminClient.Controller()
+	require.NoError(t, err)
+
+	describeFeatures := func(t require.TestingT) (supported map[string]int16, finalized map[string]int16) {
+		rsp, err := controller.ApiVersions(&ApiVersionsRequest{
+			Version:               3,
+			ClientSoftwareName:    defaultClientSoftwareName,
+			ClientSoftwareVersion: version(),
+		})
 		require.NoError(t, err)
-		require.Len(t, results, 1)
-		assert.Equal(t, "share.version", results[0].Feature)
-		assert.Equal(t, ErrNoError, results[0].ErrorCode)
+		supported = make(map[string]int16, len(rsp.SupportedFeatures))
+		for _, f := range rsp.SupportedFeatures {
+			supported[f.Name] = f.MaxVersion
+		}
+		finalized = make(map[string]int16, len(rsp.FinalizedFeatures))
+		for _, f := range rsp.FinalizedFeatures {
+			finalized[f.Name] = f.MaxVersionLevel
+		}
+		return supported, finalized
 	}
+
+	supported, finalized := describeFeatures(t)
+	require.NotEmpty(t, supported)
+
+	// upgrade every feature whose finalized level sits below the supported
+	// max, one batch each so a single rejection doesn't sink the rest
+	upgraded := make(map[string]int16)
+	for name, maxVersion := range supported {
+		// kraft.version upgrades are refused on a static-quorum cluster
+		if name == "kraft.version" || finalized[name] >= maxVersion {
+			continue
+		}
+		results, err := adminClient.UpdateFeatures([]FeatureUpdate{{
+			Feature:         name,
+			MaxVersionLevel: maxVersion,
+		}})
+		require.NoError(t, err, "upgrade %s to %d", name, maxVersion)
+		require.Len(t, results, 1)
+		assert.Equal(t, name, results[0].Feature)
+		assert.Equal(t, ErrNoError, results[0].ErrorCode)
+		upgraded[name] = maxVersion
+	}
+	if len(upgraded) == 0 {
+		t.Log("no features eligible for upgrade")
+		return
+	}
+	t.Logf("upgraded features: %v", upgraded)
+
+	// finalized levels propagate to brokers via the metadata log, so poll
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		_, finalized := describeFeatures(t)
+		for name, level := range upgraded {
+			assert.Equal(t, level, finalized[name], "feature %s", name)
+		}
+	}, 30*time.Second, 250*time.Millisecond, "finalized feature levels did not reach the requested levels")
 }

--- a/functional_admin_test.go
+++ b/functional_admin_test.go
@@ -1045,8 +1045,9 @@ func TestFuncAdminUpdateFeatures(t *testing.T) {
 	require.NoError(t, err)
 
 	describeFeatures := func(t require.TestingT) (supported map[string]int16, finalized map[string]int16) {
+		// v4 needed: v0-v3 responses omit supported features with min version 0
 		rsp, err := controller.ApiVersions(&ApiVersionsRequest{
-			Version:               3,
+			Version:               4,
 			ClientSoftwareName:    defaultClientSoftwareName,
 			ClientSoftwareVersion: version(),
 		})

--- a/request_test.go
+++ b/request_test.go
@@ -447,8 +447,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				// apiKeyListOffsets:         9, // up from 8
 				// TODO: FindCoordinatorRequest v6 is not supported, but expected for KafkaVersion 3.9.0
 				// apiKeyFindCoordinator:     6,  // up from 5
-				// TODO: ApiVersionsRequest v4 is not supported, but expected for KafkaVersion 3.9.0
-				// apiKeyApiVersions:         4,  // up from 3
+				apiKeyApiVersions: 4, // up from 3
 			},
 		},
 		{


### PR DESCRIPTION
Rather than hardcoding share.version on a 4.1 version window, upgrade whichever features the controller advertises below their supported max and verify the finalized levels afterwards.