### PR TITLE
feat: support Produce V10

### DIFF
--- a/produce_request.go
+++ b/produce_request.go
@@ -255,11 +255,13 @@ func (r *ProduceRequest) isFlexibleVersion(version int16) bool {
 }
 
 func (r *ProduceRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 9
+	return r.Version >= 0 && r.Version <= 10
 }
 
 func (r *ProduceRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 10:
+		return V3_7_0_0
 	case 9:
 		return V2_8_0_0
 	case 8:

--- a/produce_response.go
+++ b/produce_response.go
@@ -22,12 +22,62 @@ import (
 
 // partition_responses in protocol
 type ProduceResponseBlock struct {
-	Err          KError                       // v0, error_code
-	Offset       int64                        // v0, base_offset
-	Timestamp    time.Time                    // v2, log_append_time, and the broker is configured with `LogAppendTime`
-	StartOffset  int64                        // v5, log_start_offset
-	RecordErrors []ProduceResponseRecordError // v8, record_errors (KIP-467)
-	ErrorMessage *string                      // v8, error_message (KIP-467)
+	Err           KError                        // v0, error_code
+	Offset        int64                         // v0, base_offset
+	Timestamp     time.Time                     // v2, log_append_time, and the broker is configured with `LogAppendTime`
+	StartOffset   int64                         // v5, log_start_offset
+	RecordErrors  []ProduceResponseRecordError  // v8, record_errors (KIP-467)
+	ErrorMessage  *string                       // v8, error_message (KIP-467)
+	CurrentLeader *ProduceResponseCurrentLeader // v10, current_leader (tagged)
+}
+
+// ProduceResponseCurrentLeader is the new partition leader the broker returns
+// on a NOT_LEADER_OR_FOLLOWER error, so the client can retry without a metadata
+// refresh. Added in Produce response v10 (KIP-951).
+type ProduceResponseCurrentLeader struct {
+	LeaderID    int32 // v10, leader_id
+	LeaderEpoch int32 // v10, leader_epoch
+}
+
+// ProduceResponseNodeEndpoint is the host and port for a leader named by a
+// CurrentLeader hint. Added in Produce response v10 (KIP-951).
+type ProduceResponseNodeEndpoint struct {
+	NodeID int32   // v10, node_id
+	Host   string  // v10, host
+	Port   int32   // v10, port
+	Rack   *string // v10, rack (nullable)
+}
+
+func (e *ProduceResponseNodeEndpoint) encode(pe packetEncoder) error {
+	pe.putInt32(e.NodeID)
+	if err := pe.putString(e.Host); err != nil {
+		return err
+	}
+	pe.putInt32(e.Port)
+	if err := pe.putNullableString(e.Rack); err != nil {
+		return err
+	}
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (e *ProduceResponseNodeEndpoint) decode(pd packetDecoder) (err error) {
+	if e.NodeID, err = pd.getInt32(); err != nil {
+		return err
+	}
+	if e.Host, err = pd.getString(); err != nil {
+		return err
+	}
+	if e.Port, err = pd.getInt32(); err != nil {
+		return err
+	}
+	if e.Rack, err = pd.getNullableString(); err != nil {
+		return err
+	}
+	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ProduceResponseRecordError identifies a record within a produced batch that
@@ -107,6 +157,23 @@ func (b *ProduceResponseBlock) decode(pd packetDecoder, version int16) (err erro
 		}
 	}
 
+	if version >= 10 {
+		return pd.getTaggedFieldArray(taggedFieldDecoders{
+			0: func(pd packetDecoder) error {
+				leaderID, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				leaderEpoch, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				b.CurrentLeader = &ProduceResponseCurrentLeader{LeaderID: leaderID, LeaderEpoch: leaderEpoch}
+				return nil
+			},
+		})
+	}
+
 	if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
 		return err
 	}
@@ -146,15 +213,35 @@ func (b *ProduceResponseBlock) encode(pe packetEncoder, version int16) (err erro
 		}
 	}
 
+	if version >= 10 {
+		b.encodeTaggedFields(pe)
+		return nil
+	}
+
 	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
 
+func (b *ProduceResponseBlock) encodeTaggedFields(pe packetEncoder) {
+	if b.CurrentLeader == nil {
+		pe.putEmptyTaggedFieldArray()
+		return
+	}
+
+	pe.putUVarint(1) // one tagged field
+	pe.putUVarint(0) // tag 0: CurrentLeader
+	pe.putUVarint(9) // two int32s plus the struct's empty tagged fields
+	pe.putInt32(b.CurrentLeader.LeaderID)
+	pe.putInt32(b.CurrentLeader.LeaderEpoch)
+	pe.putEmptyTaggedFieldArray()
+}
+
 type ProduceResponse struct {
-	Blocks       map[string]map[int32]*ProduceResponseBlock // v0, responses
-	Version      int16
-	ThrottleTime time.Duration // v1, throttle_time_ms
+	Blocks        map[string]map[int32]*ProduceResponseBlock // v0, responses
+	Version       int16
+	ThrottleTime  time.Duration                  // v1, throttle_time_ms
+	NodeEndpoints []*ProduceResponseNodeEndpoint // v10, node_endpoints (tagged)
 }
 
 func (r *ProduceResponse) setVersion(v int16) {
@@ -214,6 +301,26 @@ func (r *ProduceResponse) decode(pd packetDecoder, version int16) (err error) {
 		}
 	}
 
+	if r.Version >= 10 {
+		return pd.getTaggedFieldArray(taggedFieldDecoders{
+			0: func(pd packetDecoder) error {
+				n, err := pd.getArrayLength()
+				if err != nil {
+					return err
+				}
+				r.NodeEndpoints = make([]*ProduceResponseNodeEndpoint, n)
+				for i := range r.NodeEndpoints {
+					ep := new(ProduceResponseNodeEndpoint)
+					if err := ep.decode(pd); err != nil {
+						return err
+					}
+					r.NodeEndpoints[i] = ep
+				}
+				return nil
+			},
+		})
+	}
+
 	_, err = pd.getEmptyTaggedFieldArray()
 	return err
 }
