### PR TITLE
feat: support Metadata V11

### DIFF
--- a/api_versions_test.go
+++ b/api_versions_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestRestrictApiVersionLowersVersionToBrokerMax(t *testing.T) {
 	request := NewMetadataRequest(V2_8_0_0, []string{"test-topic"})
 
-	if request.version() != 10 {
-		t.Errorf("Expected MetadataRequest version to be 10, got %d", request.version())
+	if request.version() != 11 {
+		t.Errorf("Expected MetadataRequest version to be 11, got %d", request.version())
 	}
 
 	brokerVersions := apiVersionMap{

--- a/metadata_request.go
+++ b/metadata_request.go
@@ -17,7 +17,7 @@ type MetadataRequest struct {
 	Topics []string
 	// AllowAutoTopicCreation contains a If this is true, the broker may auto-create topics that we requested which do not already exist, if it is configured to do so.
 	AllowAutoTopicCreation             bool
-	IncludeClusterAuthorizedOperations bool // version 8 and up
+	IncludeClusterAuthorizedOperations bool // versions 8 to 10
 	IncludeTopicAuthorizedOperations   bool // version 8 and up
 }
 
@@ -28,7 +28,7 @@ func (r *MetadataRequest) setVersion(v int16) {
 func NewMetadataRequest(version KafkaVersion, topics []string) *MetadataRequest {
 	m := &MetadataRequest{Topics: topics}
 	if version.IsAtLeast(V2_8_0_0) {
-		m.Version = 10
+		m.Version = 11
 	} else if version.IsAtLeast(V2_4_0_0) {
 		m.Version = 9
 	} else if version.IsAtLeast(V2_4_0_0) {
@@ -50,7 +50,7 @@ func NewMetadataRequest(version KafkaVersion, topics []string) *MetadataRequest 
 }
 
 func (r *MetadataRequest) encode(pe packetEncoder) (err error) {
-	if r.Version < 0 || r.Version > 10 {
+	if r.Version < 0 || r.Version > 11 {
 		return PacketEncodingError{"invalid or unsupported MetadataRequest version field"}
 	}
 	if r.Version == 0 || len(r.Topics) > 0 {
@@ -64,7 +64,7 @@ func (r *MetadataRequest) encode(pe packetEncoder) (err error) {
 				}
 				pe.putEmptyTaggedFieldArray()
 			}
-		} else { // r.Version = 10
+		} else { // r.Version >= 10
 			for _, topicName := range r.Topics {
 				if err := pe.putRawBytes(NullUUID); err != nil {
 					return err
@@ -86,8 +86,10 @@ func (r *MetadataRequest) encode(pe packetEncoder) (err error) {
 	if r.Version > 3 {
 		pe.putBool(r.AllowAutoTopicCreation)
 	}
-	if r.Version > 7 {
+	if r.Version >= 8 && r.Version <= 10 {
 		pe.putBool(r.IncludeClusterAuthorizedOperations)
+	}
+	if r.Version > 7 {
 		pe.putBool(r.IncludeTopicAuthorizedOperations)
 	}
 	pe.putEmptyTaggedFieldArray()
@@ -139,17 +141,16 @@ func (r *MetadataRequest) decode(pd packetDecoder, version int16) (err error) {
 		}
 	}
 
+	if r.Version >= 8 && r.Version <= 10 {
+		if r.IncludeClusterAuthorizedOperations, err = pd.getBool(); err != nil {
+			return err
+		}
+	}
+
 	if r.Version > 7 {
-		includeClusterAuthz, err := pd.getBool()
-		if err != nil {
+		if r.IncludeTopicAuthorizedOperations, err = pd.getBool(); err != nil {
 			return err
 		}
-		r.IncludeClusterAuthorizedOperations = includeClusterAuthz
-		includeTopicAuthz, err := pd.getBool()
-		if err != nil {
-			return err
-		}
-		r.IncludeTopicAuthorizedOperations = includeTopicAuthz
 	}
 
 	_, err = pd.getEmptyTaggedFieldArray()
@@ -172,7 +173,7 @@ func (r *MetadataRequest) headerVersion() int16 {
 }
 
 func (r *MetadataRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 10
+	return r.Version >= 0 && r.Version <= 11
 }
 
 func (r *MetadataRequest) isFlexible() bool {
@@ -185,7 +186,7 @@ func (r *MetadataRequest) isFlexibleVersion(version int16) bool {
 
 func (r *MetadataRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
-	case 10:
+	case 10, 11:
 		return V2_8_0_0
 	case 9:
 		return V2_4_0_0

--- a/metadata_request_test.go
+++ b/metadata_request_test.go
@@ -110,6 +110,47 @@ var (
 		3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 't', 'o', 'p', 'i', 'c', '1',
 		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 't', 'o', 'p', 'i', 'c', '2', 0, 1, 1, 1, 0,
 	}
+
+	// v11 drops the IncludeClusterAuthorizedOperations request field (KIP-700);
+	// it is now exposed by the DescribeCluster API.
+	metadataRequestNoTopicsV11 = []byte{
+		0x00, // Topics (null)
+		0x00, // AllowAutoTopicCreation
+		0x00, // IncludeTopicAuthorizedOperations
+		0x00, // tagged fields
+	}
+
+	metadataRequestTwoTopicsV11 = []byte{
+		0x03, // Topics length
+		// topic1
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // TopicId
+		0x07, 't', 'o', 'p', 'i', 'c', '1', // Name
+		0x00, // tagged fields
+		// topic2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // TopicId
+		0x07, 't', 'o', 'p', 'i', 'c', '2', // Name
+		0x00, // tagged fields
+
+		0x00, // AllowAutoTopicCreation
+		0x00, // IncludeTopicAuthorizedOperations
+		0x00, // tagged fields
+	}
+
+	metadataRequestAutoCreateTopicAuthV11 = []byte{
+		0x03, // Topics length
+		// topic1
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // TopicId
+		0x07, 't', 'o', 'p', 'i', 'c', '1', // Name
+		0x00, // tagged fields
+		// topic2
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // TopicId
+		0x07, 't', 'o', 'p', 'i', 'c', '2', // Name
+		0x00, // tagged fields
+
+		0x01, // AllowAutoTopicCreation
+		0x01, // IncludeTopicAuthorizedOperations
+		0x00, // tagged fields
+	}
 )
 
 func TestMetadataRequestV0(t *testing.T) {
@@ -259,4 +300,17 @@ func TestMetadataRequestV10(t *testing.T) {
 	request.IncludeClusterAuthorizedOperations = true
 	request.IncludeTopicAuthorizedOperations = true
 	testRequest(t, "one topic, auto create, cluster auth, topic auth", request, metadataRequestAutoCreateClusterAuthTopicAuthV10)
+}
+
+func TestMetadataRequestV11(t *testing.T) {
+	request := new(MetadataRequest)
+	request.Version = 11
+	testRequest(t, "no topics", request, metadataRequestNoTopicsV11)
+
+	request.Topics = []string{"topic1", "topic2"}
+	testRequest(t, "two topics", request, metadataRequestTwoTopicsV11)
+
+	request.AllowAutoTopicCreation = true
+	request.IncludeTopicAuthorizedOperations = true
+	testRequest(t, "two topics, auto create, topic auth", request, metadataRequestAutoCreateTopicAuthV11)
 }

--- a/metadata_response.go
+++ b/metadata_response.go
@@ -221,7 +221,7 @@ type MetadataResponse struct {
 	ControllerID int32
 	// Topics contains each topic in the response.
 	Topics                      []*TopicMetadata
-	ClusterAuthorizedOperations int32 // Only valid for Version >= 8
+	ClusterAuthorizedOperations int32 // Only valid for Version 8 to 10
 }
 
 func (r *MetadataResponse) setVersion(v int16) {
@@ -283,7 +283,7 @@ func (r *MetadataResponse) decode(pd packetDecoder, version int16) (err error) {
 		}
 	}
 
-	if r.Version >= 8 {
+	if r.Version >= 8 && r.Version <= 10 {
 		r.ClusterAuthorizedOperations, err = pd.getInt32()
 		if err != nil {
 			return err
@@ -332,7 +332,7 @@ func (r *MetadataResponse) encode(pe packetEncoder) (err error) {
 		}
 	}
 
-	if r.Version >= 8 {
+	if r.Version >= 8 && r.Version <= 10 {
 		pe.putInt32(r.ClusterAuthorizedOperations)
 	}
 
@@ -357,7 +357,7 @@ func (r *MetadataResponse) headerVersion() int16 {
 }
 
 func (r *MetadataResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 10
+	return r.Version >= 0 && r.Version <= 11
 }
 
 func (r *MetadataResponse) isFlexible() bool {
@@ -370,7 +370,7 @@ func (r *MetadataResponse) isFlexibleVersion(version int16) bool {
 
 func (r *MetadataResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
-	case 10:
+	case 10, 11:
 		return V2_8_0_0
 	case 9:
 		return V2_4_0_0

--- a/metadata_response_test.go
+++ b/metadata_response_test.go
@@ -5,6 +5,9 @@ package sarama
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -174,6 +177,43 @@ var (
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7b, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00,
 		0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0x00, 0x01, 'Y', 0x00, 0x00, 0x00, 0x00, 0xea, 0x00,
+	}
+
+	// v11 drops the ClusterAuthorizedOperations response field (KIP-700);
+	// it is now exposed by the DescribeCluster API.
+	OneTopicV11 = []byte{
+		0x00, 0x00, 0x00, 0x00, // ThrottleTimeMs
+		0x02, // Brokers
+		// broker
+		0x00, 0x00, 0x00, 0x00, // NodeId
+		0x05, 'h', 'o', 's', 't', // Host
+		0x00, 0x00, 0x23, 0x84, // Port
+		0x00, // Rack
+		0x00, // tagged fields
+
+		0x0a, 'c', 'l', 'u', 's', 't', 'e', 'r', 'I', 'd', // ClusterId
+		0x00, 0x00, 0x00, 0x01, // ControllerId
+		0x02, // Topics
+		// topic
+		0x00, 0x00, // ErrorCode
+		0x05, 't', 'o', 'n', 'y', // Name
+		0x84, 0xcd, 0xa7, 'U', 0x7e, 0x84, 'K', 0xf9, 0xb7, 0xdc, 0xfc, 0x11, 0x82, 0x07, 'r', 'J', // TopicId
+		0x00, // IsInternal
+		0x02, // Partitions
+		// partition
+		0x00, 0x00, // ErrorCode
+		0x00, 0x00, 0x00, 0x00, // PartitionIndex
+		0x00, 0x00, 0x00, 0x00, // LeaderId
+		0x00, 0x00, 0x00, 0x7b, // LeaderEpoch
+		0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, // ReplicaNodes
+		0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, // IsrNodes
+		0x01, // OfflineReplicas
+		0x00, // tagged fields
+
+		0x00, 0x00, 0x01, 'Y', // TopicAuthorizedOperations
+		0x00, // tagged fields
+
+		0x00, // tagged fields
 	}
 )
 
@@ -533,6 +573,27 @@ func TestMetadataResponseV10(t *testing.T) {
 	if response.Topics[0].Partitions[0].LeaderEpoch != 123 {
 		t.Error("Decoding produced", response.Topics[0].Partitions[0].LeaderEpoch, "should have been 123!")
 	}
+}
+
+func TestMetadataResponseV11(t *testing.T) {
+	response := MetadataResponse{}
+
+	testVersionDecodable(t, "1 topic with topic id V11", &response, OneTopicV11, 11)
+	assert.Zero(t, response.ThrottleTimeMs)
+	require.Len(t, response.Brokers, 1)
+	assert.Equal(t, "host:9092", response.Brokers[0].addr)
+	assert.Equal(t, int32(1), response.ControllerID)
+	require.NotNil(t, response.ClusterID)
+	assert.Equal(t, "clusterId", *response.ClusterID)
+	require.Len(t, response.Topics, 1)
+	assert.Equal(t, Uuid{
+		0x84, 0xcd, 0xa7, 0x55, 0x7e, 0x84, 0x4b, 0xf9,
+		0xb7, 0xdc, 0xfc, 0x11, 0x82, 0x07, 0x72, 0x4a,
+	}, response.Topics[0].Uuid)
+	assert.Equal(t, int32(345), response.Topics[0].TopicAuthorizedOperations)
+	require.Len(t, response.Topics[0].Partitions, 1)
+	assert.Empty(t, response.Topics[0].Partitions[0].OfflineReplicas)
+	assert.Equal(t, int32(123), response.Topics[0].Partitions[0].LeaderEpoch)
 }
 
 func TestFlexibleMetadataResponseInvalidInt32ArrayLength(t *testing.T) {

--- a/request_test.go
+++ b/request_test.go
@@ -317,7 +317,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V2_8_0_0,
 			map[int16]int16{
-				apiKeyMetadata:             10, // up from 9
+				apiKeyMetadata:             11, // up from 9
 				apiKeyDescribeClientQuotas: 1,  // up from 0
 				apiKeyDescribeCluster:      0,  // new in 2.8
 				apiKeyDescribeConfigs:      4,  // up from 3
@@ -325,8 +325,6 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyProduce:              9,  // up from 8
 				// TODO: ListOffsetsRequest v6 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyListOffsets:          6, // up from 5
-				// TODO: MetadataRequest v11 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyMetadata:             11, // up from 9
 				// TODO: AddOffsetsToTxnRequest v3 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyAddOffsetsToTxn:      3, // up from 2
 				// TODO: EndTxnRequest v3 is not supported, but expected for KafkaVersion 2.8.0


### PR DESCRIPTION
Bump MetadataRequest/Response to v11, which deprecates the cluster-authorized-operations fields (now served by DescribeCluster) per KIP-700. Negotiate v11 at Kafka 2.8.0.