### PR TITLE
fix: correct fetch v12 tagged struct encoding

### DIFF
--- a/fetch_response.go
+++ b/fetch_response.go
@@ -357,15 +357,17 @@ func (b *FetchResponseBlock) encodeTaggedFields(pe packetEncoder) {
 	pe.putUVarint(numTaggedFields)
 	if b.DivergingEpoch != nil {
 		pe.putUVarint(0)
-		pe.putUVarint(12)
+		pe.putUVarint(13) // int32 plus int64 plus the struct's empty tagged fields
 		pe.putInt32(b.DivergingEpoch.Epoch)
 		pe.putInt64(b.DivergingEpoch.EndOffset)
+		pe.putEmptyTaggedFieldArray()
 	}
 	if b.CurrentLeader != nil {
 		pe.putUVarint(1)
-		pe.putUVarint(8)
+		pe.putUVarint(9) // two int32s plus the struct's empty tagged fields
 		pe.putInt32(b.CurrentLeader.LeaderID)
 		pe.putInt32(b.CurrentLeader.LeaderEpoch)
+		pe.putEmptyTaggedFieldArray()
 	}
 }
 

--- a/fetch_response_test.go
+++ b/fetch_response_test.go
@@ -223,13 +223,15 @@ var (
 		0x01,                   // Records
 		0x02,                   // Partition tagged fields
 		0x00,                   // DivergingEpoch tag
-		0x0C,                   // DivergingEpoch tag size
+		0x0D,                   // DivergingEpoch tag size
 		0x00, 0x00, 0x00, 0x77, // DivergingEpoch epoch
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // DivergingEpoch end offset
+		0x00,                   // DivergingEpoch tagged fields
 		0x01,                   // CurrentLeader tag
-		0x08,                   // CurrentLeader tag size
+		0x09,                   // CurrentLeader tag size
 		0x00, 0x00, 0x00, 0x09, // CurrentLeader leader ID
 		0x00, 0x00, 0x00, 0x88, // CurrentLeader leader epoch
+		0x00, // CurrentLeader tagged fields
 		0x00, // Topic tagged fields
 		0x00, // Response tagged fields
 	}


### PR DESCRIPTION
The DivergingEpoch and CurrentLeader tagged fields are structs, so in a flexible response each needs its own trailing empty tagged-field array. Without it the encoder wrote a length one byte short, so the bytes didn't match what a broker sends.

Only encoding was affected; decoding slices by the declared length and ignored the missing byte.