@@ -245,8 +352,40 @@ func (r *ProduceResponse) encode(pe packetEncoder) error {
 	if r.Version >= 1 {
 		pe.putDurationMs(r.ThrottleTime)
 	}
+
+	if r.Version >= 10 {
+		return r.encodeTaggedFields(pe)
+	}
+
 	pe.putEmptyTaggedFieldArray()
 	return nil
+}
+
+func (r *ProduceResponse) encodeTaggedFields(pe packetEncoder) error {
+	if len(r.NodeEndpoints) == 0 {
+		pe.putEmptyTaggedFieldArray()
+		return nil
+	}
+
+	value, err := encode(taggedFieldValue(func(pe packetEncoder) error {
+		if err := pe.putArrayLength(len(r.NodeEndpoints)); err != nil {
+			return err
+		}
+		for i := range r.NodeEndpoints {
+			if err := r.NodeEndpoints[i].encode(pe); err != nil {
+				return err
+			}
+		}
+		return nil
+	}), nil)
+	if err != nil {
+		return err
+	}
+
+	pe.putUVarint(1)
+	pe.putUVarint(0)
+	pe.putUVarint(uint64(len(value)))
+	return pe.putRawBytes(value)
 }
 
 func (r *ProduceResponse) key() int16 {
@@ -273,11 +412,13 @@ func (r *ProduceResponse) isFlexibleVersion(version int16) bool {
 }
 
 func (r *ProduceResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 9
+	return r.Version >= 0 && r.Version <= 10
 }
 
 func (r *ProduceResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 10:
+		return V3_7_0_0
 	case 9:
 		return V2_8_0_0
 	case 8:

--- a/produce_response_test.go
+++ b/produce_response_test.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -105,6 +108,65 @@ var (
 			0x00, 0x00, 0x00, 0x64, // 100 ms throttle time
 			0x00, // response tagged fields
 		},
+		10: { // version 10 adds CurrentLeader and NodeEndpoints tagged fields (KIP-951), absent here
+			0x02, // 1 topic
+
+			0x04, 'f', 'o', 'o',
+			0x02, // 1 partition
+
+			0x00, 0x00, 0x00, 0x01, // Partition 1
+			0x00, 0x02, // ErrInvalidMessage
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, // Offset 255
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xE8, // Timestamp January 1st 0001 at 00:00:01,000 UTC (LogAppendTime was used)
+			0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x32, // StartOffset 50
+			0x02,                   // 1 record error
+			0x00, 0x00, 0x00, 0x03, // BatchIndex 3
+			0x08, 'b', 'a', 'd', ' ', 'r', 'e', 'c', // BatchIndexErrorMessage
+			0x00,                                              // record error tagged fields
+			0x0A, 'b', 'a', 'd', ' ', 'b', 'a', 't', 'c', 'h', // ErrorMessage
+			0x00, // partition tagged fields
+			0x00, // topic tagged fields
+
+			0x00, 0x00, 0x00, 0x64, // 100 ms throttle time
+			0x00, // response tagged fields
+		},
+	}
+
+	// produceResponseKIP951V10 carries a NOT_LEADER_OR_FOLLOWER partition with a
+	// populated CurrentLeader hint and the matching NodeEndpoints (KIP-951).
+	produceResponseKIP951V10 = []byte{
+		0x02, // 1 topic
+
+		0x04, 'f', 'o', 'o',
+		0x02, // 1 partition
+
+		0x00, 0x00, 0x00, 0x01, // Partition 1
+		0x00, 0x06, // ErrNotLeaderForPartition
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, // Offset 255
+		0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, // Timestamp -1
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x32, // StartOffset 50
+		0x01, // 0 record errors
+		0x00, // ErrorMessage null
+		// partition tagged fields
+		0x01,                   // 1 tagged field
+		0x00,                   // tag 0 (CurrentLeader)
+		0x09,                   // size
+		0x00, 0x00, 0x00, 0x05, // LeaderID 5
+		0x00, 0x00, 0x00, 0x07, // LeaderEpoch 7
+		0x00, // CurrentLeader tagged fields
+		0x00, // topic tagged fields
+
+		0x00, 0x00, 0x00, 0x64, // 100 ms throttle time
+		// response tagged fields
+		0x01,                   // 1 tagged field
+		0x00,                   // tag 0 (NodeEndpoints)
+		0x0D,                   // size
+		0x02,                   // 1 node endpoint
+		0x00, 0x00, 0x00, 0x05, // NodeID 5
+		0x02, 'h', // Host "h"
+		0x00, 0x00, 0x23, 0x84, // Port 9092
+		0x00, // Rack null
+		0x00, // node endpoint tagged fields
 	}
 )
 
@@ -193,6 +255,41 @@ func TestProduceResponseEncode(t *testing.T) {
 		response.Version = int16(v)
 		testEncodable(t, fmt.Sprintf("many blocks version %d", v), &response, produceResponseManyBlocks)
 	}
+}
+
+func TestProduceResponseV10(t *testing.T) {
+	response := ProduceResponse{Version: 10}
+	response.Blocks = map[string]map[int32]*ProduceResponseBlock{
+		"foo": {
+			1: {
+				Err:           ErrNotLeaderForPartition,
+				Offset:        255,
+				StartOffset:   50,
+				CurrentLeader: &ProduceResponseCurrentLeader{LeaderID: 5, LeaderEpoch: 7},
+			},
+		},
+	}
+	response.ThrottleTime = 100 * time.Millisecond
+	response.NodeEndpoints = []*ProduceResponseNodeEndpoint{
+		{NodeID: 5, Host: "h", Port: 9092},
+	}
+
+	testEncodable(t, "current leader and node endpoints", &response, produceResponseKIP951V10)
+
+	decoded := ProduceResponse{}
+	testVersionDecodable(t, "current leader and node endpoints", &decoded, produceResponseKIP951V10, 10)
+
+	block := decoded.GetBlock("foo", 1)
+	require.NotNil(t, block)
+	require.NotNil(t, block.CurrentLeader)
+	assert.Equal(t, int32(5), block.CurrentLeader.LeaderID)
+	assert.Equal(t, int32(7), block.CurrentLeader.LeaderEpoch)
+
+	require.Len(t, decoded.NodeEndpoints, 1)
+	assert.Equal(t, int32(5), decoded.NodeEndpoints[0].NodeID)
+	assert.Equal(t, "h", decoded.NodeEndpoints[0].Host)
+	assert.Equal(t, int32(9092), decoded.NodeEndpoints[0].Port)
+	assert.Nil(t, decoded.NodeEndpoints[0].Rack)
 }
 
 func TestProduceResponseEncodeInvalidTimestamp(t *testing.T) {

--- a/produce_set.go
+++ b/produce_set.go
@@ -206,6 +206,9 @@ func (ps *produceSet) buildRequest() *ProduceRequest {
 	if ps.parent.conf.Version.IsAtLeast(V2_8_0_0) {
 		req.Version = 9
 	}
+	if ps.parent.conf.Version.IsAtLeast(V3_7_0_0) {
+		req.Version = 10
+	}
 
 	for topic, partitionSets := range ps.msgs {
 		for partition, set := range partitionSets {

--- a/request_test.go
+++ b/request_test.go
@@ -407,9 +407,8 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V3_7_0_0,
 			map[int16]int16{
-				apiKeyDescribeCluster: 1, // up from 0
-				// TODO: ProduceRequest v10 is not supported, but expected for KafkaVersion 3.7.0
-				// apiKeyProduce:         10, // up from 9
+				apiKeyDescribeCluster: 1,  // up from 0
+				apiKeyProduce:         10, // up from 9
 				// TODO: FetchRequest v16 is not supported, but expected for KafkaVersion 3.7.0
 				// apiKeyFetch:           16, // up from 15
 				// TODO: OffsetFetchRequest v9 is not supported, but expected for KafkaVersion 3.7.0


### PR DESCRIPTION
Bump ProduceRequest/Response to v10 (KIP-951). The request is unchanged from v9; the response gains CurrentLeader (per-partition) and NodeEndpoints (top-level) as tagged fields, letting the broker return the new leader on NOT_LEADER_OR_FOLLOWER. Negotiate v10 at Kafka 3.7.0.