### PR TITLE
producer: keep non-idempotent connection retries ordered

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/eapache/go-resiliency/breaker"
@@ -103,6 +104,10 @@ type asyncProducer struct {
 	errors                    chan *ProducerError
 	input, successes, retries chan *ProducerMessage
 	inFlight                  sync.WaitGroup
+	// shutdownCh is closed before waiting on in-flight messages so retryBatch
+	// goroutines can stop waiting on broker handoff and release partition mutes.
+	shutdownCh       chan struct{}
+	shutdownChClosed atomic.Bool
 
 	brokers    map[*Broker]*brokerProducer
 	brokerRefs map[*brokerProducer]int
@@ -314,6 +319,7 @@ func newAsyncProducer(client Client) (AsyncProducer, error) {
 		input:           make(chan *ProducerMessage),
 		successes:       make(chan *ProducerMessage),
 		retries:         make(chan *ProducerMessage),
+		shutdownCh:      make(chan struct{}),
 		brokers:         make(map[*Broker]*brokerProducer),
 		brokerRefs:      make(map[*brokerProducer]int),
 		txnmgr:          txnmgr,
@@ -991,6 +997,7 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 		input:             input,
 		output:            bridge,
 		responses:         responses,
+		done:              make(chan struct{}),
 		accumulatingBatch: newProduceSet(p),
 		currentRetries:    make(map[string]map[int32]error),
 	}
@@ -1104,6 +1111,11 @@ type brokerProducer struct {
 	output    chan<- *produceSet
 	responses <-chan *brokerProducerResponse
 	abandoned chan struct{}
+	// done is closed before output is closed. Direct retry handoff waits on
+	// output while the batch still owns its partition mute; if the brokerProducer
+	// is shutting down, that send may never be received and the mute would block
+	// later same-partition messages and producer shutdown.
+	done chan struct{}
 
 	accumulatingBatch *produceSet
 	flushingBatch     *produceSet // batch that has been muted and is ready to send
@@ -1246,6 +1258,9 @@ func (bp *brokerProducer) tryBuildFlushingBatch() bool {
 }
 
 func (bp *brokerProducer) shutdown() {
+	if bp.done != nil {
+		close(bp.done)
+	}
 	// flush any ready buffer
 	for bp.flushingBatch != nil {
 		select {
@@ -1476,12 +1491,21 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	produceSet.msgs[topic][partition] = pSet
 	produceSet.bufferBytes += pSet.bufferBytes
 	produceSet.bufferCount += len(pSet.msgs)
+	muted := alreadyMuted
+	failBatch := func(err error) {
+		// Release the partition before reporting errors so a blocked Errors
+		// consumer cannot keep later same-partition messages muted.
+		if muted {
+			p.muter.unmute(produceSet)
+			muted = false
+		}
+		for _, msg := range pSet.msgs {
+			p.returnError(msg, err)
+		}
+	}
 	for _, msg := range pSet.msgs {
 		if msg.retries >= p.conf.Producer.Retry.Max {
-			p.returnErrors(pSet.msgs, retryErr)
-			if alreadyMuted {
-				p.muter.unmute(produceSet)
-			}
+			failBatch(retryErr)
 			return
 		}
 		msg.retries++
@@ -1497,25 +1521,88 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	leader, leaderErr := p.client.Leader(topic, partition)
 	if leaderErr != nil {
 		Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", topic, partition, leaderErr)
-		for _, msg := range pSet.msgs {
-			p.returnError(msg, retryErr)
-		}
-		if alreadyMuted {
-			p.muter.unmute(produceSet)
-		}
+		failBatch(retryErr)
 		return
 	}
 	if !alreadyMuted {
 		if !p.muter.waitUntilMuted(produceSet) {
-			for _, msg := range pSet.msgs {
-				p.returnError(msg, retryErr)
-			}
+			failBatch(retryErr)
 			return
 		}
+		muted = true
 	}
 	bp := p.getBrokerProducer(leader)
-	bp.output <- produceSet
-	p.unrefBrokerProducer(leader, bp)
+	defer p.unrefBrokerProducer(leader, bp)
+	if !p.sendRetryBatch(bp, produceSet) {
+		failBatch(ErrShuttingDown)
+		return
+	}
+}
+
+type partitionBatchRetry struct {
+	topic     string
+	partition int32
+	pSet      *partitionSet
+}
+
+// retryBatchesAfterRefresh keeps metadata refresh out of brokerProducer.handleError.
+// Connection errors already hold partition mutes; doing the refresh in the
+// response loop can block all progress for that broker while the cluster is
+// unstable. Refresh once for the failed request so multi-partition batches do
+// not amplify controller-fail metadata traffic, then retry partitions
+// independently so one blocked broker handoff cannot hold up the rest.
+func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []partitionBatchRetry, retryErr error) {
+	if p.shutdownCh != nil {
+		select {
+		case <-p.shutdownCh:
+			for _, batch := range batches {
+				go p.retryBatch(batch.topic, batch.partition, batch.pSet, retryErr, true)
+			}
+			return
+		default:
+		}
+	}
+	if len(topics) > 0 {
+		if err := p.client.RefreshMetadata(topics...); err != nil {
+			Logger.Printf("Failed refreshing metadata because of %v\n", err)
+		}
+	}
+	for _, batch := range batches {
+		go p.retryBatch(batch.topic, batch.partition, batch.pSet, retryErr, true)
+	}
+}
+
+// sendRetryBatch transfers ownership of a muted retry batch to the broker
+// bridge. A false result means no owner accepted the batch, so the caller must
+// release the mute and fail the messages instead of leaving a retry goroutine
+// blocked while it still owns the partition mute.
+func (p *asyncProducer) sendRetryBatch(bp *brokerProducer, set *produceSet) bool {
+	var done <-chan struct{}
+	if bp.done != nil {
+		done = bp.done
+	}
+	select {
+	case <-done:
+		return false
+	default:
+	}
+	select {
+	case bp.output <- set:
+		return true
+	default:
+	}
+	var shutdownCh <-chan struct{}
+	if p.shutdownCh != nil {
+		shutdownCh = p.shutdownCh
+	}
+	select {
+	case bp.output <- set:
+		return true
+	case <-done:
+		return false
+	case <-shutdownCh:
+		return false
+	}
 }
 
 func (bp *brokerProducer) handleError(sent *produceSet, err error) {
@@ -1530,22 +1617,10 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 		bp.parent.abandonBrokerConnection(bp.broker)
 		_ = bp.broker.Close()
 		bp.closing = err
+		keepMuted := make(map[string]map[int32]struct{})
 		var retryTopics []string
 		retryTopicSeen := make(map[string]struct{})
-		sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
-			if _, ok := retryTopicSeen[topic]; ok {
-				return
-			}
-			retryTopicSeen[topic] = struct{}{}
-			retryTopics = append(retryTopics, topic)
-		})
-		if len(retryTopics) > 0 {
-			refreshErr := bp.parent.client.RefreshMetadata(retryTopics...)
-			if refreshErr != nil {
-				Logger.Printf("Failed refreshing metadata because of %v\n", refreshErr)
-			}
-		}
-		keepMuted := make(map[string]map[int32]struct{})
+		var retryBatches []partitionBatchRetry
 		sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
 			// Connection failures have no ProduceResponse to feed back through
 			// partitionProducer. Keep the sent batch muted and retry it asynchronously
@@ -1555,18 +1630,27 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 				bp.currentRetries[topic] = make(map[int32]error)
 			}
 			bp.currentRetries[topic][partition] = err
-			if bp.parent.conf.Producer.Idempotent || pSet.canRetry(bp.parent.conf.Producer.Retry.Max) {
+			if !(bp.parent.conf.Producer.Idempotent || pSet.shouldKeepMuted(bp.parent.conf.Producer.Retry.Max)) {
+				bp.parent.returnErrors(pSet.msgs, err)
+			} else {
 				if keepMuted[topic] == nil {
 					keepMuted[topic] = make(map[int32]struct{})
 				}
 				keepMuted[topic][partition] = struct{}{}
-			}
-			if bp.parent.conf.Producer.Idempotent || pSet.canRetry(bp.parent.conf.Producer.Retry.Max) {
-				go bp.parent.retryBatch(topic, partition, pSet, err, true)
-			} else {
-				bp.parent.retryMessages(pSet.msgs, err)
+				if _, ok := retryTopicSeen[topic]; !ok {
+					retryTopicSeen[topic] = struct{}{}
+					retryTopics = append(retryTopics, topic)
+				}
+				retryBatches = append(retryBatches, partitionBatchRetry{
+					topic:     topic,
+					partition: partition,
+					pSet:      pSet,
+				})
 			}
 		})
+		if len(retryBatches) > 0 {
+			go bp.parent.retryBatchesAfterRefresh(retryTopics, retryBatches, err)
+		}
 		bp.accumulatingBatch.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
 			bp.parent.retryMessages(pSet.msgs, err)
 		})
@@ -1649,6 +1733,9 @@ func (p *asyncProducer) retryHandler() {
 
 func (p *asyncProducer) shutdown() {
 	Logger.Println("Producer shutting down.")
+	if p.shutdownCh != nil && p.shutdownChClosed.CompareAndSwap(false, true) {
+		close(p.shutdownCh)
+	}
 	p.inFlight.Add(1)
 	p.input <- &ProducerMessage{flags: shutdown}
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -388,17 +388,17 @@ type ProducerMessage struct {
 	// successfully delivered and RequiredAcks is not NoResponse.
 	Timestamp time.Time
 
-	retries int
-	flags   flagSet
+	retries        int
+	flags          flagSet
+	expectation    chan *ProducerError
+	sequenceNumber int32
+	producerEpoch  int16
+	hasSequence    bool
 	// reusePartitionMute is a one-shot marker for non-idempotent retries. The
 	// first retried message from a failed, still-muted batch may reuse that
 	// existing in-flight reservation so later same-partition messages cannot
 	// slip in between the failed send and its retry.
 	reusePartitionMute bool
-	expectation        chan *ProducerError
-	sequenceNumber     int32
-	producerEpoch      int16
-	hasSequence        bool
 }
 
 const producerMessageOverhead = 26 // the metadata overhead of CRC, flags, etc.
@@ -1132,9 +1132,15 @@ func (bp *brokerProducer) run() {
 	Logger.Printf("producer/broker/%d starting up\n", bp.broker.ID())
 
 	for {
-		readyToFlush := bp.timerFired || bp.accumulatingBatch.readyToFlush()
-		if bp.flushingBatch == nil && readyToFlush {
+		var unmuteCh <-chan struct{}
+		readyToFlush := bp.flushingBatch == nil && (bp.timerFired || bp.accumulatingBatch.readyToFlush())
+		if readyToFlush {
 			bp.tryBuildFlushingBatch()
+			if bp.flushingBatch == nil {
+				if ch, blocked := bp.parent.muter.awaitUnmuteChan(bp.accumulatingBatch); blocked {
+					unmuteCh = ch
+				}
+			}
 		}
 
 		var timerChan <-chan time.Time
@@ -1146,13 +1152,6 @@ func (bp *brokerProducer) run() {
 			output = bp.output
 		} else {
 			output = nil
-		}
-
-		var unmuteCh <-chan struct{}
-		if bp.flushingBatch == nil && readyToFlush {
-			if ch, blocked := bp.parent.muter.awaitUnmuteChan(bp.accumulatingBatch); blocked {
-				unmuteCh = ch
-			}
 		}
 
 		select {

--- a/async_producer.go
+++ b/async_producer.go
@@ -1534,7 +1534,7 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	Logger.Printf("Retrying batch for %v-%d because of %v\n", topic, partition, retryErr)
 	produceSet := newProduceSet(p)
 	produceSet.addPartitionSet(topic, partition, pSet)
-	bufferMessages, bufferBytes := p.produceSetBufferSize(produceSet)
+	bufferMessages, bufferBytes := int64(produceSet.bufferCount), int64(produceSet.bufferBytes)
 	bufferReserved := false
 	releaseBuffer := func() {
 		if bufferReserved {
@@ -1645,29 +1645,6 @@ func (p *asyncProducer) producerMessageByteSizeVersion() int {
 	return 1
 }
 
-func (p *asyncProducer) batchBufferSize(batch partitionBatchRetry) (int64, int64) {
-	return int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
-}
-
-func (p *asyncProducer) batchesBufferSize(batches []partitionBatchRetry) (int64, int64) {
-	var messages, bytes int64
-	for _, batch := range batches {
-		batchMessages, batchBytes := p.batchBufferSize(batch)
-		messages += batchMessages
-		bytes += batchBytes
-	}
-	return messages, bytes
-}
-
-func (p *asyncProducer) produceSetBufferSize(set *produceSet) (int64, int64) {
-	var messages, bytes int64
-	set.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
-		messages += int64(len(pSet.msgs))
-		bytes += int64(pSet.bufferBytes)
-	})
-	return messages, bytes
-}
-
 func (p *asyncProducer) bufferWouldOverflow(messages, bytes int64) bool {
 	maxBufferLength, maxBufferBytes := p.retryBufferLimits()
 	return (maxBufferLength > 0 && messages >= maxBufferLength) ||
@@ -1725,8 +1702,14 @@ func (p *asyncProducer) releaseBuffer(messages, bytes int64) {
 // Connection errors already hold partition mutes; doing the refresh in the
 // response loop can block all progress for that broker while the cluster is
 // unstable. Refresh once for the failed request so multi-partition batches do
-// not amplify controller-fail metadata traffic, then group retry partitions by
-// their refreshed leader broker to keep handoff fanout bounded by broker count.
+// not amplify controller-fail metadata traffic. Group retry partitions by their
+// refreshed leader broker, but hand them off from this retry worker so large
+// clusters do not create one temporary goroutine per target broker.
+//
+// This is intentionally not implemented as a loop over retryBatch. retryBatch
+// is the single-partition direct retry primitive; this path owns all muted
+// partitions from one failed ProduceRequest and must retry, fail, reserve
+// buffer, back off, and refresh metadata at that failed-request boundary.
 func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []partitionBatchRetry, retryErr error) {
 	if p.shuttingDown() {
 		p.failMutedBatches(batches, ErrShuttingDown)
@@ -1736,14 +1719,7 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 	var retryable []partitionBatchRetry
 	maxRetryAttempt := 0
 	for _, batch := range batches {
-		shouldRetry := true
-		for _, msg := range batch.pSet.msgs {
-			if msg.retries >= p.conf.Producer.Retry.Max {
-				shouldRetry = false
-				break
-			}
-		}
-		if !shouldRetry {
+		if !batch.pSet.shouldKeepMuted(p.conf.Producer.Retry.Max) {
 			p.failMutedBatch(batch, retryErr)
 			continue
 		}
@@ -1761,7 +1737,11 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 
 	// Reserve before metadata refresh so refresh-blocked direct retries still
 	// count against the producer-level retry buffer budget.
-	bufferMessages, bufferBytes := p.batchesBufferSize(retryable)
+	var bufferMessages, bufferBytes int64
+	for _, batch := range retryable {
+		bufferMessages += int64(len(batch.pSet.msgs))
+		bufferBytes += int64(batch.pSet.bufferBytes)
+	}
 	if !p.reserveBuffer(bufferMessages, bufferBytes) {
 		p.failMutedBatches(retryable, ErrProducerRetryBufferOverflow)
 		return
@@ -1792,7 +1772,7 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 	brokerSets := make(map[*Broker]*produceSet)
 	for _, batch := range retryable {
 		if p.shuttingDown() {
-			batchMessages, batchBytes := p.batchBufferSize(batch)
+			batchMessages, batchBytes := int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
 			p.releaseBuffer(batchMessages, batchBytes)
 			p.failMutedBatch(batch, ErrShuttingDown)
 			continue
@@ -1800,7 +1780,7 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 		leader, leaderErr := p.client.Leader(batch.topic, batch.partition)
 		if leaderErr != nil {
 			Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", batch.topic, batch.partition, leaderErr)
-			batchMessages, batchBytes := p.batchBufferSize(batch)
+			batchMessages, batchBytes := int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
 			p.releaseBuffer(batchMessages, batchBytes)
 			p.failMutedBatch(batch, retryErr)
 			continue
@@ -1814,7 +1794,7 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 	}
 
 	for leader, set := range brokerSets {
-		go p.handoffRetrySet(leader, set)
+		p.handoffRetrySet(leader, set)
 	}
 }
 
@@ -1822,7 +1802,7 @@ func (p *asyncProducer) handoffRetrySet(leader *Broker, set *produceSet) {
 	bp := p.getBrokerProducer(leader)
 	accepted := p.sendRetryBatch(bp, set)
 	p.unrefBrokerProducer(leader, bp)
-	setMessages, setBytes := p.produceSetBufferSize(set)
+	setMessages, setBytes := int64(set.bufferCount), int64(set.bufferBytes)
 	p.releaseBuffer(setMessages, setBytes)
 	if !accepted {
 		p.muter.unmute(set)

--- a/async_producer.go
+++ b/async_producer.go
@@ -195,13 +195,6 @@ func (m *partitionMuter) tryMutePartition(topic string, partition int32) bool {
 	return true
 }
 
-func (m *partitionMuter) isMutedPartition(topic string, partition int32) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	return m.isMuted(topic, partition)
-}
-
 // waitUntilMuted blocks until all partitions in the set can be muted, then mutes them.
 // Returns false if the muter was closed before all partitions could be muted.
 func (m *partitionMuter) waitUntilMuted(set *produceSet) bool {
@@ -394,11 +387,6 @@ type ProducerMessage struct {
 	sequenceNumber int32
 	producerEpoch  int16
 	hasSequence    bool
-	// reusePartitionMute is a one-shot marker for non-idempotent retries. The
-	// first retried message from a failed, still-muted batch may reuse that
-	// existing in-flight reservation so later same-partition messages cannot
-	// slip in between the failed send and its retry.
-	reusePartitionMute bool
 }
 
 const producerMessageOverhead = 26 // the metadata overhead of CRC, flags, etc.
@@ -425,7 +413,6 @@ func (m *ProducerMessage) ByteSize(version int) int {
 func (m *ProducerMessage) clear() {
 	m.flags = 0
 	m.retries = 0
-	m.reusePartitionMute = false
 	m.sequenceNumber = 0
 	m.producerEpoch = 0
 	m.hasSequence = false
@@ -1255,25 +1242,7 @@ func (bp *brokerProducer) tryBuildFlushingBatch() bool {
 		return true
 	}
 
-	reused := bp.accumulatingBatch.takePartitions(func(topic string, partition int32) bool {
-		partitions := bp.accumulatingBatch.msgs[topic]
-		if partitions == nil {
-			return false
-		}
-		set := partitions[partition]
-		return set.canReusePartitionMute() && bp.parent.muter.isMutedPartition(topic, partition)
-	})
-	if reused == nil {
-		return false
-	}
-	reused.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
-		pSet.clearPartitionMuteReuse()
-	})
-	bp.flushingBatch = reused
-	if bp.accumulatingBatch.empty() {
-		bp.rollOver()
-	}
-	return true
+	return false
 }
 
 func (bp *brokerProducer) shutdown() {
@@ -1436,7 +1405,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 				bp.parent.returnErrors(pSet.msgs, block.Err)
 			} else {
 				retryTopics = append(retryTopics, topic)
-				if bp.parent.conf.Producer.Idempotent || pSet.canRetry(bp.parent.conf.Producer.Retry.Max) {
+				if bp.parent.conf.Producer.Idempotent {
 					if keepMuted[topic] == nil {
 						keepMuted[topic] = make(map[int32]struct{})
 					}
@@ -1479,7 +1448,6 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 				if bp.parent.conf.Producer.Idempotent {
 					go bp.parent.retryBatch(topic, partition, pSet, block.Err, true)
 				} else {
-					pSet.markPartitionMuteReusable()
 					bp.parent.retryMessages(pSet.msgs, block.Err)
 				}
 				// dropping the following messages has the side effect of incrementing their retry count
@@ -1516,9 +1484,8 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 		msg.retries++
 	}
 
-	// honor Producer.Retry.Backoff between retry attempts (#2469); the
-	// non-idempotent path gets this from partitionProducer.dispatch, but
-	// retryBatch dispatches the produceSet directly to the broker
+	// honor Producer.Retry.Backoff between retry attempts (#2469). retryBatch
+	// dispatches the produceSet directly to the broker, bypassing partitionProducer.dispatch.
 	if len(pSet.msgs) > 0 {
 		p.backoff(pSet.msgs[0].retries)
 	}
@@ -1569,7 +1536,7 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 			retryTopicSeen[topic] = struct{}{}
 			retryTopics = append(retryTopics, topic)
 		})
-		if bp.parent.conf.Producer.Idempotent && len(retryTopics) > 0 {
+		if len(retryTopics) > 0 {
 			refreshErr := bp.parent.client.RefreshMetadata(retryTopics...)
 			if refreshErr != nil {
 				Logger.Printf("Failed refreshing metadata because of %v\n", refreshErr)
@@ -1588,10 +1555,9 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 				}
 				keepMuted[topic][partition] = struct{}{}
 			}
-			if bp.parent.conf.Producer.Idempotent {
+			if bp.parent.conf.Producer.Idempotent || pSet.canRetry(bp.parent.conf.Producer.Retry.Max) {
 				go bp.parent.retryBatch(topic, partition, pSet, err, true)
 			} else {
-				pSet.markPartitionMuteReusable()
 				bp.parent.retryMessages(pSet.msgs, err)
 			}
 		})

--- a/async_producer.go
+++ b/async_producer.go
@@ -105,8 +105,8 @@ type asyncProducer struct {
 	input, successes, retries chan *ProducerMessage
 	inFlight                  sync.WaitGroup
 
-	// done is closed before waiting on in-flight messages so retryBatch
-	// goroutines can stop waiting on broker handoff and release partition mutes.
+	// done is closed before waiting on in-flight messages so retry goroutines can
+	// stop waiting on broker handoff and release partition mutes.
 	done   chan struct{}
 	closed atomic.Bool
 
@@ -1407,8 +1407,32 @@ func (bp *brokerProducer) handleResponse(response *brokerProducerResponse) {
 func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceResponse) {
 	// we iterate through the blocks in the request set, not the response, so that we notice
 	// if the response is missing a block completely
-	var retryTopics []string
-	keepMuted := make(map[string]map[int32]struct{})
+	var (
+		retryTopics []string
+		keepMuted   map[string]map[int32]struct{}
+		// Group by broker error so failed retries report the original partition error.
+		responseRetries map[KError]*produceSet
+	)
+	markKeepMuted := func(topic string, partition int32) {
+		if keepMuted == nil {
+			keepMuted = make(map[string]map[int32]struct{})
+		}
+		if keepMuted[topic] == nil {
+			keepMuted[topic] = make(map[int32]struct{})
+		}
+		keepMuted[topic][partition] = struct{}{}
+	}
+	addResponseRetry := func(retryErr KError, topic string, partition int32, pSet *partitionSet) {
+		if responseRetries == nil {
+			responseRetries = make(map[KError]*produceSet)
+		}
+		retrySet := responseRetries[retryErr]
+		if retrySet == nil {
+			retrySet = newProduceSet(bp.parent)
+			responseRetries[retryErr] = retrySet
+		}
+		retrySet.addPartitionSet(topic, partition, pSet)
+	}
 	sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
 		if response == nil {
 			// this only happens when RequiredAcks is NoResponse, so we have to assume success
@@ -1445,12 +1469,8 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 				bp.parent.returnErrors(pSet.msgs, block.Err)
 			} else {
 				retryTopics = append(retryTopics, topic)
-				if bp.parent.conf.Producer.Idempotent {
-					if keepMuted[topic] == nil {
-						keepMuted[topic] = make(map[int32]struct{})
-					}
-					keepMuted[topic][partition] = struct{}{}
-				}
+				markKeepMuted(topic, partition)
+				addResponseRetry(block.Err, topic, partition, pSet)
 			}
 		// Other non-retriable errors
 		default:
@@ -1462,13 +1482,6 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 	})
 
 	if len(retryTopics) > 0 {
-		if bp.parent.conf.Producer.Idempotent {
-			err := bp.parent.client.RefreshMetadata(retryTopics...)
-			if err != nil {
-				Logger.Printf("Failed refreshing metadata because of %v\n", err)
-			}
-		}
-
 		sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
 			block := response.GetBlock(topic, partition)
 			if block == nil {
@@ -1485,18 +1498,14 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 					bp.currentRetries[topic] = make(map[int32]error)
 				}
 				bp.currentRetries[topic][partition] = block.Err
-				if bp.parent.conf.Producer.Idempotent {
-					go bp.parent.retryBatch(topic, partition, pSet, block.Err, true)
-				} else {
-					// Non-idempotent response retries must go back through partitionProducer.
-					// That path advances the retry high watermark and refreshes the partition
-					// leader before sending the retry; retryBatch would bypass that state.
-					bp.parent.retryMessages(pSet.msgs, block.Err)
-				}
 				// dropping the following messages has the side effect of incrementing their retry count
 				bp.parent.retryMessages(bp.accumulatingBatch.dropPartition(topic, partition), block.Err)
 			}
 		})
+	}
+
+	for retryErr, retrySet := range responseRetries {
+		go bp.parent.retryBatchesAfterRefresh(retrySet, retryErr)
 	}
 
 	unmuteSet := sent.copyFunc(func(topic string, partition int32) bool {
@@ -1507,63 +1516,6 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 		return true
 	})
 	bp.parent.muter.unmute(unmuteSet)
-}
-
-func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitionSet, retryErr error, alreadyMuted bool) {
-	Logger.Printf("Retrying batch for %v-%d because of %v\n", topic, partition, retryErr)
-	produceSet := newProduceSet(p)
-	produceSet.addPartitionSet(topic, partition, pSet)
-	bufferMessages, bufferBytes := int64(produceSet.bufferCount), int64(produceSet.bufferBytes)
-
-	muted := alreadyMuted
-	failBatch := func(err error) {
-		// Release the partition before reporting errors so a blocked Errors
-		// consumer cannot keep later same-partition messages muted.
-		if muted {
-			p.muter.unmute(produceSet)
-			muted = false
-		}
-		p.returnErrors(pSet.msgs, err)
-	}
-	for _, msg := range pSet.msgs {
-		if msg.retries >= p.conf.Producer.Retry.Max {
-			failBatch(retryErr)
-			return
-		}
-		msg.retries++
-	}
-	if !p.retryBufferQuota.tryReserve(bufferMessages, bufferBytes) {
-		failBatch(ErrProducerRetryBufferOverflow)
-		return
-	}
-	defer p.retryBufferQuota.release(bufferMessages, bufferBytes)
-
-	// Honor Producer.Retry.Backoff between retry attempts (#2469). retryBatch
-	// dispatches the produceSet directly to the broker, bypassing partitionProducer.dispatch.
-	if len(pSet.msgs) > 0 && !p.backoffOrDone(pSet.msgs[0].retries) {
-		failBatch(ErrShuttingDown)
-		return
-	}
-
-	// it's expected that a metadata refresh has been requested prior to calling retryBatch
-	leader, leaderErr := p.client.Leader(topic, partition)
-	if leaderErr != nil {
-		Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", topic, partition, leaderErr)
-		failBatch(retryErr)
-		return
-	}
-	if !alreadyMuted {
-		if !p.muter.waitUntilMuted(produceSet) {
-			failBatch(retryErr)
-			return
-		}
-		muted = true
-	}
-	bp := p.getBrokerProducer(leader)
-	defer p.unrefBrokerProducer(leader, bp)
-	if !p.handoffRetryBatch(bp, produceSet) {
-		failBatch(ErrShuttingDown)
-	}
 }
 
 func (p *asyncProducer) failMutedSet(set *produceSet, err error) {

--- a/async_producer.go
+++ b/async_producer.go
@@ -15,7 +15,7 @@ import (
 	"github.com/IBM/sarama/internal/queue"
 )
 
-// ErrProducerRetryBufferOverflow is returned when the bridging retry buffer is full and OOM prevention needs to be applied.
+// ErrProducerRetryBufferOverflow is returned when producer retry buffering is full and OOM prevention needs to be applied.
 var ErrProducerRetryBufferOverflow = errors.New("retry buffer full: message discarded to prevent buffer overflow")
 
 const (
@@ -113,6 +113,8 @@ type asyncProducer struct {
 	brokerRefs map[*brokerProducer]int
 	brokerLock sync.Mutex
 
+	retryBuffer retryBufferQuota
+
 	txnmgr *transactionManager
 	txLock sync.Mutex
 
@@ -121,6 +123,14 @@ type asyncProducer struct {
 	muter *partitionMuter
 
 	metricsRegistry metrics.Registry
+}
+
+type retryBufferQuota struct {
+	// messages and bytes track producer-level retry buffer occupancy when
+	// Producer.Retry.MaxBufferLength or MaxBufferBytes is bounded.
+	messages int64
+	bytes    int64
+	mu       sync.Mutex
 }
 
 type partitionMuter struct {
@@ -810,6 +820,13 @@ func (pp *partitionProducer) backoff(retries int) {
 }
 
 func (p *asyncProducer) backoff(retries int) {
+	backoff := p.retryBackoff(retries)
+	if backoff > 0 {
+		time.Sleep(backoff)
+	}
+}
+
+func (p *asyncProducer) retryBackoff(retries int) time.Duration {
 	var backoff time.Duration
 	if p.conf.Producer.Retry.BackoffFunc != nil {
 		maxRetries := p.conf.Producer.Retry.Max
@@ -817,8 +834,37 @@ func (p *asyncProducer) backoff(retries int) {
 	} else {
 		backoff = p.conf.Producer.Retry.Backoff
 	}
-	if backoff > 0 {
-		time.Sleep(backoff)
+	return backoff
+}
+
+func (p *asyncProducer) shuttingDown() bool {
+	if p.shutdownCh == nil {
+		return false
+	}
+	select {
+	case <-p.shutdownCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *asyncProducer) backoffOrDone(retries int) bool {
+	backoff := p.retryBackoff(retries)
+	if backoff <= 0 {
+		return !p.shuttingDown()
+	}
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	if p.shutdownCh == nil {
+		<-timer.C
+		return true
+	}
+	select {
+	case <-timer.C:
+		return true
+	case <-p.shutdownCh:
+		return false
 	}
 }
 
@@ -1487,12 +1533,18 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitionSet, retryErr error, alreadyMuted bool) {
 	Logger.Printf("Retrying batch for %v-%d because of %v\n", topic, partition, retryErr)
 	produceSet := newProduceSet(p)
-	produceSet.msgs[topic] = make(map[int32]*partitionSet)
-	produceSet.msgs[topic][partition] = pSet
-	produceSet.bufferBytes += pSet.bufferBytes
-	produceSet.bufferCount += len(pSet.msgs)
+	produceSet.addPartitionSet(topic, partition, pSet)
+	bufferMessages, bufferBytes := p.produceSetBufferSize(produceSet)
+	bufferReserved := false
+	releaseBuffer := func() {
+		if bufferReserved {
+			p.releaseBuffer(bufferMessages, bufferBytes)
+			bufferReserved = false
+		}
+	}
 	muted := alreadyMuted
 	failBatch := func(err error) {
+		releaseBuffer()
 		// Release the partition before reporting errors so a blocked Errors
 		// consumer cannot keep later same-partition messages muted.
 		if muted {
@@ -1510,11 +1562,17 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 		}
 		msg.retries++
 	}
+	if !p.reserveBuffer(bufferMessages, bufferBytes) {
+		failBatch(ErrProducerRetryBufferOverflow)
+		return
+	}
+	bufferReserved = p.retryBufferBounded() && (bufferMessages != 0 || bufferBytes != 0)
 
-	// honor Producer.Retry.Backoff between retry attempts (#2469). retryBatch
+	// Honor Producer.Retry.Backoff between retry attempts (#2469). retryBatch
 	// dispatches the produceSet directly to the broker, bypassing partitionProducer.dispatch.
-	if len(pSet.msgs) > 0 {
-		p.backoff(pSet.msgs[0].retries)
+	if len(pSet.msgs) > 0 && !p.backoffOrDone(pSet.msgs[0].retries) {
+		failBatch(ErrShuttingDown)
+		return
 	}
 
 	// it's expected that a metadata refresh has been requested prior to calling retryBatch
@@ -1537,6 +1595,7 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 		failBatch(ErrShuttingDown)
 		return
 	}
+	releaseBuffer()
 }
 
 type partitionBatchRetry struct {
@@ -1545,30 +1604,233 @@ type partitionBatchRetry struct {
 	pSet      *partitionSet
 }
 
+func (p *asyncProducer) failMutedBatch(batch partitionBatchRetry, err error) {
+	produceSet := newProduceSet(p)
+	produceSet.addPartitionSet(batch.topic, batch.partition, batch.pSet)
+	p.muter.unmute(produceSet)
+	for _, msg := range batch.pSet.msgs {
+		p.returnError(msg, err)
+	}
+}
+
+func (p *asyncProducer) failMutedBatches(batches []partitionBatchRetry, err error) {
+	for _, batch := range batches {
+		p.failMutedBatch(batch, err)
+	}
+}
+
+func (p *asyncProducer) retryBufferLimits() (int64, int64) {
+	maxBufferLength := p.conf.Producer.Retry.MaxBufferLength
+	if 0 < maxBufferLength && maxBufferLength < minFunctionalRetryBufferLength {
+		maxBufferLength = minFunctionalRetryBufferLength
+	}
+
+	maxBufferBytes := p.conf.Producer.Retry.MaxBufferBytes
+	if 0 < maxBufferBytes && maxBufferBytes < minFunctionalRetryBufferBytes {
+		maxBufferBytes = minFunctionalRetryBufferBytes
+	}
+
+	return int64(maxBufferLength), maxBufferBytes
+}
+
+func (p *asyncProducer) retryBufferBounded() bool {
+	maxBufferLength, maxBufferBytes := p.retryBufferLimits()
+	return maxBufferLength > 0 || maxBufferBytes > 0
+}
+
+func (p *asyncProducer) producerMessageByteSizeVersion() int {
+	if p.conf.Version.IsAtLeast(V0_11_0_0) {
+		return 2
+	}
+	return 1
+}
+
+func (p *asyncProducer) batchBufferSize(batch partitionBatchRetry) (int64, int64) {
+	return int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
+}
+
+func (p *asyncProducer) batchesBufferSize(batches []partitionBatchRetry) (int64, int64) {
+	var messages, bytes int64
+	for _, batch := range batches {
+		batchMessages, batchBytes := p.batchBufferSize(batch)
+		messages += batchMessages
+		bytes += batchBytes
+	}
+	return messages, bytes
+}
+
+func (p *asyncProducer) produceSetBufferSize(set *produceSet) (int64, int64) {
+	var messages, bytes int64
+	set.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
+		messages += int64(len(pSet.msgs))
+		bytes += int64(pSet.bufferBytes)
+	})
+	return messages, bytes
+}
+
+func (p *asyncProducer) bufferWouldOverflow(messages, bytes int64) bool {
+	maxBufferLength, maxBufferBytes := p.retryBufferLimits()
+	return (maxBufferLength > 0 && messages >= maxBufferLength) ||
+		(maxBufferBytes > 0 && bytes >= maxBufferBytes)
+}
+
+func (p *asyncProducer) reserveBuffer(messages, bytes int64) bool {
+	if messages == 0 && bytes == 0 {
+		return true
+	}
+	if !p.retryBufferBounded() {
+		return true
+	}
+	p.retryBuffer.mu.Lock()
+	defer p.retryBuffer.mu.Unlock()
+
+	if p.bufferWouldOverflow(p.retryBuffer.messages+messages, p.retryBuffer.bytes+bytes) {
+		return false
+	}
+	p.retryBuffer.messages += messages
+	p.retryBuffer.bytes += bytes
+	return true
+}
+
+func (p *asyncProducer) addToBuffer(messages, bytes int64) bool {
+	if messages == 0 && bytes == 0 {
+		return false
+	}
+	if !p.retryBufferBounded() {
+		return false
+	}
+	p.retryBuffer.mu.Lock()
+	defer p.retryBuffer.mu.Unlock()
+
+	p.retryBuffer.messages += messages
+	p.retryBuffer.bytes += bytes
+	return p.bufferWouldOverflow(p.retryBuffer.messages, p.retryBuffer.bytes)
+}
+
+func (p *asyncProducer) releaseBuffer(messages, bytes int64) {
+	if messages == 0 && bytes == 0 {
+		return
+	}
+	if !p.retryBufferBounded() {
+		return
+	}
+	p.retryBuffer.mu.Lock()
+	defer p.retryBuffer.mu.Unlock()
+
+	p.retryBuffer.messages -= messages
+	p.retryBuffer.bytes -= bytes
+}
+
 // retryBatchesAfterRefresh keeps metadata refresh out of brokerProducer.handleError.
 // Connection errors already hold partition mutes; doing the refresh in the
 // response loop can block all progress for that broker while the cluster is
 // unstable. Refresh once for the failed request so multi-partition batches do
-// not amplify controller-fail metadata traffic, then retry partitions
-// independently so one blocked broker handoff cannot hold up the rest.
+// not amplify controller-fail metadata traffic, then group retry partitions by
+// their refreshed leader broker to keep handoff fanout bounded by broker count.
 func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []partitionBatchRetry, retryErr error) {
-	if p.shutdownCh != nil {
-		select {
-		case <-p.shutdownCh:
-			for _, batch := range batches {
-				go p.retryBatch(batch.topic, batch.partition, batch.pSet, retryErr, true)
+	if p.shuttingDown() {
+		p.failMutedBatches(batches, ErrShuttingDown)
+		return
+	}
+
+	var retryable []partitionBatchRetry
+	maxRetryAttempt := 0
+	for _, batch := range batches {
+		shouldRetry := true
+		for _, msg := range batch.pSet.msgs {
+			if msg.retries >= p.conf.Producer.Retry.Max {
+				shouldRetry = false
+				break
 			}
-			return
-		default:
 		}
+		if !shouldRetry {
+			p.failMutedBatch(batch, retryErr)
+			continue
+		}
+		for _, msg := range batch.pSet.msgs {
+			msg.retries++
+			if msg.retries > maxRetryAttempt {
+				maxRetryAttempt = msg.retries
+			}
+		}
+		retryable = append(retryable, batch)
+	}
+	if len(retryable) == 0 {
+		return
+	}
+
+	// Reserve before metadata refresh so refresh-blocked direct retries still
+	// count against the producer-level retry buffer budget.
+	bufferMessages, bufferBytes := p.batchesBufferSize(retryable)
+	if !p.reserveBuffer(bufferMessages, bufferBytes) {
+		p.failMutedBatches(retryable, ErrProducerRetryBufferOverflow)
+		return
+	}
+
+	if p.shuttingDown() {
+		p.releaseBuffer(bufferMessages, bufferBytes)
+		p.failMutedBatches(retryable, ErrShuttingDown)
+		return
 	}
 	if len(topics) > 0 {
 		if err := p.client.RefreshMetadata(topics...); err != nil {
 			Logger.Printf("Failed refreshing metadata because of %v\n", err)
 		}
 	}
-	for _, batch := range batches {
-		go p.retryBatch(batch.topic, batch.partition, batch.pSet, retryErr, true)
+	if p.shuttingDown() {
+		p.releaseBuffer(bufferMessages, bufferBytes)
+		p.failMutedBatches(retryable, ErrShuttingDown)
+		return
+	}
+
+	if !p.backoffOrDone(maxRetryAttempt) {
+		p.releaseBuffer(bufferMessages, bufferBytes)
+		p.failMutedBatches(retryable, ErrShuttingDown)
+		return
+	}
+
+	brokerSets := make(map[*Broker]*produceSet)
+	for _, batch := range retryable {
+		if p.shuttingDown() {
+			batchMessages, batchBytes := p.batchBufferSize(batch)
+			p.releaseBuffer(batchMessages, batchBytes)
+			p.failMutedBatch(batch, ErrShuttingDown)
+			continue
+		}
+		leader, leaderErr := p.client.Leader(batch.topic, batch.partition)
+		if leaderErr != nil {
+			Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", batch.topic, batch.partition, leaderErr)
+			batchMessages, batchBytes := p.batchBufferSize(batch)
+			p.releaseBuffer(batchMessages, batchBytes)
+			p.failMutedBatch(batch, retryErr)
+			continue
+		}
+		set := brokerSets[leader]
+		if set == nil {
+			set = newProduceSet(p)
+			brokerSets[leader] = set
+		}
+		set.addPartitionSet(batch.topic, batch.partition, batch.pSet)
+	}
+
+	for leader, set := range brokerSets {
+		go p.handoffRetrySet(leader, set)
+	}
+}
+
+func (p *asyncProducer) handoffRetrySet(leader *Broker, set *produceSet) {
+	bp := p.getBrokerProducer(leader)
+	accepted := p.sendRetryBatch(bp, set)
+	p.unrefBrokerProducer(leader, bp)
+	setMessages, setBytes := p.produceSetBufferSize(set)
+	p.releaseBuffer(setMessages, setBytes)
+	if !accepted {
+		p.muter.unmute(set)
+		set.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
+			for _, msg := range pSet.msgs {
+				p.returnError(msg, ErrShuttingDown)
+			}
+		})
 	}
 }
 
@@ -1671,22 +1933,8 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 // effectively a "bridge" between the flushers and the dispatcher in order to avoid deadlock
 // based on https://godoc.org/github.com/eapache/channels#InfiniteChannel
 func (p *asyncProducer) retryHandler() {
-	maxBufferLength := p.conf.Producer.Retry.MaxBufferLength
-	if 0 < maxBufferLength && maxBufferLength < minFunctionalRetryBufferLength {
-		maxBufferLength = minFunctionalRetryBufferLength
-	}
+	version := p.producerMessageByteSizeVersion()
 
-	maxBufferBytes := p.conf.Producer.Retry.MaxBufferBytes
-	if 0 < maxBufferBytes && maxBufferBytes < minFunctionalRetryBufferBytes {
-		maxBufferBytes = minFunctionalRetryBufferBytes
-	}
-
-	version := 1
-	if p.conf.Version.IsAtLeast(V0_11_0_0) {
-		version = 2
-	}
-
-	var currentByteSize int64
 	var msg *ProducerMessage
 	var buf queue.Queue[*ProducerMessage]
 
@@ -1698,7 +1946,7 @@ func (p *asyncProducer) retryHandler() {
 			case msg = <-p.retries:
 			case p.input <- buf.Peek():
 				msgToRemove := buf.Remove()
-				currentByteSize -= int64(msgToRemove.ByteSize(version))
+				p.releaseBuffer(1, int64(msgToRemove.ByteSize(version)))
 				continue
 			}
 		}
@@ -1708,9 +1956,9 @@ func (p *asyncProducer) retryHandler() {
 		}
 
 		buf.Add(msg)
-		currentByteSize += int64(msg.ByteSize(version))
+		bufferOverflow := p.addToBuffer(1, int64(msg.ByteSize(version)))
 
-		if (maxBufferLength <= 0 || buf.Length() < maxBufferLength) && (maxBufferBytes <= 0 || currentByteSize < maxBufferBytes) {
+		if !bufferOverflow {
 			continue
 		}
 
@@ -1719,10 +1967,10 @@ func (p *asyncProducer) retryHandler() {
 			select {
 			case p.input <- msgToHandle:
 				buf.Remove()
-				currentByteSize -= int64(msgToHandle.ByteSize(version))
+				p.releaseBuffer(1, int64(msgToHandle.ByteSize(version)))
 			default:
 				buf.Remove()
-				currentByteSize -= int64(msgToHandle.ByteSize(version))
+				p.releaseBuffer(1, int64(msgToHandle.ByteSize(version)))
 				p.returnError(msgToHandle, ErrProducerRetryBufferOverflow)
 			}
 		}

--- a/async_producer.go
+++ b/async_producer.go
@@ -827,6 +827,23 @@ func (pp *partitionProducer) updateLeaderIfBrokerProducerIsNil(msg *ProducerMess
 	return nil
 }
 
+func (pp *partitionProducer) tryUpdateLeader(old *Broker) bool {
+	leader, err := pp.parent.client.Leader(pp.topic, pp.partition)
+	if err != nil {
+		return false
+	}
+	if old != nil && leader.ID() == old.ID() {
+		return false
+	}
+
+	pp.leader = leader
+	pp.brokerProducer = pp.parent.getBrokerProducer(pp.leader)
+	pp.parent.inFlight.Add(1)
+	pp.brokerProducer.input <- &ProducerMessage{Topic: pp.topic, Partition: pp.partition, flags: syn}
+	Logger.Printf("producer/leader/%s/%d selected broker %d\n", pp.topic, pp.partition, pp.leader.ID())
+	return true
+}
+
 func (pp *partitionProducer) dispatch() {
 	// try to prefetch the leader; if this doesn't work, we'll do a proper call to `updateLeader`
 	// on the first message
@@ -849,9 +866,12 @@ func (pp *partitionProducer) dispatch() {
 			case <-pp.brokerProducer.abandoned:
 				// a message on the abandoned channel means that our current broker selection is out of date
 				Logger.Printf("producer/leader/%s/%d abandoning broker %d\n", pp.topic, pp.partition, pp.leader.ID())
+				oldLeader := pp.leader
 				pp.parent.unrefBrokerProducer(pp.leader, pp.brokerProducer)
 				pp.brokerProducer = nil
-				time.Sleep(pp.parent.conf.Producer.Retry.Backoff)
+				if !pp.tryUpdateLeader(oldLeader) {
+					time.Sleep(pp.parent.conf.Producer.Retry.Backoff)
+				}
 			default:
 				// producer connection is still open.
 			}
@@ -990,6 +1010,7 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 		input:             input,
 		output:            bridge,
 		responses:         responses,
+		abandoned:         make(chan struct{}),
 		done:              make(chan struct{}),
 		accumulatingBatch: newProduceSet(p),
 		currentRetries:    make(map[string]map[int32]error),
@@ -1080,10 +1101,6 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 			}
 		}
 	})
-
-	if p.conf.Producer.Retry.Max <= 0 {
-		bp.abandoned = make(chan struct{})
-	}
 
 	return bp
 }
@@ -1379,8 +1396,9 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 	// we iterate through the blocks in the request set, not the response, so that we notice
 	// if the response is missing a block completely
 	var (
-		retryTopics []string
-		keepMuted   map[string]map[int32]struct{}
+		shouldAbandonBroker bool
+		retryTopics         []string
+		keepMuted           map[string]map[int32]struct{}
 		// Group by broker error so failed retries report the original partition error.
 		responseRetries map[KError]*produceSet
 	)
@@ -1432,11 +1450,11 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 		// Duplicate
 		case ErrDuplicateSequenceNumber:
 			bp.parent.returnSuccesses(pSet.msgs)
-		// Retriable errors
 		case ErrInvalidMessage, ErrUnknownTopicOrPartition, ErrLeaderNotAvailable, ErrNotLeaderForPartition,
 			ErrRequestTimedOut, ErrNotEnoughReplicas, ErrNotEnoughReplicasAfterAppend, ErrKafkaStorageError:
+			// Retriable errors
+			shouldAbandonBroker = true
 			if bp.parent.conf.Producer.Retry.Max <= 0 {
-				bp.parent.abandonBrokerConnection(bp.broker)
 				bp.parent.returnErrors(pSet.msgs, block.Err)
 			} else {
 				retryTopics = append(retryTopics, topic)
@@ -1451,6 +1469,10 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 			bp.parent.returnErrors(pSet.msgs, block.Err)
 		}
 	})
+
+	if shouldAbandonBroker {
+		bp.parent.abandonBrokerConnection(bp.broker)
+	}
 
 	if len(retryTopics) > 0 {
 		sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {

--- a/async_producer.go
+++ b/async_producer.go
@@ -195,6 +195,13 @@ func (m *partitionMuter) tryMutePartition(topic string, partition int32) bool {
 	return true
 }
 
+func (m *partitionMuter) isMutedPartition(topic string, partition int32) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.isMuted(topic, partition)
+}
+
 // waitUntilMuted blocks until all partitions in the set can be muted, then mutes them.
 // Returns false if the muter was closed before all partitions could be muted.
 func (m *partitionMuter) waitUntilMuted(set *produceSet) bool {
@@ -381,12 +388,17 @@ type ProducerMessage struct {
 	// successfully delivered and RequiredAcks is not NoResponse.
 	Timestamp time.Time
 
-	retries        int
-	flags          flagSet
-	expectation    chan *ProducerError
-	sequenceNumber int32
-	producerEpoch  int16
-	hasSequence    bool
+	retries int
+	flags   flagSet
+	// reusePartitionMute is a one-shot marker for non-idempotent retries. The
+	// first retried message from a failed, still-muted batch may reuse that
+	// existing in-flight reservation so later same-partition messages cannot
+	// slip in between the failed send and its retry.
+	reusePartitionMute bool
+	expectation        chan *ProducerError
+	sequenceNumber     int32
+	producerEpoch      int16
+	hasSequence        bool
 }
 
 const producerMessageOverhead = 26 // the metadata overhead of CRC, flags, etc.
@@ -413,6 +425,7 @@ func (m *ProducerMessage) ByteSize(version int) int {
 func (m *ProducerMessage) clear() {
 	m.flags = 0
 	m.retries = 0
+	m.reusePartitionMute = false
 	m.sequenceNumber = 0
 	m.producerEpoch = 0
 	m.hasSequence = false
@@ -1119,7 +1132,8 @@ func (bp *brokerProducer) run() {
 	Logger.Printf("producer/broker/%d starting up\n", bp.broker.ID())
 
 	for {
-		if bp.flushingBatch == nil && (bp.timerFired || bp.accumulatingBatch.readyToFlush()) {
+		readyToFlush := bp.timerFired || bp.accumulatingBatch.readyToFlush()
+		if bp.flushingBatch == nil && readyToFlush {
 			bp.tryBuildFlushingBatch()
 		}
 
@@ -1132,6 +1146,13 @@ func (bp *brokerProducer) run() {
 			output = bp.output
 		} else {
 			output = nil
+		}
+
+		var unmuteCh <-chan struct{}
+		if bp.flushingBatch == nil && readyToFlush {
+			if ch, blocked := bp.parent.muter.awaitUnmuteChan(bp.accumulatingBatch); blocked {
+				unmuteCh = ch
+			}
 		}
 
 		select {
@@ -1210,6 +1231,7 @@ func (bp *brokerProducer) run() {
 			if ok {
 				bp.handleResponse(response)
 			}
+		case <-unmuteCh:
 		}
 	}
 }
@@ -1227,10 +1249,29 @@ func (bp *brokerProducer) tryBuildFlushingBatch() bool {
 	partial := bp.accumulatingBatch.takePartitions(func(topic string, partition int32) bool {
 		return bp.parent.muter.tryMutePartition(topic, partition)
 	})
-	if partial == nil {
+	if partial != nil {
+		bp.flushingBatch = partial
+		if bp.accumulatingBatch.empty() {
+			bp.rollOver()
+		}
+		return true
+	}
+
+	reused := bp.accumulatingBatch.takePartitions(func(topic string, partition int32) bool {
+		partitions := bp.accumulatingBatch.msgs[topic]
+		if partitions == nil {
+			return false
+		}
+		set := partitions[partition]
+		return set.canReusePartitionMute() && bp.parent.muter.isMutedPartition(topic, partition)
+	})
+	if reused == nil {
 		return false
 	}
-	bp.flushingBatch = partial
+	reused.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
+		pSet.clearPartitionMuteReuse()
+	})
+	bp.flushingBatch = reused
 	if bp.accumulatingBatch.empty() {
 		bp.rollOver()
 	}
@@ -1397,7 +1438,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 				bp.parent.returnErrors(pSet.msgs, block.Err)
 			} else {
 				retryTopics = append(retryTopics, topic)
-				if bp.parent.conf.Producer.Idempotent {
+				if bp.parent.conf.Producer.Idempotent || pSet.canRetry(bp.parent.conf.Producer.Retry.Max) {
 					if keepMuted[topic] == nil {
 						keepMuted[topic] = make(map[int32]struct{})
 					}
@@ -1440,6 +1481,7 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 				if bp.parent.conf.Producer.Idempotent {
 					go bp.parent.retryBatch(topic, partition, pSet, block.Err, true)
 				} else {
+					pSet.markPartitionMuteReusable()
 					bp.parent.retryMessages(pSet.msgs, block.Err)
 				}
 				// dropping the following messages has the side effect of incrementing their retry count
@@ -1542,13 +1584,16 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 				bp.currentRetries[topic] = make(map[int32]error)
 			}
 			bp.currentRetries[topic][partition] = err
-			if bp.parent.conf.Producer.Idempotent {
+			if bp.parent.conf.Producer.Idempotent || pSet.canRetry(bp.parent.conf.Producer.Retry.Max) {
 				if keepMuted[topic] == nil {
 					keepMuted[topic] = make(map[int32]struct{})
 				}
 				keepMuted[topic][partition] = struct{}{}
+			}
+			if bp.parent.conf.Producer.Idempotent {
 				go bp.parent.retryBatch(topic, partition, pSet, err, true)
 			} else {
+				pSet.markPartitionMuteReusable()
 				bp.parent.retryMessages(pSet.msgs, err)
 			}
 		})

--- a/async_producer.go
+++ b/async_producer.go
@@ -130,19 +130,16 @@ type asyncProducer struct {
 
 type partitionMuter struct {
 	mu             sync.Mutex
-	cond           *sync.Cond
 	closed         bool
 	inFlightCounts map[string]map[int32]int // topic -> partition -> in-flight count
 	unmuteSignal   chan struct{}
 }
 
 func newPartitionMuter() *partitionMuter {
-	m := &partitionMuter{
+	return &partitionMuter{
 		inFlightCounts: make(map[string]map[int32]int),
 		unmuteSignal:   make(chan struct{}),
 	}
-	m.cond = sync.NewCond(&m.mu)
-	return m
 }
 
 // isMuted reports whether the partition has an in-flight batch.
@@ -205,30 +202,6 @@ func (m *partitionMuter) tryMutePartition(topic string, partition int32) bool {
 	return true
 }
 
-// waitUntilMuted blocks until all partitions in the set can be muted, then mutes them.
-// Returns false if the muter was closed before all partitions could be muted.
-func (m *partitionMuter) waitUntilMuted(set *produceSet) bool {
-	if set == nil || set.empty() {
-		return false
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	for {
-		if m.closed {
-			return false
-		}
-		if !m.isAnyMuted(set) {
-			break
-		}
-		m.cond.Wait()
-	}
-
-	m.muteSet(set)
-	return true
-}
-
 func (m *partitionMuter) awaitUnmuteChan(set *produceSet) (<-chan struct{}, bool) {
 	if set == nil || set.empty() {
 		return nil, false
@@ -272,10 +245,9 @@ func (m *partitionMuter) unmute(set *produceSet) {
 	})
 	close(m.unmuteSignal)
 	m.unmuteSignal = make(chan struct{})
-	m.cond.Broadcast()
 }
 
-// close shuts down the muter, waking any goroutines blocked in waitUntilMuted.
+// close shuts down the muter, waking goroutines waiting for an unmute signal.
 func (m *partitionMuter) close() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -285,7 +257,6 @@ func (m *partitionMuter) close() {
 	}
 	m.closed = true
 	close(m.unmuteSignal)
-	m.cond.Broadcast()
 }
 
 // NewAsyncProducer creates a new AsyncProducer using the given broker addresses and configuration.

--- a/async_producer.go
+++ b/async_producer.go
@@ -836,10 +836,8 @@ func (p *asyncProducer) backoffOrDone(retries int) bool {
 	if backoff <= 0 {
 		return !p.shuttingDown()
 	}
-	timer := time.NewTimer(backoff)
-	defer timer.Stop()
 	select {
-	case <-timer.C:
+	case <-time.After(backoff):
 		return true
 	case <-p.done:
 		return false
@@ -1282,7 +1280,7 @@ func (bp *brokerProducer) tryBuildFlushingBatch() bool {
 }
 
 func (bp *brokerProducer) shutdown() {
-	if bp.closed.Swap(true) {
+	if !bp.closed.CompareAndSwap(false, true) {
 		return
 	}
 	if bp.done != nil {
@@ -1516,10 +1514,6 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	produceSet := newProduceSet(p)
 	produceSet.addPartitionSet(topic, partition, pSet)
 	bufferMessages, bufferBytes := int64(produceSet.bufferCount), int64(produceSet.bufferBytes)
-	var reservedMessages, reservedBytes int64
-	defer func() {
-		p.retryBufferQuota.release(reservedMessages, reservedBytes)
-	}()
 
 	muted := alreadyMuted
 	failBatch := func(err error) {
@@ -1542,7 +1536,7 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 		failBatch(ErrProducerRetryBufferOverflow)
 		return
 	}
-	reservedMessages, reservedBytes = bufferMessages, bufferBytes
+	defer p.retryBufferQuota.release(bufferMessages, bufferBytes)
 
 	// Honor Producer.Retry.Backoff between retry attempts (#2469). retryBatch
 	// dispatches the produceSet directly to the broker, bypassing partitionProducer.dispatch.
@@ -1572,23 +1566,11 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	}
 }
 
-type partitionBatchRetry struct {
-	topic     string
-	partition int32
-	pSet      *partitionSet
-}
-
-func (p *asyncProducer) failMutedBatch(batch partitionBatchRetry, err error) {
-	produceSet := newProduceSet(p)
-	produceSet.addPartitionSet(batch.topic, batch.partition, batch.pSet)
-	p.muter.unmute(produceSet)
-	p.returnErrors(batch.pSet.msgs, err)
-}
-
-func (p *asyncProducer) failMutedBatches(batches []partitionBatchRetry, err error) {
-	for _, batch := range batches {
-		p.failMutedBatch(batch, err)
-	}
+func (p *asyncProducer) failMutedSet(set *produceSet, err error) {
+	p.muter.unmute(set)
+	set.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
+		p.returnErrors(pSet.msgs, err)
+	})
 }
 
 func newRetryBufferQuota(conf *Config) messageQuota {
@@ -1617,99 +1599,88 @@ func producerMessageByteSizeVersion(conf *Config) int {
 	return 1
 }
 
-// retryBatchesAfterRefresh keeps metadata refresh out of brokerProducer.handleError.
-// Connection errors already hold partition mutes; doing the refresh in the
-// response loop can block all progress for that broker while the cluster is
-// unstable. Refresh once for the failed request so multi-partition batches do
-// not amplify controller-fail metadata traffic. Group retry partitions by their
-// refreshed leader broker, but hand them off from this retry worker so large
-// clusters do not create one temporary goroutine per target broker.
-//
-// This is intentionally not implemented as a loop over retryBatch. retryBatch
-// is the single-partition direct retry primitive; this path owns all muted
-// partitions from one failed ProduceRequest and must retry, fail, reserve
-// buffer, back off, and refresh metadata at that failed-request boundary.
-func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []partitionBatchRetry, retryErr error) {
+// retryBatchesAfterRefresh retries muted batches from one failed ProduceRequest
+// after a single metadata refresh, preserving that failed-request boundary.
+func (p *asyncProducer) retryBatchesAfterRefresh(batches *produceSet, retryErr error) {
 	if p.shuttingDown() {
-		p.failMutedBatches(batches, ErrShuttingDown)
+		p.failMutedSet(batches, ErrShuttingDown)
 		return
 	}
 
-	var retryable []partitionBatchRetry
-	maxRetryAttempt := 0
-	for _, batch := range batches {
-		if !batch.pSet.shouldKeepMuted(p.conf.Producer.Retry.Max) {
-			p.failMutedBatch(batch, retryErr)
-			continue
+	var (
+		maxRetryAttempt             int
+		bufferMessages, bufferBytes int64
+	)
+	retryable := newProduceSet(p)
+	batches.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
+		if !pSet.shouldKeepMuted(p.conf.Producer.Retry.Max) {
+			failed := newProduceSet(p)
+			failed.addPartitionSet(topic, partition, pSet)
+			p.failMutedSet(failed, retryErr)
+			return
 		}
-		for _, msg := range batch.pSet.msgs {
+		for _, msg := range pSet.msgs {
 			msg.retries++
 			if msg.retries > maxRetryAttempt {
 				maxRetryAttempt = msg.retries
 			}
 		}
-		retryable = append(retryable, batch)
-	}
-	if len(retryable) == 0 {
+		retryable.addPartitionSet(topic, partition, pSet)
+		bufferMessages += int64(len(pSet.msgs))
+		bufferBytes += int64(pSet.bufferBytes)
+	})
+	if retryable.empty() {
 		return
 	}
 
-	// Reserve before metadata refresh so refresh-blocked direct retries still
-	// count against the producer-level retry buffer budget.
-	var bufferMessages, bufferBytes int64
-	for _, batch := range retryable {
-		bufferMessages += int64(len(batch.pSet.msgs))
-		bufferBytes += int64(batch.pSet.bufferBytes)
-	}
+	// Reserve before waiting so pending direct retries still count against the
+	// producer-level retry buffer budget.
 	if !p.retryBufferQuota.tryReserve(bufferMessages, bufferBytes) {
-		p.failMutedBatches(retryable, ErrProducerRetryBufferOverflow)
-		return
-	}
-
-	if p.shuttingDown() {
-		p.retryBufferQuota.release(bufferMessages, bufferBytes)
-		p.failMutedBatches(retryable, ErrShuttingDown)
-		return
-	}
-	if len(topics) > 0 {
-		if err := p.client.RefreshMetadata(topics...); err != nil {
-			Logger.Printf("Failed refreshing metadata because of %v\n", err)
-		}
-	}
-	if p.shuttingDown() {
-		p.retryBufferQuota.release(bufferMessages, bufferBytes)
-		p.failMutedBatches(retryable, ErrShuttingDown)
+		p.failMutedSet(retryable, ErrProducerRetryBufferOverflow)
 		return
 	}
 
 	if !p.backoffOrDone(maxRetryAttempt) {
 		p.retryBufferQuota.release(bufferMessages, bufferBytes)
-		p.failMutedBatches(retryable, ErrShuttingDown)
+		p.failMutedSet(retryable, ErrShuttingDown)
 		return
+	}
+	topics := make([]string, 0, len(retryable.msgs))
+	for topic := range retryable.msgs {
+		topics = append(topics, topic)
+	}
+	if err := p.client.RefreshMetadata(topics...); err != nil {
+		Logger.Printf("Failed refreshing metadata because of %v\n", err)
 	}
 
 	brokerSets := make(map[*Broker]*produceSet)
-	for _, batch := range retryable {
-		if p.shuttingDown() {
-			batchMessages, batchBytes := int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
-			p.retryBufferQuota.release(batchMessages, batchBytes)
-			p.failMutedBatch(batch, ErrShuttingDown)
-			continue
-		}
-		leader, err := p.client.Leader(batch.topic, batch.partition)
+	retryable.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
+		leader, err := p.client.Leader(topic, partition)
 		if err != nil {
-			Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", batch.topic, batch.partition, err)
-			batchMessages, batchBytes := int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
+			Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", topic, partition, err)
+			batchMessages, batchBytes := int64(len(pSet.msgs)), int64(pSet.bufferBytes)
 			p.retryBufferQuota.release(batchMessages, batchBytes)
-			p.failMutedBatch(batch, retryErr)
-			continue
+			failed := newProduceSet(p)
+			failed.addPartitionSet(topic, partition, pSet)
+			p.failMutedSet(failed, retryErr)
+			return
 		}
 		set := brokerSets[leader]
 		if set == nil {
 			set = newProduceSet(p)
 			brokerSets[leader] = set
 		}
-		set.addPartitionSet(batch.topic, batch.partition, batch.pSet)
+		set.addPartitionSet(topic, partition, pSet)
+	})
+
+	// handoffRetryBatch also checks shutdown, but doing it here avoids creating
+	// or ref-counting brokerProducers just to reject the retry.
+	if p.shuttingDown() {
+		for _, set := range brokerSets {
+			p.retryBufferQuota.release(int64(set.bufferCount), int64(set.bufferBytes))
+			p.failMutedSet(set, ErrShuttingDown)
+		}
+		return
 	}
 
 	for leader, set := range brokerSets {
@@ -1718,10 +1689,7 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 		p.unrefBrokerProducer(leader, bp)
 		p.retryBufferQuota.release(int64(set.bufferCount), int64(set.bufferBytes))
 		if !accepted {
-			p.muter.unmute(set)
-			set.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
-				p.returnErrors(pSet.msgs, ErrShuttingDown)
-			})
+			p.failMutedSet(set, ErrShuttingDown)
 		}
 	}
 }
@@ -1729,10 +1697,16 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 // handoffRetryBatch transfers ownership of a muted retry batch to the broker
 // bridge. On false, the caller still owns the mute and must fail the batch.
 func (p *asyncProducer) handoffRetryBatch(bp *brokerProducer, set *produceSet) bool {
-	if bp.closed.Load() {
+	// If shutdown is already visible, do not let select randomly choose a ready
+	// send on bp.output. The second select still handles shutdown racing with
+	// the handoff.
+	select {
+	case <-bp.done:
 		return false
+	case <-p.done:
+		return false
+	default:
 	}
-
 	select {
 	case bp.output <- set:
 		return true
@@ -1755,10 +1729,9 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 		bp.parent.abandonBrokerConnection(bp.broker)
 		_ = bp.broker.Close()
 		bp.closing = err
+
+		var retrySet *produceSet
 		keepMuted := make(map[string]map[int32]struct{})
-		var retryTopics []string
-		retryTopicSeen := make(map[string]struct{})
-		var retryBatches []partitionBatchRetry
 		sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
 			// Connection failures have no ProduceResponse to feed back through
 			// partitionProducer. Keep the sent batch muted and retry it asynchronously
@@ -1771,23 +1744,18 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 			if !(bp.parent.conf.Producer.Idempotent || pSet.shouldKeepMuted(bp.parent.conf.Producer.Retry.Max)) {
 				bp.parent.returnErrors(pSet.msgs, err)
 			} else {
+				if retrySet == nil {
+					retrySet = newProduceSet(bp.parent)
+				}
 				if keepMuted[topic] == nil {
 					keepMuted[topic] = make(map[int32]struct{})
 				}
 				keepMuted[topic][partition] = struct{}{}
-				if _, ok := retryTopicSeen[topic]; !ok {
-					retryTopicSeen[topic] = struct{}{}
-					retryTopics = append(retryTopics, topic)
-				}
-				retryBatches = append(retryBatches, partitionBatchRetry{
-					topic:     topic,
-					partition: partition,
-					pSet:      pSet,
-				})
+				retrySet.addPartitionSet(topic, partition, pSet)
 			}
 		})
-		if len(retryBatches) > 0 {
-			go bp.parent.retryBatchesAfterRefresh(retryTopics, retryBatches, err)
+		if retrySet != nil {
+			go bp.parent.retryBatchesAfterRefresh(retrySet, err)
 		}
 		bp.accumulatingBatch.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
 			bp.parent.retryMessages(pSet.msgs, err)
@@ -2031,7 +1999,7 @@ func (q *messageQuota) tryReserve(messages, bytes int64) bool {
 
 	nextMessages := q.messages + messages
 	nextBytes := q.bytes + bytes
-	if q.wouldOverflow(nextMessages, nextBytes) {
+	if q.overflows(nextMessages, nextBytes) {
 		return false
 	}
 	q.messages = nextMessages
@@ -2049,7 +2017,7 @@ func (q *messageQuota) addAndCheckOverflow(messages, bytes int64) bool {
 
 	q.messages += messages
 	q.bytes += bytes
-	return q.wouldOverflow(q.messages, q.bytes)
+	return q.overflows(q.messages, q.bytes)
 }
 
 func (q *messageQuota) release(messages, bytes int64) {
@@ -2068,7 +2036,7 @@ func (q *messageQuota) shouldTrack(messages, bytes int64) bool {
 	return (messages != 0 || bytes != 0) && (q.maxMessages > 0 || q.maxBytes > 0)
 }
 
-func (q *messageQuota) wouldOverflow(messages, bytes int64) bool {
+func (q *messageQuota) overflows(messages, bytes int64) bool {
 	return (q.maxMessages > 0 && messages >= q.maxMessages) ||
 		(q.maxBytes > 0 && bytes >= q.maxBytes)
 }

--- a/async_producer.go
+++ b/async_producer.go
@@ -114,8 +114,6 @@ type asyncProducer struct {
 	brokerRefs map[*brokerProducer]int
 	brokerLock sync.Mutex
 
-	retryBuffer retryBufferQuota
-
 	txnmgr *transactionManager
 	txLock sync.Mutex
 
@@ -123,15 +121,11 @@ type asyncProducer struct {
 	// mirroring Kafka's RecordAccumulator.
 	muter *partitionMuter
 
-	metricsRegistry metrics.Registry
-}
-
-type retryBufferQuota struct {
-	// messages and bytes track producer-level retry buffer occupancy when
+	// retryBufferQuota tracks producer-level retry buffer occupancy when
 	// Producer.Retry.MaxBufferLength or MaxBufferBytes is bounded.
-	mu       sync.Mutex
-	messages int64
-	bytes    int64
+	retryBufferQuota messageQuota
+
+	metricsRegistry metrics.Registry
 }
 
 type partitionMuter struct {
@@ -324,18 +318,19 @@ func newAsyncProducer(client Client) (AsyncProducer, error) {
 	}
 
 	p := &asyncProducer{
-		client:          client,
-		conf:            client.Config(),
-		errors:          make(chan *ProducerError),
-		input:           make(chan *ProducerMessage),
-		successes:       make(chan *ProducerMessage),
-		retries:         make(chan *ProducerMessage),
-		done:            make(chan struct{}),
-		brokers:         make(map[*Broker]*brokerProducer),
-		brokerRefs:      make(map[*brokerProducer]int),
-		txnmgr:          txnmgr,
-		muter:           newPartitionMuter(),
-		metricsRegistry: newCleanupRegistry(client.Config().MetricRegistry),
+		client:           client,
+		conf:             client.Config(),
+		errors:           make(chan *ProducerError),
+		input:            make(chan *ProducerMessage),
+		successes:        make(chan *ProducerMessage),
+		retries:          make(chan *ProducerMessage),
+		done:             make(chan struct{}),
+		brokers:          make(map[*Broker]*brokerProducer),
+		brokerRefs:       make(map[*brokerProducer]int),
+		txnmgr:           txnmgr,
+		muter:            newPartitionMuter(),
+		retryBufferQuota: newRetryBufferQuota(client.Config()),
+		metricsRegistry:  newCleanupRegistry(client.Config().MetricRegistry),
 	}
 
 	// launch our singleton dispatchers
@@ -1521,18 +1516,13 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	produceSet := newProduceSet(p)
 	produceSet.addPartitionSet(topic, partition, pSet)
 	bufferMessages, bufferBytes := int64(produceSet.bufferCount), int64(produceSet.bufferBytes)
-	bufferReserved := false
-	releaseBuffer := func() {
-		if bufferReserved {
-			p.releaseBuffer(bufferMessages, bufferBytes)
-			bufferReserved = false
-		}
-	}
-	defer releaseBuffer()
+	var reservedMessages, reservedBytes int64
+	defer func() {
+		p.retryBufferQuota.release(reservedMessages, reservedBytes)
+	}()
 
 	muted := alreadyMuted
 	failBatch := func(err error) {
-		releaseBuffer()
 		// Release the partition before reporting errors so a blocked Errors
 		// consumer cannot keep later same-partition messages muted.
 		if muted {
@@ -1548,11 +1538,11 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 		}
 		msg.retries++
 	}
-	if !p.reserveBuffer(bufferMessages, bufferBytes) {
+	if !p.retryBufferQuota.tryReserve(bufferMessages, bufferBytes) {
 		failBatch(ErrProducerRetryBufferOverflow)
 		return
 	}
-	bufferReserved = p.retryBufferBounded() && (bufferMessages != 0 || bufferBytes != 0)
+	reservedMessages, reservedBytes = bufferMessages, bufferBytes
 
 	// Honor Producer.Retry.Backoff between retry attempts (#2469). retryBatch
 	// dispatches the produceSet directly to the broker, bypassing partitionProducer.dispatch.
@@ -1577,11 +1567,9 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 	}
 	bp := p.getBrokerProducer(leader)
 	defer p.unrefBrokerProducer(leader, bp)
-	if !p.sendRetryBatch(bp, produceSet) {
+	if !p.handoffRetryBatch(bp, produceSet) {
 		failBatch(ErrShuttingDown)
-		return
 	}
-	releaseBuffer()
 }
 
 type partitionBatchRetry struct {
@@ -1603,13 +1591,18 @@ func (p *asyncProducer) failMutedBatches(batches []partitionBatchRetry, err erro
 	}
 }
 
-func (p *asyncProducer) retryBufferLimits() (int64, int64) {
-	maxBufferLength := p.conf.Producer.Retry.MaxBufferLength
+func newRetryBufferQuota(conf *Config) messageQuota {
+	maxBufferLength, maxBufferBytes := retryBufferLimits(conf)
+	return newMessageQuota(maxBufferLength, maxBufferBytes)
+}
+
+func retryBufferLimits(conf *Config) (int64, int64) {
+	maxBufferLength := conf.Producer.Retry.MaxBufferLength
 	if maxBufferLength > 0 {
 		maxBufferLength = max(maxBufferLength, minFunctionalRetryBufferLength)
 	}
 
-	maxBufferBytes := p.conf.Producer.Retry.MaxBufferBytes
+	maxBufferBytes := conf.Producer.Retry.MaxBufferBytes
 	if maxBufferBytes > 0 {
 		maxBufferBytes = max(maxBufferBytes, minFunctionalRetryBufferBytes)
 	}
@@ -1617,75 +1610,11 @@ func (p *asyncProducer) retryBufferLimits() (int64, int64) {
 	return int64(maxBufferLength), maxBufferBytes
 }
 
-func (p *asyncProducer) retryBufferBounded() bool {
-	maxBufferLength, maxBufferBytes := p.retryBufferLimits()
-	return maxBufferLength > 0 || maxBufferBytes > 0
-}
-
-func (p *asyncProducer) producerMessageByteSizeVersion() int {
-	if p.conf.Version.IsAtLeast(V0_11_0_0) {
+func producerMessageByteSizeVersion(conf *Config) int {
+	if conf.Version.IsAtLeast(V0_11_0_0) {
 		return 2
 	}
 	return 1
-}
-
-func (p *asyncProducer) bufferWouldOverflow(messages, bytes int64) bool {
-	maxBufferLength, maxBufferBytes := p.retryBufferLimits()
-	return (maxBufferLength > 0 && messages >= maxBufferLength) ||
-		(maxBufferBytes > 0 && bytes >= maxBufferBytes)
-}
-
-func (p *asyncProducer) reserveBuffer(messages, bytes int64) bool {
-	if messages == 0 && bytes == 0 {
-		return true
-	}
-	if !p.retryBufferBounded() {
-		return true
-	}
-
-	p.retryBuffer.mu.Lock()
-	defer p.retryBuffer.mu.Unlock()
-
-	messages += p.retryBuffer.messages
-	bytes += p.retryBuffer.bytes
-	if p.bufferWouldOverflow(messages, bytes) {
-		return false
-	}
-	p.retryBuffer.messages = messages
-	p.retryBuffer.bytes = bytes
-	return true
-}
-
-func (p *asyncProducer) addToBuffer(messages, bytes int64) bool {
-	if messages == 0 && bytes == 0 {
-		return false
-	}
-	if !p.retryBufferBounded() {
-		return false
-	}
-
-	p.retryBuffer.mu.Lock()
-	defer p.retryBuffer.mu.Unlock()
-
-	nextMessages := p.retryBuffer.messages + messages
-	nextBytes := p.retryBuffer.bytes + bytes
-	p.retryBuffer.messages = nextMessages
-	p.retryBuffer.bytes = nextBytes
-	return p.bufferWouldOverflow(nextMessages, nextBytes)
-}
-
-func (p *asyncProducer) releaseBuffer(messages, bytes int64) {
-	if messages == 0 && bytes == 0 {
-		return
-	}
-	if !p.retryBufferBounded() {
-		return
-	}
-	p.retryBuffer.mu.Lock()
-	defer p.retryBuffer.mu.Unlock()
-
-	p.retryBuffer.messages -= messages
-	p.retryBuffer.bytes -= bytes
 }
 
 // retryBatchesAfterRefresh keeps metadata refresh out of brokerProducer.handleError.
@@ -1732,13 +1661,13 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 		bufferMessages += int64(len(batch.pSet.msgs))
 		bufferBytes += int64(batch.pSet.bufferBytes)
 	}
-	if !p.reserveBuffer(bufferMessages, bufferBytes) {
+	if !p.retryBufferQuota.tryReserve(bufferMessages, bufferBytes) {
 		p.failMutedBatches(retryable, ErrProducerRetryBufferOverflow)
 		return
 	}
 
 	if p.shuttingDown() {
-		p.releaseBuffer(bufferMessages, bufferBytes)
+		p.retryBufferQuota.release(bufferMessages, bufferBytes)
 		p.failMutedBatches(retryable, ErrShuttingDown)
 		return
 	}
@@ -1748,13 +1677,13 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 		}
 	}
 	if p.shuttingDown() {
-		p.releaseBuffer(bufferMessages, bufferBytes)
+		p.retryBufferQuota.release(bufferMessages, bufferBytes)
 		p.failMutedBatches(retryable, ErrShuttingDown)
 		return
 	}
 
 	if !p.backoffOrDone(maxRetryAttempt) {
-		p.releaseBuffer(bufferMessages, bufferBytes)
+		p.retryBufferQuota.release(bufferMessages, bufferBytes)
 		p.failMutedBatches(retryable, ErrShuttingDown)
 		return
 	}
@@ -1763,7 +1692,7 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 	for _, batch := range retryable {
 		if p.shuttingDown() {
 			batchMessages, batchBytes := int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
-			p.releaseBuffer(batchMessages, batchBytes)
+			p.retryBufferQuota.release(batchMessages, batchBytes)
 			p.failMutedBatch(batch, ErrShuttingDown)
 			continue
 		}
@@ -1771,7 +1700,7 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 		if err != nil {
 			Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", batch.topic, batch.partition, err)
 			batchMessages, batchBytes := int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
-			p.releaseBuffer(batchMessages, batchBytes)
+			p.retryBufferQuota.release(batchMessages, batchBytes)
 			p.failMutedBatch(batch, retryErr)
 			continue
 		}
@@ -1784,39 +1713,26 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 	}
 
 	for leader, set := range brokerSets {
-		p.handoffRetrySet(leader, set)
+		bp := p.getBrokerProducer(leader)
+		accepted := p.handoffRetryBatch(bp, set)
+		p.unrefBrokerProducer(leader, bp)
+		p.retryBufferQuota.release(int64(set.bufferCount), int64(set.bufferBytes))
+		if !accepted {
+			p.muter.unmute(set)
+			set.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
+				p.returnErrors(pSet.msgs, ErrShuttingDown)
+			})
+		}
 	}
 }
 
-func (p *asyncProducer) handoffRetrySet(leader *Broker, set *produceSet) {
-	bp := p.getBrokerProducer(leader)
-	accepted := p.sendRetryBatch(bp, set)
-	p.unrefBrokerProducer(leader, bp)
-	setMessages, setBytes := int64(set.bufferCount), int64(set.bufferBytes)
-	p.releaseBuffer(setMessages, setBytes)
-	if !accepted {
-		p.muter.unmute(set)
-		set.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
-			p.returnErrors(pSet.msgs, ErrShuttingDown)
-		})
-	}
-}
-
-// sendRetryBatch transfers ownership of a muted retry batch to the broker
-// bridge. A false result means no owner accepted the batch, so the caller must
-// release the mute and fail the messages instead of leaving a retry goroutine
-// blocked while it still owns the partition mute.
-func (p *asyncProducer) sendRetryBatch(bp *brokerProducer, set *produceSet) bool {
-	select {
-	case <-bp.done:
+// handoffRetryBatch transfers ownership of a muted retry batch to the broker
+// bridge. On false, the caller still owns the mute and must fail the batch.
+func (p *asyncProducer) handoffRetryBatch(bp *brokerProducer, set *produceSet) bool {
+	if bp.closed.Load() {
 		return false
-	default:
 	}
-	select {
-	case bp.output <- set:
-		return true
-	default:
-	}
+
 	select {
 	case bp.output <- set:
 		return true
@@ -1893,7 +1809,7 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 // effectively a "bridge" between the flushers and the dispatcher in order to avoid deadlock
 // based on https://godoc.org/github.com/eapache/channels#InfiniteChannel
 func (p *asyncProducer) retryHandler() {
-	version := p.producerMessageByteSizeVersion()
+	version := producerMessageByteSizeVersion(p.conf)
 
 	var msg *ProducerMessage
 	var buf queue.Queue[*ProducerMessage]
@@ -1906,7 +1822,7 @@ func (p *asyncProducer) retryHandler() {
 			case msg = <-p.retries:
 			case p.input <- buf.Peek():
 				msgToRemove := buf.Remove()
-				p.releaseBuffer(1, int64(msgToRemove.ByteSize(version)))
+				p.retryBufferQuota.release(1, int64(msgToRemove.ByteSize(version)))
 				continue
 			}
 		}
@@ -1916,7 +1832,7 @@ func (p *asyncProducer) retryHandler() {
 		}
 
 		buf.Add(msg)
-		bufferOverflow := p.addToBuffer(1, int64(msg.ByteSize(version)))
+		bufferOverflow := p.retryBufferQuota.addAndCheckOverflow(1, int64(msg.ByteSize(version)))
 
 		if !bufferOverflow {
 			continue
@@ -1927,10 +1843,10 @@ func (p *asyncProducer) retryHandler() {
 			select {
 			case p.input <- msgToHandle:
 				buf.Remove()
-				p.releaseBuffer(1, int64(msgToHandle.ByteSize(version)))
+				p.retryBufferQuota.release(1, int64(msgToHandle.ByteSize(version)))
 			default:
 				buf.Remove()
-				p.releaseBuffer(1, int64(msgToHandle.ByteSize(version)))
+				p.retryBufferQuota.release(1, int64(msgToHandle.ByteSize(version)))
 				p.returnError(msgToHandle, ErrProducerRetryBufferOverflow)
 			}
 		}
@@ -2087,4 +2003,72 @@ func (p *asyncProducer) abandonBrokerConnection(broker *Broker) {
 	}
 
 	delete(p.brokers, broker)
+}
+
+// messageQuota tracks message and byte counts against optional maximums.
+type messageQuota struct {
+	mu          sync.Mutex
+	messages    int64
+	bytes       int64
+	maxMessages int64
+	maxBytes    int64
+}
+
+func newMessageQuota(maxMessages, maxBytes int64) messageQuota {
+	return messageQuota{
+		maxMessages: maxMessages,
+		maxBytes:    maxBytes,
+	}
+}
+
+func (q *messageQuota) tryReserve(messages, bytes int64) bool {
+	if !q.shouldTrack(messages, bytes) {
+		return true
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	nextMessages := q.messages + messages
+	nextBytes := q.bytes + bytes
+	if q.wouldOverflow(nextMessages, nextBytes) {
+		return false
+	}
+	q.messages = nextMessages
+	q.bytes = nextBytes
+	return true
+}
+
+func (q *messageQuota) addAndCheckOverflow(messages, bytes int64) bool {
+	if !q.shouldTrack(messages, bytes) {
+		return false
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.messages += messages
+	q.bytes += bytes
+	return q.wouldOverflow(q.messages, q.bytes)
+}
+
+func (q *messageQuota) release(messages, bytes int64) {
+	if !q.shouldTrack(messages, bytes) {
+		return
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	q.messages -= messages
+	q.bytes -= bytes
+}
+
+func (q *messageQuota) shouldTrack(messages, bytes int64) bool {
+	return (messages != 0 || bytes != 0) && (q.maxMessages > 0 || q.maxBytes > 0)
+}
+
+func (q *messageQuota) wouldOverflow(messages, bytes int64) bool {
+	return (q.maxMessages > 0 && messages >= q.maxMessages) ||
+		(q.maxBytes > 0 && bytes >= q.maxBytes)
 }

--- a/async_producer.go
+++ b/async_producer.go
@@ -1448,6 +1448,9 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 				if bp.parent.conf.Producer.Idempotent {
 					go bp.parent.retryBatch(topic, partition, pSet, block.Err, true)
 				} else {
+					// Non-idempotent response retries must go back through partitionProducer.
+					// That path advances the retry high watermark and refreshes the partition
+					// leader before sending the retry; retryBatch would bypass that state.
 					bp.parent.retryMessages(pSet.msgs, block.Err)
 				}
 				// dropping the following messages has the side effect of incrementing their retry count
@@ -1544,7 +1547,10 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 		}
 		keepMuted := make(map[string]map[int32]struct{})
 		sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
-			// keep partition marked as in-flight during retry (connection error)
+			// Connection failures have no ProduceResponse to feed back through
+			// partitionProducer. Keep the sent batch muted and retry it asynchronously
+			// so later same-partition batches cannot pass it, without blocking the
+			// brokerProducer response loop (#1203).
 			if bp.currentRetries[topic] == nil {
 				bp.currentRetries[topic] = make(map[int32]error)
 			}

--- a/async_producer.go
+++ b/async_producer.go
@@ -104,10 +104,11 @@ type asyncProducer struct {
 	errors                    chan *ProducerError
 	input, successes, retries chan *ProducerMessage
 	inFlight                  sync.WaitGroup
-	// shutdownCh is closed before waiting on in-flight messages so retryBatch
+
+	// done is closed before waiting on in-flight messages so retryBatch
 	// goroutines can stop waiting on broker handoff and release partition mutes.
-	shutdownCh       chan struct{}
-	shutdownChClosed atomic.Bool
+	done   chan struct{}
+	closed atomic.Bool
 
 	brokers    map[*Broker]*brokerProducer
 	brokerRefs map[*brokerProducer]int
@@ -128,9 +129,9 @@ type asyncProducer struct {
 type retryBufferQuota struct {
 	// messages and bytes track producer-level retry buffer occupancy when
 	// Producer.Retry.MaxBufferLength or MaxBufferBytes is bounded.
+	mu       sync.Mutex
 	messages int64
 	bytes    int64
-	mu       sync.Mutex
 }
 
 type partitionMuter struct {
@@ -329,7 +330,7 @@ func newAsyncProducer(client Client) (AsyncProducer, error) {
 		input:           make(chan *ProducerMessage),
 		successes:       make(chan *ProducerMessage),
 		retries:         make(chan *ProducerMessage),
-		shutdownCh:      make(chan struct{}),
+		done:            make(chan struct{}),
 		brokers:         make(map[*Broker]*brokerProducer),
 		brokerRefs:      make(map[*brokerProducer]int),
 		txnmgr:          txnmgr,
@@ -816,33 +817,19 @@ func (p *asyncProducer) newPartitionProducer(topic string, partition int32) chan
 }
 
 func (pp *partitionProducer) backoff(retries int) {
-	pp.parent.backoff(retries)
+	time.Sleep(pp.parent.calcBackoff(retries))
 }
 
-func (p *asyncProducer) backoff(retries int) {
-	backoff := p.retryBackoff(retries)
-	if backoff > 0 {
-		time.Sleep(backoff)
+func (p *asyncProducer) calcBackoff(retries int) time.Duration {
+	if backoffFunc := p.conf.Producer.Retry.BackoffFunc; backoffFunc != nil {
+		return backoffFunc(retries, p.conf.Producer.Retry.Max)
 	}
-}
-
-func (p *asyncProducer) retryBackoff(retries int) time.Duration {
-	var backoff time.Duration
-	if p.conf.Producer.Retry.BackoffFunc != nil {
-		maxRetries := p.conf.Producer.Retry.Max
-		backoff = p.conf.Producer.Retry.BackoffFunc(retries, maxRetries)
-	} else {
-		backoff = p.conf.Producer.Retry.Backoff
-	}
-	return backoff
+	return p.conf.Producer.Retry.Backoff
 }
 
 func (p *asyncProducer) shuttingDown() bool {
-	if p.shutdownCh == nil {
-		return false
-	}
 	select {
-	case <-p.shutdownCh:
+	case <-p.done:
 		return true
 	default:
 		return false
@@ -850,20 +837,16 @@ func (p *asyncProducer) shuttingDown() bool {
 }
 
 func (p *asyncProducer) backoffOrDone(retries int) bool {
-	backoff := p.retryBackoff(retries)
+	backoff := p.calcBackoff(retries)
 	if backoff <= 0 {
 		return !p.shuttingDown()
 	}
 	timer := time.NewTimer(backoff)
 	defer timer.Stop()
-	if p.shutdownCh == nil {
-		<-timer.C
-		return true
-	}
 	select {
 	case <-timer.C:
 		return true
-	case <-p.shutdownCh:
+	case <-p.done:
 		return false
 	}
 }
@@ -1161,7 +1144,8 @@ type brokerProducer struct {
 	// output while the batch still owns its partition mute; if the brokerProducer
 	// is shutting down, that send may never be received and the mute would block
 	// later same-partition messages and producer shutdown.
-	done chan struct{}
+	done   chan struct{}
+	closed atomic.Bool
 
 	accumulatingBatch *produceSet
 	flushingBatch     *produceSet // batch that has been muted and is ready to send
@@ -1292,18 +1276,20 @@ func (bp *brokerProducer) tryBuildFlushingBatch() bool {
 	partial := bp.accumulatingBatch.takePartitions(func(topic string, partition int32) bool {
 		return bp.parent.muter.tryMutePartition(topic, partition)
 	})
-	if partial != nil {
-		bp.flushingBatch = partial
-		if bp.accumulatingBatch.empty() {
-			bp.rollOver()
-		}
-		return true
+	if partial == nil {
+		return false
 	}
-
-	return false
+	bp.flushingBatch = partial
+	if bp.accumulatingBatch.empty() {
+		bp.rollOver()
+	}
+	return true
 }
 
 func (bp *brokerProducer) shutdown() {
+	if bp.closed.Swap(true) {
+		return
+	}
 	if bp.done != nil {
 		close(bp.done)
 	}
@@ -1542,6 +1528,8 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 			bufferReserved = false
 		}
 	}
+	defer releaseBuffer()
+
 	muted := alreadyMuted
 	failBatch := func(err error) {
 		releaseBuffer()
@@ -1551,9 +1539,7 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 			p.muter.unmute(produceSet)
 			muted = false
 		}
-		for _, msg := range pSet.msgs {
-			p.returnError(msg, err)
-		}
+		p.returnErrors(pSet.msgs, err)
 	}
 	for _, msg := range pSet.msgs {
 		if msg.retries >= p.conf.Producer.Retry.Max {
@@ -1608,9 +1594,7 @@ func (p *asyncProducer) failMutedBatch(batch partitionBatchRetry, err error) {
 	produceSet := newProduceSet(p)
 	produceSet.addPartitionSet(batch.topic, batch.partition, batch.pSet)
 	p.muter.unmute(produceSet)
-	for _, msg := range batch.pSet.msgs {
-		p.returnError(msg, err)
-	}
+	p.returnErrors(batch.pSet.msgs, err)
 }
 
 func (p *asyncProducer) failMutedBatches(batches []partitionBatchRetry, err error) {
@@ -1621,13 +1605,13 @@ func (p *asyncProducer) failMutedBatches(batches []partitionBatchRetry, err erro
 
 func (p *asyncProducer) retryBufferLimits() (int64, int64) {
 	maxBufferLength := p.conf.Producer.Retry.MaxBufferLength
-	if 0 < maxBufferLength && maxBufferLength < minFunctionalRetryBufferLength {
-		maxBufferLength = minFunctionalRetryBufferLength
+	if maxBufferLength > 0 {
+		maxBufferLength = max(maxBufferLength, minFunctionalRetryBufferLength)
 	}
 
 	maxBufferBytes := p.conf.Producer.Retry.MaxBufferBytes
-	if 0 < maxBufferBytes && maxBufferBytes < minFunctionalRetryBufferBytes {
-		maxBufferBytes = minFunctionalRetryBufferBytes
+	if maxBufferBytes > 0 {
+		maxBufferBytes = max(maxBufferBytes, minFunctionalRetryBufferBytes)
 	}
 
 	return int64(maxBufferLength), maxBufferBytes
@@ -1658,14 +1642,17 @@ func (p *asyncProducer) reserveBuffer(messages, bytes int64) bool {
 	if !p.retryBufferBounded() {
 		return true
 	}
+
 	p.retryBuffer.mu.Lock()
 	defer p.retryBuffer.mu.Unlock()
 
-	if p.bufferWouldOverflow(p.retryBuffer.messages+messages, p.retryBuffer.bytes+bytes) {
+	messages += p.retryBuffer.messages
+	bytes += p.retryBuffer.bytes
+	if p.bufferWouldOverflow(messages, bytes) {
 		return false
 	}
-	p.retryBuffer.messages += messages
-	p.retryBuffer.bytes += bytes
+	p.retryBuffer.messages = messages
+	p.retryBuffer.bytes = bytes
 	return true
 }
 
@@ -1676,12 +1663,15 @@ func (p *asyncProducer) addToBuffer(messages, bytes int64) bool {
 	if !p.retryBufferBounded() {
 		return false
 	}
+
 	p.retryBuffer.mu.Lock()
 	defer p.retryBuffer.mu.Unlock()
 
-	p.retryBuffer.messages += messages
-	p.retryBuffer.bytes += bytes
-	return p.bufferWouldOverflow(p.retryBuffer.messages, p.retryBuffer.bytes)
+	nextMessages := p.retryBuffer.messages + messages
+	nextBytes := p.retryBuffer.bytes + bytes
+	p.retryBuffer.messages = nextMessages
+	p.retryBuffer.bytes = nextBytes
+	return p.bufferWouldOverflow(nextMessages, nextBytes)
 }
 
 func (p *asyncProducer) releaseBuffer(messages, bytes int64) {
@@ -1777,9 +1767,9 @@ func (p *asyncProducer) retryBatchesAfterRefresh(topics []string, batches []part
 			p.failMutedBatch(batch, ErrShuttingDown)
 			continue
 		}
-		leader, leaderErr := p.client.Leader(batch.topic, batch.partition)
-		if leaderErr != nil {
-			Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", batch.topic, batch.partition, leaderErr)
+		leader, err := p.client.Leader(batch.topic, batch.partition)
+		if err != nil {
+			Logger.Printf("Failed retrying batch for %v-%d because of %v while looking up for new leader\n", batch.topic, batch.partition, err)
 			batchMessages, batchBytes := int64(len(batch.pSet.msgs)), int64(batch.pSet.bufferBytes)
 			p.releaseBuffer(batchMessages, batchBytes)
 			p.failMutedBatch(batch, retryErr)
@@ -1807,9 +1797,7 @@ func (p *asyncProducer) handoffRetrySet(leader *Broker, set *produceSet) {
 	if !accepted {
 		p.muter.unmute(set)
 		set.eachPartition(func(_ string, _ int32, pSet *partitionSet) {
-			for _, msg := range pSet.msgs {
-				p.returnError(msg, ErrShuttingDown)
-			}
+			p.returnErrors(pSet.msgs, ErrShuttingDown)
 		})
 	}
 }
@@ -1819,12 +1807,8 @@ func (p *asyncProducer) handoffRetrySet(leader *Broker, set *produceSet) {
 // release the mute and fail the messages instead of leaving a retry goroutine
 // blocked while it still owns the partition mute.
 func (p *asyncProducer) sendRetryBatch(bp *brokerProducer, set *produceSet) bool {
-	var done <-chan struct{}
-	if bp.done != nil {
-		done = bp.done
-	}
 	select {
-	case <-done:
+	case <-bp.done:
 		return false
 	default:
 	}
@@ -1833,16 +1817,12 @@ func (p *asyncProducer) sendRetryBatch(bp *brokerProducer, set *produceSet) bool
 		return true
 	default:
 	}
-	var shutdownCh <-chan struct{}
-	if p.shutdownCh != nil {
-		shutdownCh = p.shutdownCh
-	}
 	select {
 	case bp.output <- set:
 		return true
-	case <-done:
+	case <-bp.done:
 		return false
-	case <-shutdownCh:
+	case <-p.done:
 		return false
 	}
 }
@@ -1961,8 +1941,8 @@ func (p *asyncProducer) retryHandler() {
 
 func (p *asyncProducer) shutdown() {
 	Logger.Println("Producer shutting down.")
-	if p.shutdownCh != nil && p.shutdownChClosed.CompareAndSwap(false, true) {
-		close(p.shutdownCh)
+	if p.done != nil && p.closed.CompareAndSwap(false, true) {
+		close(p.done)
 	}
 	p.inFlight.Add(1)
 	p.input <- &ProducerMessage{flags: shutdown}

--- a/async_producer.go
+++ b/async_producer.go
@@ -1133,8 +1133,7 @@ func (bp *brokerProducer) run() {
 
 	for {
 		var unmuteCh <-chan struct{}
-		readyToFlush := bp.flushingBatch == nil && (bp.timerFired || bp.accumulatingBatch.readyToFlush())
-		if readyToFlush {
+		if bp.flushingBatch == nil && (bp.timerFired || bp.accumulatingBatch.readyToFlush()) {
 			bp.tryBuildFlushingBatch()
 			if bp.flushingBatch == nil {
 				if ch, blocked := bp.parent.muter.awaitUnmuteChan(bp.accumulatingBatch); blocked {

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2130,37 +2130,39 @@ func TestRetryBatchRespectsPartitionMuter(t *testing.T) {
 	}
 }
 
-func TestHandleSuccessNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
+func TestHandleErrorNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
 	config.Producer.Retry.Backoff = 0
 
-	txnMgr := &transactionManager{
-		producerID:      0,
-		producerEpoch:   0,
-		sequenceNumbers: make(map[string]int32),
-	}
 	parent := &asyncProducer{
 		conf:       config,
 		muter:      newPartitionMuter(),
 		brokers:    make(map[*Broker]*brokerProducer),
 		brokerRefs: make(map[*brokerProducer]int),
-		retries:    make(chan *ProducerMessage, 1),
-		txnmgr:     txnMgr,
+		txnmgr:     &transactionManager{},
 	}
-	leader := &Broker{id: 1}
-	parent.client = &stubLeaderClient{leader: leader, cfg: config}
+	failedBroker := &Broker{id: 1}
+	retryLeader := &Broker{id: 2}
+	parent.client = &stubLeaderClient{leader: retryLeader, cfg: config}
+
+	output := make(chan *produceSet)
+	retryBP := &brokerProducer{
+		parent: parent,
+		broker: retryLeader,
+		output: output,
+		input:  make(chan *ProducerMessage),
+	}
+	parent.brokers[retryLeader] = retryBP
 
 	bp := &brokerProducer{
 		parent:            parent,
-		broker:            leader,
+		broker:            failedBroker,
 		input:             make(chan *ProducerMessage),
 		accumulatingBatch: newProduceSet(parent),
 		currentRetries:    make(map[string]map[int32]error),
 	}
-	parent.brokers[leader] = bp
-	parent.brokerRefs[bp] = 1
 
 	sent := newProduceSet(parent)
 	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
@@ -2168,15 +2170,18 @@ func TestHandleSuccessNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
 	if !parent.muter.tryMute(sent) {
 		t.Fatal("expected sent batch to mute partitions")
 	}
-	defer parent.muter.unmute(sent)
 
-	response := new(ProduceResponse)
-	response.AddTopicPartition("topic", 0, ErrNotLeaderForPartition)
-	bp.handleSuccess(sent, response)
+	done := make(chan struct{})
+	go func() {
+		bp.handleError(sent, ErrOutOfBrokers)
+		close(done)
+	}()
+	assertDoneWithin(t, done, 2*time.Second)
 
-	retried := assertDoneWithin(t, parent.retries, 2*time.Second)
-	require.Equal(t, retryPartitionSet.msgs[0], retried)
-	require.True(t, retried.reusePartitionMute)
+	retrySet := assertDoneWithin(t, output, 2*time.Second)
+	defer parent.muter.unmute(retrySet)
+	require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
+	require.Equal(t, 1, retryPartitionSet.msgs[0].retries)
 
 	contender := newProduceSet(parent)
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
@@ -2184,13 +2189,54 @@ func TestHandleSuccessNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
 		parent.muter.unmute(contender)
 		t.Fatal("expected partition to remain muted by the retrying batch")
 	}
+}
 
-	safeAddMessage(t, bp.accumulatingBatch, retried)
-	if !bp.tryBuildFlushingBatch() {
-		t.Fatal("expected retry batch to reuse the existing partition mute")
+func TestHandleErrorNonIdempotentRetryReleasesMuteOnLeaderError(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+	config.Producer.Return.Errors = true
+
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		errors:     make(chan *ProducerError, 1),
+		txnmgr:     &transactionManager{},
 	}
-	require.Equal(t, retryPartitionSet.msgs[0], bp.flushingBatch.msgs["topic"][0].msgs[0])
-	require.False(t, retryPartitionSet.msgs[0].reusePartitionMute)
+	parent.client = &failingLeaderClient{
+		stubLeaderClient: stubLeaderClient{cfg: config},
+		err:              ErrOutOfBrokers,
+	}
+
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            &Broker{id: 1},
+		input:             make(chan *ProducerMessage),
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+
+	bp.handleError(sent, ErrOutOfBrokers)
+
+	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, ErrOutOfBrokers, producerErr.Err)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected partition mute to be released after retry leader lookup failure")
+	}
+	parent.muter.unmute(contender)
 }
 
 type stubLeaderClient struct {
@@ -2227,6 +2273,19 @@ func (c *stubLeaderClient) LeastLoadedBroker() *Broker                       { r
 func (c *stubLeaderClient) PartitionNotReadable(string, int32) bool          { return false }
 func (c *stubLeaderClient) Close() error                                     { return nil }
 func (c *stubLeaderClient) Closed() bool                                     { return false }
+
+type failingLeaderClient struct {
+	stubLeaderClient
+	err error
+}
+
+func (c *failingLeaderClient) Leader(string, int32) (*Broker, error) {
+	return nil, c.err
+}
+
+func (c *failingLeaderClient) LeaderAndEpoch(string, int32) (*Broker, int32, error) {
+	return nil, 0, c.err
+}
 
 func testProducerInterceptor(
 	t *testing.T,

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1899,6 +1899,53 @@ func TestBrokerProducerFlushSkipsMutedPartitions(t *testing.T) {
 	}
 }
 
+func TestBrokerProducerRunFlushesAfterExternalUnmute(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Flush.Messages = 1
+	parent := &asyncProducer{
+		conf:   config,
+		muter:  newPartitionMuter(),
+		txnmgr: &transactionManager{},
+	}
+
+	blockedSet := newProduceSet(parent)
+	safeAddMessage(t, blockedSet, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("held")})
+	if !parent.muter.tryMute(blockedSet) {
+		t.Fatal("expected to mute partition externally")
+	}
+
+	input := make(chan *ProducerMessage)
+	output := make(chan *produceSet, 1)
+	responses := make(chan *brokerProducerResponse)
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            &Broker{id: 1},
+		input:             input,
+		output:            output,
+		responses:         responses,
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+	retryMsg := &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("waiting")}
+	safeAddMessage(t, bp.accumulatingBatch, retryMsg)
+
+	done := make(chan struct{})
+	go func() {
+		bp.run()
+		close(done)
+	}()
+
+	assertNotDone(t, output, 50*time.Millisecond)
+	parent.muter.unmute(blockedSet)
+
+	flushed := assertDoneWithin(t, output, 2*time.Second)
+	require.Equal(t, retryMsg, flushed.msgs["topic"][0].msgs[0])
+
+	close(input)
+	close(responses)
+	assertDoneWithin(t, done, 2*time.Second)
+}
+
 // TestBrokerProducerWaitForSpaceAllPartitionsMuted verifies that waitForSpace unblocks
 // when all partitions in the accumulating batch are externally muted and later unmuted.
 func TestBrokerProducerWaitForSpaceAllPartitionsMuted(t *testing.T) {
@@ -2081,6 +2128,69 @@ func TestRetryBatchRespectsPartitionMuter(t *testing.T) {
 	if parent.muter.tryMute(contender) {
 		t.Fatal("expected partition to remain muted by retry batch")
 	}
+}
+
+func TestHandleSuccessNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+
+	txnMgr := &transactionManager{
+		producerID:      0,
+		producerEpoch:   0,
+		sequenceNumbers: make(map[string]int32),
+	}
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		retries:    make(chan *ProducerMessage, 1),
+		txnmgr:     txnMgr,
+	}
+	leader := &Broker{id: 1}
+	parent.client = &stubLeaderClient{leader: leader, cfg: config}
+
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            leader,
+		input:             make(chan *ProducerMessage),
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+	parent.brokers[leader] = bp
+	parent.brokerRefs[bp] = 1
+
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+	retryPartitionSet := sent.msgs["topic"][0]
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+	defer parent.muter.unmute(sent)
+
+	response := new(ProduceResponse)
+	response.AddTopicPartition("topic", 0, ErrNotLeaderForPartition)
+	bp.handleSuccess(sent, response)
+
+	retried := assertDoneWithin(t, parent.retries, 2*time.Second)
+	require.Equal(t, retryPartitionSet.msgs[0], retried)
+	require.True(t, retried.reusePartitionMute)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+	if parent.muter.tryMute(contender) {
+		parent.muter.unmute(contender)
+		t.Fatal("expected partition to remain muted by the retrying batch")
+	}
+
+	safeAddMessage(t, bp.accumulatingBatch, retried)
+	if !bp.tryBuildFlushingBatch() {
+		t.Fatal("expected retry batch to reuse the existing partition mute")
+	}
+	require.Equal(t, retryPartitionSet.msgs[0], bp.flushingBatch.msgs["topic"][0].msgs[0])
+	require.False(t, retryPartitionSet.msgs[0].reusePartitionMute)
 }
 
 type stubLeaderClient struct {

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1746,7 +1746,7 @@ func TestBrokerProducerShutdown(t *testing.T) {
 
 // TestBrokerProducerWaitForSpaceEmptyBufferRollover ensures forced rollovers with an empty buffer
 // do not deadlock waiting for responses when no partitions are muted.
-func TestBrokerProducerWaitForSpaceEmptyBufferRollover(t *testing.T) {
+func TestBrokerProducerWaitForSpaceEmptyRollover(t *testing.T) {
 	config := NewTestConfig()
 	parent := &asyncProducer{
 		conf:   config,
@@ -1882,9 +1882,9 @@ func holdFirstRetryAfterReserve(parent *asyncProducer, retryBP *brokerProducer, 
 	return firstRetryReserved, release
 }
 
-// TestBrokerProducerWaitForSpaceRespectsExternalUnmute ensures waitForSpace does not
+// TestBrokerProducerWaitForSpaceExternalUnmute ensures waitForSpace does not
 // deadlock when partitions are muted by another producer and are unmuted elsewhere.
-func TestBrokerProducerWaitForSpaceRespectsExternalUnmute(t *testing.T) {
+func TestBrokerProducerWaitForSpaceExternalUnmute(t *testing.T) {
 	config := NewTestConfig()
 	txnMgr := &transactionManager{
 		producerID:      0,
@@ -1971,7 +1971,7 @@ func TestBrokerProducerFlushSkipsMutedPartitions(t *testing.T) {
 	}
 }
 
-func TestBrokerProducerRunFlushesAfterExternalUnmute(t *testing.T) {
+func TestBrokerProducerRunExternalUnmute(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Flush.Messages = 1
 	parent := &asyncProducer{
@@ -2018,9 +2018,9 @@ func TestBrokerProducerRunFlushesAfterExternalUnmute(t *testing.T) {
 	assertDoneWithin(t, done, 2*time.Second)
 }
 
-// TestBrokerProducerWaitForSpaceAllPartitionsMuted verifies that waitForSpace unblocks
+// TestBrokerProducerWaitForSpaceAllMuted verifies that waitForSpace unblocks
 // when all partitions in the accumulating batch are externally muted and later unmuted.
-func TestBrokerProducerWaitForSpaceAllPartitionsMuted(t *testing.T) {
+func TestBrokerProducerWaitForSpaceAllMuted(t *testing.T) {
 	config := NewTestConfig()
 	parent := &asyncProducer{
 		conf:   config,
@@ -2053,9 +2053,9 @@ func TestBrokerProducerWaitForSpaceAllPartitionsMuted(t *testing.T) {
 	require.NoError(t, assertDoneWithin(t, done, 2*time.Second))
 }
 
-// TestPartitionMuterCloseWakesWaitUntilMuted verifies that closing the muter wakes
+// TestPartitionMuterCloseWakesWait verifies that closing the muter wakes
 // goroutines blocked in waitUntilMuted.
-func TestPartitionMuterCloseWakesWaitUntilMuted(t *testing.T) {
+func TestPartitionMuterCloseWakesWait(t *testing.T) {
 	config := NewTestConfig()
 	parent := &asyncProducer{
 		conf:   config,
@@ -2204,7 +2204,7 @@ func TestRetryBatchRespectsPartitionMuter(t *testing.T) {
 	}
 }
 
-func TestHandleErrorNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
+func TestHandleErrorRetryKeepsMute(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
@@ -2265,7 +2265,7 @@ func TestHandleErrorNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
 	}
 }
 
-func TestHandleErrorNonIdempotentRetryFailsWholeBatch(t *testing.T) {
+func TestHandleErrorRetryFailsBatch(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
@@ -2314,7 +2314,7 @@ func TestHandleErrorNonIdempotentRetryFailsWholeBatch(t *testing.T) {
 	parent.muter.unmute(contender)
 }
 
-func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T) {
+func TestHandleErrorRetryAsyncRefresh(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
@@ -2392,7 +2392,7 @@ func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T
 	require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
 }
 
-func TestHandleErrorNonIdempotentRetryRefreshesMetadataOncePerFailedRequest(t *testing.T) {
+func TestHandleErrorRetryRefreshOnce(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
@@ -2461,7 +2461,7 @@ func TestHandleErrorNonIdempotentRetryRefreshesMetadataOncePerFailedRequest(t *t
 	require.Same(t, retryPartitionSet1, retriedPartitions[int32(1)])
 }
 
-func TestHandleErrorNonIdempotentRetryGroupsBatchesByLeader(t *testing.T) {
+func TestHandleErrorRetryGroupsByLeader(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
@@ -2558,7 +2558,7 @@ func TestHandleErrorNonIdempotentRetryGroupsBatchesByLeader(t *testing.T) {
 	assertNotDone(t, outputB, 50*time.Millisecond)
 }
 
-func TestHandleSuccessNonIdempotentRetryUsesPartitionProducer(t *testing.T) {
+func TestHandleSuccessRetryUsesPartitionProducer(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
@@ -2602,7 +2602,7 @@ func TestHandleSuccessNonIdempotentRetryUsesPartitionProducer(t *testing.T) {
 	parent.muter.unmute(contender)
 }
 
-func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
+func TestRetryBatchShutdownReleasesMute(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
@@ -2715,11 +2715,9 @@ func TestRetryUsesSharedBufferBudget(t *testing.T) {
 
 			retry := func(partition int32, pSet *partitionSet) {
 				if tt.afterRefresh {
-					parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
-						topic:     "topic",
-						partition: partition,
-						pSet:      pSet,
-					}}, ErrOutOfBrokers)
+					retrySet := newProduceSet(parent)
+					retrySet.addPartitionSet("topic", partition, pSet)
+					parent.retryBatchesAfterRefresh(retrySet, ErrOutOfBrokers)
 					return
 				}
 				parent.retryBatch("topic", partition, pSet, ErrNotEnoughReplicas, true)
@@ -2773,7 +2771,7 @@ func TestRetryUsesSharedBufferBudget(t *testing.T) {
 	}
 }
 
-func TestRetryBatchesAfterRefreshReleasesMuteWhenBrokerProducerDone(t *testing.T) {
+func TestRetryBatchesAfterRefreshBrokerDone(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
@@ -2810,11 +2808,9 @@ func TestRetryBatchesAfterRefreshReleasesMuteWhenBrokerProducerDone(t *testing.T
 
 	done := make(chan struct{})
 	go func() {
-		parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
-			topic:     "topic",
-			partition: 0,
-			pSet:      retryPartitionSet,
-		}}, ErrOutOfBrokers)
+		retrySet := newProduceSet(parent)
+		retrySet.addPartitionSet("topic", 0, retryPartitionSet)
+		parent.retryBatchesAfterRefresh(retrySet, ErrOutOfBrokers)
 		close(done)
 	}()
 
@@ -2831,7 +2827,70 @@ func TestRetryBatchesAfterRefreshReleasesMuteWhenBrokerProducerDone(t *testing.T
 	parent.muter.unmute(contender)
 }
 
-func TestHandleErrorNonIdempotentRetryReleasesMuteOnLeaderError(t *testing.T) {
+func TestRetryBatchesAfterRefreshShutdown(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+	config.Producer.Return.Errors = true
+
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		errors:     make(chan *ProducerError, 2),
+		done:       make(chan struct{}),
+		txnmgr:     &transactionManager{},
+	}
+	leader := &Broker{id: 1}
+	output := make(chan *produceSet, 1)
+	parent.brokers[leader] = &brokerProducer{
+		parent: parent,
+		broker: leader,
+		output: output,
+		input:  make(chan *ProducerMessage),
+		done:   make(chan struct{}),
+	}
+	shutdownStarted := false
+	parent.client = &stubLeaderClient{
+		cfg: config,
+		leaderFunc: func(string, int32) (*Broker, error) {
+			if !shutdownStarted {
+				close(parent.done)
+				shutdownStarted = true
+			}
+			return leader, nil
+		},
+	}
+
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry-0")})
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("retry-1")})
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+	parent.inFlight.Add(2)
+
+	parent.retryBatchesAfterRefresh(sent, ErrOutOfBrokers)
+
+	firstErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	secondErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, ErrShuttingDown, firstErr.Err)
+	require.Equal(t, ErrShuttingDown, secondErr.Err)
+	require.ElementsMatch(t, []int32{0, 1}, []int32{firstErr.Msg.Partition, secondErr.Msg.Partition})
+	assertNotDone(t, output, 50*time.Millisecond)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next-0")})
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next-1")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected partition mutes to be released after shutdown")
+	}
+	parent.muter.unmute(contender)
+}
+
+func TestHandleErrorRetryLeaderError(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2191,6 +2191,141 @@ func TestHandleErrorNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
 	}
 }
 
+func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		txnmgr:     &transactionManager{},
+	}
+	failedBroker := &Broker{id: 1}
+	retryLeader := &Broker{id: 2}
+	client := &blockingRefreshClient{
+		stubLeaderClient: stubLeaderClient{leader: retryLeader, cfg: config},
+		started:          make(chan struct{}, 1),
+		release:          make(chan struct{}),
+	}
+	parent.client = client
+
+	output := make(chan *produceSet)
+	retryBP := &brokerProducer{
+		parent: parent,
+		broker: retryLeader,
+		output: output,
+		input:  make(chan *ProducerMessage),
+	}
+	parent.brokers[retryLeader] = retryBP
+
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            failedBroker,
+		input:             make(chan *ProducerMessage),
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+	retryPartitionSet := sent.msgs["topic"][0]
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		bp.handleError(sent, ErrOutOfBrokers)
+		close(done)
+	}()
+	assertDoneWithin(t, done, 2*time.Second)
+	assertDoneWithin(t, client.started, 2*time.Second)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+	if parent.muter.tryMute(contender) {
+		parent.muter.unmute(contender)
+		t.Fatal("expected partition to remain muted while async metadata refresh is pending")
+	}
+
+	close(client.release)
+	retrySet := assertDoneWithin(t, output, 2*time.Second)
+	defer parent.muter.unmute(retrySet)
+	require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
+}
+
+func TestHandleErrorNonIdempotentRetryRefreshesMetadataOncePerFailedRequest(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		txnmgr:     &transactionManager{},
+	}
+	failedBroker := &Broker{id: 1}
+	retryLeader := &Broker{id: 2}
+	client := &countingRefreshClient{
+		stubLeaderClient: stubLeaderClient{leader: retryLeader, cfg: config},
+		calls:            make(chan []string, 1),
+	}
+	parent.client = client
+
+	output := make(chan *produceSet, 2)
+	retryBP := &brokerProducer{
+		parent: parent,
+		broker: retryLeader,
+		output: output,
+		input:  make(chan *ProducerMessage),
+	}
+	parent.brokers[retryLeader] = retryBP
+	parent.brokerRefs[retryBP] = 1
+
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            failedBroker,
+		input:             make(chan *ProducerMessage),
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry-0")})
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("retry-1")})
+	retryPartitionSet0 := sent.msgs["topic"][0]
+	retryPartitionSet1 := sent.msgs["topic"][1]
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+
+	bp.handleError(sent, ErrOutOfBrokers)
+
+	require.Equal(t, []string{"topic"}, assertDoneWithin(t, client.calls, 2*time.Second))
+	retrySet0 := assertDoneWithin(t, output, 2*time.Second)
+	defer parent.muter.unmute(retrySet0)
+	retrySet1 := assertDoneWithin(t, output, 2*time.Second)
+	defer parent.muter.unmute(retrySet1)
+	assertNotDone(t, client.calls, 50*time.Millisecond)
+
+	retriedPartitions := make(map[int32]*partitionSet)
+	retrySet0.eachPartition(func(_ string, partition int32, pSet *partitionSet) {
+		retriedPartitions[partition] = pSet
+	})
+	retrySet1.eachPartition(func(_ string, partition int32, pSet *partitionSet) {
+		retriedPartitions[partition] = pSet
+	})
+	require.Same(t, retryPartitionSet0, retriedPartitions[int32(0)])
+	require.Same(t, retryPartitionSet1, retriedPartitions[int32(1)])
+}
+
 func TestHandleSuccessNonIdempotentRetryUsesPartitionProducer(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
@@ -2231,6 +2366,62 @@ func TestHandleSuccessNonIdempotentRetryUsesPartitionProducer(t *testing.T) {
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
 	if !parent.muter.tryMute(contender) {
 		t.Fatal("expected response retry to release sent mute before partitionProducer retry")
+	}
+	parent.muter.unmute(contender)
+}
+
+func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+	config.Producer.Return.Errors = true
+
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		errors:     make(chan *ProducerError, 1),
+		shutdownCh: make(chan struct{}),
+		txnmgr:     &transactionManager{},
+	}
+	leader := &Broker{id: 1}
+	parent.client = &stubLeaderClient{leader: leader, cfg: config}
+	retryBP := &brokerProducer{
+		parent: parent,
+		broker: leader,
+		output: make(chan *produceSet),
+		input:  make(chan *ProducerMessage),
+		done:   make(chan struct{}),
+	}
+	parent.brokers[leader] = retryBP
+
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+	retryPartitionSet := sent.msgs["topic"][0]
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+	if parent.shutdownChClosed.CompareAndSwap(false, true) {
+		close(parent.shutdownCh)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		parent.retryBatch("topic", 0, retryPartitionSet, ErrOutOfBrokers, true)
+		close(done)
+	}()
+
+	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, ErrShuttingDown, producerErr.Err)
+	assertDoneWithin(t, done, 2*time.Second)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected partition mute to be released after aborted retry handoff")
 	}
 	parent.muter.unmute(contender)
 }
@@ -2329,6 +2520,31 @@ func (c *failingLeaderClient) Leader(string, int32) (*Broker, error) {
 
 func (c *failingLeaderClient) LeaderAndEpoch(string, int32) (*Broker, int32, error) {
 	return nil, 0, c.err
+}
+
+type blockingRefreshClient struct {
+	stubLeaderClient
+	started chan struct{}
+	release chan struct{}
+}
+
+func (c *blockingRefreshClient) RefreshMetadata(...string) error {
+	select {
+	case c.started <- struct{}{}:
+	default:
+	}
+	<-c.release
+	return nil
+}
+
+type countingRefreshClient struct {
+	stubLeaderClient
+	calls chan []string
+}
+
+func (c *countingRefreshClient) RefreshMetadata(topics ...string) error {
+	c.calls <- append([]string(nil), topics...)
+	return nil
 }
 
 func testProducerInterceptor(

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1812,37 +1812,16 @@ func assertDoneWithin[T any](t *testing.T, ch <-chan T, timeout time.Duration) T
 	}
 }
 
-func waitForProducerBuffer(t *testing.T, parent *asyncProducer, messages, bytes int64) {
-	t.Helper()
-	deadline := time.After(2 * time.Second)
-	ticker := time.NewTicker(time.Millisecond)
-	defer ticker.Stop()
-	for {
-		parent.retryBuffer.mu.Lock()
-		gotMessages := parent.retryBuffer.messages
-		gotBytes := parent.retryBuffer.bytes
-		parent.retryBuffer.mu.Unlock()
-		if (messages < 0 || gotMessages == messages) && (bytes < 0 || gotBytes == bytes) {
-			return
-		}
-		select {
-		case <-deadline:
-			t.Fatalf("timed out waiting for buffer budget messages=%d bytes=%d, got messages=%d bytes=%d",
-				messages, bytes, gotMessages, gotBytes)
-		case <-ticker.C:
-		}
-	}
-}
-
 func newBlockingRetryProducer(config *Config, errorBuffer int) (*asyncProducer, *brokerProducer) {
 	parent := &asyncProducer{
-		conf:       config,
-		muter:      newPartitionMuter(),
-		brokers:    make(map[*Broker]*brokerProducer),
-		brokerRefs: make(map[*brokerProducer]int),
-		errors:     make(chan *ProducerError, errorBuffer),
-		done:       make(chan struct{}),
-		txnmgr:     &transactionManager{},
+		conf:             config,
+		muter:            newPartitionMuter(),
+		brokers:          make(map[*Broker]*brokerProducer),
+		brokerRefs:       make(map[*brokerProducer]int),
+		errors:           make(chan *ProducerError, errorBuffer),
+		done:             make(chan struct{}),
+		txnmgr:           &transactionManager{},
+		retryBufferQuota: newRetryBufferQuota(config),
 	}
 	leader := &Broker{id: 1}
 	parent.client = &stubLeaderClient{leader: leader, cfg: config}
@@ -1855,6 +1834,52 @@ func newBlockingRetryProducer(config *Config, errorBuffer int) (*asyncProducer, 
 	}
 	parent.brokers[leader] = retryBP
 	return parent, retryBP
+}
+
+// holdFirstRetryAfterReserve lets the test prove a second retry sees quota held by the first.
+func holdFirstRetryAfterReserve(parent *asyncProducer, retryBP *brokerProducer, afterRefresh bool) (<-chan struct{}, func()) {
+	firstRetryReserved := make(chan struct{}, 1)
+	blockFirstRetry := make(chan struct{}, 1)
+	releaseFirstRetry := make(chan struct{}, 1)
+	blockFirstRetry <- struct{}{}
+
+	hold := func() {
+		select {
+		case <-blockFirstRetry:
+			firstRetryReserved <- struct{}{}
+			<-releaseFirstRetry
+		default:
+		}
+	}
+	release := func() {
+		select {
+		case releaseFirstRetry <- struct{}{}:
+		default:
+		}
+	}
+
+	if afterRefresh {
+		parent.client = &stubLeaderClient{
+			leader: retryBP.broker,
+			cfg:    parent.conf,
+			refreshMetadata: func(...string) error {
+				hold()
+				return nil
+			},
+		}
+	} else {
+		parent.client = &stubLeaderClient{
+			cfg: parent.conf,
+			leaderFunc: func(_ string, partition int32) (*Broker, error) {
+				if partition == 0 {
+					hold()
+				}
+				return retryBP.broker, nil
+			},
+		}
+	}
+
+	return firstRetryReserved, release
 }
 
 // TestBrokerProducerWaitForSpaceRespectsExternalUnmute ensures waitForSpace does not
@@ -2135,11 +2160,12 @@ func TestRetryBatchRespectsPartitionMuter(t *testing.T) {
 	}
 
 	parent := &asyncProducer{
-		conf:       config,
-		muter:      newPartitionMuter(),
-		brokers:    make(map[*Broker]*brokerProducer),
-		brokerRefs: make(map[*brokerProducer]int),
-		txnmgr:     txnMgr,
+		conf:             config,
+		muter:            newPartitionMuter(),
+		brokers:          make(map[*Broker]*brokerProducer),
+		brokerRefs:       make(map[*brokerProducer]int),
+		txnmgr:           txnMgr,
+		retryBufferQuota: newRetryBufferQuota(config),
 	}
 	leader := &Broker{}
 	parent.client = &stubLeaderClient{leader: leader, cfg: config}
@@ -2170,7 +2196,6 @@ func TestRetryBatchRespectsPartitionMuter(t *testing.T) {
 	default:
 		t.Fatal("expected retry batch to be dispatched")
 	}
-	waitForProducerBuffer(t, parent, 0, 0)
 
 	contender := newProduceSet(parent)
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
@@ -2297,18 +2322,28 @@ func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T
 	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength
 
 	parent := &asyncProducer{
-		conf:       config,
-		muter:      newPartitionMuter(),
-		brokers:    make(map[*Broker]*brokerProducer),
-		brokerRefs: make(map[*brokerProducer]int),
-		txnmgr:     &transactionManager{},
+		conf:             config,
+		muter:            newPartitionMuter(),
+		brokers:          make(map[*Broker]*brokerProducer),
+		brokerRefs:       make(map[*brokerProducer]int),
+		txnmgr:           &transactionManager{},
+		retryBufferQuota: newRetryBufferQuota(config),
 	}
 	failedBroker := &Broker{id: 1}
 	retryLeader := &Broker{id: 2}
-	client := &blockingRefreshClient{
-		stubLeaderClient: stubLeaderClient{leader: retryLeader, cfg: config},
-		started:          make(chan struct{}, 1),
-		release:          make(chan struct{}),
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	client := &stubLeaderClient{
+		leader: retryLeader,
+		cfg:    config,
+		refreshMetadata: func(...string) error {
+			select {
+			case started <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil
+		},
 	}
 	parent.client = client
 
@@ -2342,8 +2377,7 @@ func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T
 		close(done)
 	}()
 	assertDoneWithin(t, done, 2*time.Second)
-	assertDoneWithin(t, client.started, 2*time.Second)
-	waitForProducerBuffer(t, parent, 1, -1)
+	assertDoneWithin(t, started, 2*time.Second)
 
 	contender := newProduceSet(parent)
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
@@ -2352,11 +2386,10 @@ func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T
 		t.Fatal("expected partition to remain muted while async metadata refresh is pending")
 	}
 
-	close(client.release)
+	close(release)
 	retrySet := assertDoneWithin(t, output, 2*time.Second)
 	defer parent.muter.unmute(retrySet)
 	require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
-	waitForProducerBuffer(t, parent, 0, 0)
 }
 
 func TestHandleErrorNonIdempotentRetryRefreshesMetadataOncePerFailedRequest(t *testing.T) {
@@ -2374,9 +2407,14 @@ func TestHandleErrorNonIdempotentRetryRefreshesMetadataOncePerFailedRequest(t *t
 	}
 	failedBroker := &Broker{id: 1}
 	retryLeader := &Broker{id: 2}
-	client := &countingRefreshClient{
-		stubLeaderClient: stubLeaderClient{leader: retryLeader, cfg: config},
-		calls:            make(chan []string, 1),
+	calls := make(chan []string, 1)
+	client := &stubLeaderClient{
+		leader: retryLeader,
+		cfg:    config,
+		refreshMetadata: func(topics ...string) error {
+			calls <- append([]string(nil), topics...)
+			return nil
+		},
 	}
 	parent.client = client
 
@@ -2409,10 +2447,10 @@ func TestHandleErrorNonIdempotentRetryRefreshesMetadataOncePerFailedRequest(t *t
 
 	bp.handleError(sent, ErrOutOfBrokers)
 
-	require.Equal(t, []string{"topic"}, assertDoneWithin(t, client.calls, 2*time.Second))
+	require.Equal(t, []string{"topic"}, assertDoneWithin(t, calls, 2*time.Second))
 	retrySet := assertDoneWithin(t, output, 2*time.Second)
 	defer parent.muter.unmute(retrySet)
-	assertNotDone(t, client.calls, 50*time.Millisecond)
+	assertNotDone(t, calls, 50*time.Millisecond)
 	assertNotDone(t, output, 50*time.Millisecond)
 
 	retriedPartitions := make(map[int32]*partitionSet)
@@ -2439,8 +2477,9 @@ func TestHandleErrorNonIdempotentRetryGroupsBatchesByLeader(t *testing.T) {
 	failedBroker := &Broker{id: 1}
 	leaderA := &Broker{id: 2}
 	leaderB := &Broker{id: 3}
-	client := &routingLeaderClient{
-		stubLeaderClient: stubLeaderClient{cfg: config},
+	calls := make(chan []string, 1)
+	client := &stubLeaderClient{
+		cfg: config,
 		leaders: map[string]map[int32]*Broker{
 			"topic-a": {
 				0: leaderA,
@@ -2451,7 +2490,10 @@ func TestHandleErrorNonIdempotentRetryGroupsBatchesByLeader(t *testing.T) {
 				1: leaderB,
 			},
 		},
-		calls: make(chan []string, 1),
+		refreshMetadata: func(topics ...string) error {
+			calls <- append([]string(nil), topics...)
+			return nil
+		},
 	}
 	parent.client = client
 
@@ -2491,7 +2533,7 @@ func TestHandleErrorNonIdempotentRetryGroupsBatchesByLeader(t *testing.T) {
 
 	bp.handleError(sent, ErrOutOfBrokers)
 
-	require.ElementsMatch(t, []string{"topic-a", "topic-b"}, assertDoneWithin(t, client.calls, 2*time.Second))
+	require.ElementsMatch(t, []string{"topic-a", "topic-b"}, assertDoneWithin(t, calls, 2*time.Second))
 	retrySetA := assertDoneWithin(t, outputA, 2*time.Second)
 	defer parent.muter.unmute(retrySetA)
 	retrySetB := assertDoneWithin(t, outputB, 2*time.Second)
@@ -2569,16 +2611,27 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength
 
 	parent := &asyncProducer{
-		conf:       config,
-		muter:      newPartitionMuter(),
-		brokers:    make(map[*Broker]*brokerProducer),
-		brokerRefs: make(map[*brokerProducer]int),
-		errors:     make(chan *ProducerError, 1),
-		done:       make(chan struct{}),
-		txnmgr:     &transactionManager{},
+		conf:             config,
+		muter:            newPartitionMuter(),
+		brokers:          make(map[*Broker]*brokerProducer),
+		brokerRefs:       make(map[*brokerProducer]int),
+		errors:           make(chan *ProducerError, 1),
+		done:             make(chan struct{}),
+		txnmgr:           &transactionManager{},
+		retryBufferQuota: newRetryBufferQuota(config),
 	}
 	leader := &Broker{id: 1}
-	parent.client = &stubLeaderClient{leader: leader, cfg: config}
+	leaderLookup := make(chan struct{}, 1)
+	parent.client = &stubLeaderClient{
+		cfg: config,
+		leaderFunc: func(string, int32) (*Broker, error) {
+			select {
+			case leaderLookup <- struct{}{}:
+			default:
+			}
+			return leader, nil
+		},
+	}
 	retryBP := &brokerProducer{
 		parent: parent,
 		broker: leader,
@@ -2601,7 +2654,7 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 		parent.retryBatch("topic", 0, retryPartitionSet, ErrOutOfBrokers, true)
 		close(done)
 	}()
-	waitForProducerBuffer(t, parent, 1, -1)
+	assertDoneWithin(t, leaderLookup, 2*time.Second)
 
 	if parent.closed.CompareAndSwap(false, true) {
 		close(parent.done)
@@ -2610,7 +2663,6 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
 	require.Equal(t, ErrShuttingDown, producerErr.Err)
 	assertDoneWithin(t, done, 2*time.Second)
-	waitForProducerBuffer(t, parent, 0, 0)
 
 	contender := newProduceSet(parent)
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
@@ -2620,114 +2672,105 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 	parent.muter.unmute(contender)
 }
 
-func TestRetryBatchUsesSharedBufferLengthBudget(t *testing.T) {
-	config := NewTestConfig()
-	config.Producer.Idempotent = true
-	config.Producer.Retry.Max = 1
-	config.Producer.Retry.Backoff = 0
-	config.Producer.Return.Errors = true
-	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength + 1
-
-	parent, retryBP := newBlockingRetryProducer(config, minFunctionalRetryBufferLength+1)
-
-	first := newProduceSet(parent)
-	for i := 0; i < minFunctionalRetryBufferLength; i++ {
-		safeAddMessage(t, first, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+func TestRetryUsesSharedBufferBudget(t *testing.T) {
+	tests := []struct {
+		name         string
+		afterRefresh bool
+		bytesLimit   bool
+	}{
+		{name: "retryBatch length"},
+		{name: "retryBatch bytes", bytesLimit: true},
+		{name: "retryBatchesAfterRefresh length", afterRefresh: true},
+		{name: "retryBatchesAfterRefresh bytes", afterRefresh: true, bytesLimit: true},
 	}
-	firstPartitionSet := first.msgs["topic"][0]
-	if !parent.muter.tryMute(first) {
-		t.Fatal("expected first retry batch to mute partitions")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := NewTestConfig()
+			config.Producer.Idempotent = !tt.afterRefresh
+			config.Producer.Retry.Max = 1
+			config.Producer.Retry.Backoff = 0
+			config.Producer.Return.Errors = true
+
+			firstCount := 1
+			errorBuffer := 2
+			var firstMsg *ProducerMessage
+			secondMsg := &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")}
+
+			if tt.bytesLimit {
+				firstMsg = &ProducerMessage{Topic: "topic", Partition: 0, Value: ByteEncoder(make([]byte, minFunctionalRetryBufferBytes))}
+				version := producerMessageByteSizeVersion(config)
+				firstBytes := int64(firstMsg.ByteSize(version))
+				secondBytes := int64(secondMsg.ByteSize(version))
+				config.Producer.Retry.MaxBufferBytes = firstBytes + secondBytes
+			} else {
+				config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength + 1
+				firstCount = minFunctionalRetryBufferLength
+				errorBuffer = minFunctionalRetryBufferLength + 1
+			}
+
+			parent, retryBP := newBlockingRetryProducer(config, errorBuffer)
+			firstRetryReserved, releaseFirstRetry := holdFirstRetryAfterReserve(parent, retryBP, tt.afterRefresh)
+			defer releaseFirstRetry()
+
+			retry := func(partition int32, pSet *partitionSet) {
+				if tt.afterRefresh {
+					parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
+						topic:     "topic",
+						partition: partition,
+						pSet:      pSet,
+					}}, ErrOutOfBrokers)
+					return
+				}
+				parent.retryBatch("topic", partition, pSet, ErrNotEnoughReplicas, true)
+			}
+
+			first := newProduceSet(parent)
+			if tt.bytesLimit {
+				safeAddMessage(t, first, firstMsg)
+			} else {
+				for i := 0; i < minFunctionalRetryBufferLength; i++ {
+					safeAddMessage(t, first, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+				}
+			}
+			firstPartitionSet := first.msgs["topic"][0]
+			if !parent.muter.tryMute(first) {
+				t.Fatal("expected first retry batch to mute partitions")
+			}
+			parent.inFlight.Add(firstCount)
+
+			firstDone := make(chan struct{})
+			go func() {
+				retry(0, firstPartitionSet)
+				close(firstDone)
+			}()
+			assertDoneWithin(t, firstRetryReserved, 2*time.Second)
+
+			second := newProduceSet(parent)
+			safeAddMessage(t, second, secondMsg)
+			secondPartitionSet := second.msgs["topic"][1]
+			if !parent.muter.tryMute(second) {
+				t.Fatal("expected second retry batch to mute partitions")
+			}
+			parent.inFlight.Add(1)
+			retry(1, secondPartitionSet)
+
+			producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+			require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
+			require.Equal(t, int32(1), producerErr.Msg.Partition)
+
+			contender := newProduceSet(parent)
+			safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
+			if !parent.muter.tryMute(contender) {
+				t.Fatal("expected overflowed retry batch to release partition mute")
+			}
+			parent.muter.unmute(contender)
+
+			close(retryBP.done)
+			releaseFirstRetry()
+			assertDoneWithin(t, firstDone, 2*time.Second)
+		})
 	}
-	parent.inFlight.Add(minFunctionalRetryBufferLength)
-
-	firstDone := make(chan struct{})
-	go func() {
-		parent.retryBatch("topic", 0, firstPartitionSet, ErrNotEnoughReplicas, true)
-		close(firstDone)
-	}()
-	waitForProducerBuffer(t, parent, minFunctionalRetryBufferLength, -1)
-
-	second := newProduceSet(parent)
-	safeAddMessage(t, second, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")})
-	secondPartitionSet := second.msgs["topic"][1]
-	if !parent.muter.tryMute(second) {
-		t.Fatal("expected second retry batch to mute partitions")
-	}
-	parent.inFlight.Add(1)
-	parent.retryBatch("topic", 1, secondPartitionSet, ErrNotEnoughReplicas, true)
-
-	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
-	require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
-	require.Equal(t, int32(1), producerErr.Msg.Partition)
-	waitForProducerBuffer(t, parent, minFunctionalRetryBufferLength, -1)
-
-	contender := newProduceSet(parent)
-	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
-	if !parent.muter.tryMute(contender) {
-		t.Fatal("expected overflowed retry batch to release partition mute")
-	}
-	parent.muter.unmute(contender)
-
-	close(retryBP.done)
-	assertDoneWithin(t, firstDone, 2*time.Second)
-	waitForProducerBuffer(t, parent, 0, 0)
-}
-
-func TestRetryBatchUsesSharedBufferBytesBudget(t *testing.T) {
-	config := NewTestConfig()
-	config.Producer.Idempotent = true
-	config.Producer.Retry.Max = 1
-	config.Producer.Retry.Backoff = 0
-	config.Producer.Return.Errors = true
-
-	parent, retryBP := newBlockingRetryProducer(config, 2)
-
-	firstMsg := &ProducerMessage{Topic: "topic", Partition: 0, Value: ByteEncoder(make([]byte, minFunctionalRetryBufferBytes))}
-	secondMsg := &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")}
-	version := parent.producerMessageByteSizeVersion()
-	firstBytes := int64(firstMsg.ByteSize(version))
-	secondBytes := int64(secondMsg.ByteSize(version))
-	config.Producer.Retry.MaxBufferBytes = firstBytes + secondBytes
-
-	first := newProduceSet(parent)
-	safeAddMessage(t, first, firstMsg)
-	firstPartitionSet := first.msgs["topic"][0]
-	if !parent.muter.tryMute(first) {
-		t.Fatal("expected first retry batch to mute partitions")
-	}
-	parent.inFlight.Add(1)
-
-	firstDone := make(chan struct{})
-	go func() {
-		parent.retryBatch("topic", 0, firstPartitionSet, ErrNotEnoughReplicas, true)
-		close(firstDone)
-	}()
-	waitForProducerBuffer(t, parent, -1, firstBytes)
-
-	second := newProduceSet(parent)
-	safeAddMessage(t, second, secondMsg)
-	secondPartitionSet := second.msgs["topic"][1]
-	if !parent.muter.tryMute(second) {
-		t.Fatal("expected second retry batch to mute partitions")
-	}
-	parent.inFlight.Add(1)
-	parent.retryBatch("topic", 1, secondPartitionSet, ErrNotEnoughReplicas, true)
-
-	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
-	require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
-	require.Equal(t, int32(1), producerErr.Msg.Partition)
-	waitForProducerBuffer(t, parent, -1, firstBytes)
-
-	contender := newProduceSet(parent)
-	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
-	if !parent.muter.tryMute(contender) {
-		t.Fatal("expected overflowed retry batch to release partition mute")
-	}
-	parent.muter.unmute(contender)
-
-	close(retryBP.done)
-	assertDoneWithin(t, firstDone, 2*time.Second)
-	waitForProducerBuffer(t, parent, 0, 0)
 }
 
 func TestRetryBatchesAfterRefreshReleasesMuteWhenBrokerProducerDone(t *testing.T) {
@@ -2788,128 +2831,6 @@ func TestRetryBatchesAfterRefreshReleasesMuteWhenBrokerProducerDone(t *testing.T
 	parent.muter.unmute(contender)
 }
 
-func TestRetryBatchesAfterRefreshUsesSharedBufferLengthBudget(t *testing.T) {
-	config := NewTestConfig()
-	config.Producer.Idempotent = false
-	config.Producer.Retry.Max = 1
-	config.Producer.Retry.Backoff = 0
-	config.Producer.Return.Errors = true
-	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength + 1
-
-	parent, retryBP := newBlockingRetryProducer(config, minFunctionalRetryBufferLength+1)
-
-	first := newProduceSet(parent)
-	for i := 0; i < minFunctionalRetryBufferLength; i++ {
-		safeAddMessage(t, first, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
-	}
-	if !parent.muter.tryMute(first) {
-		t.Fatal("expected first retry batch to mute partitions")
-	}
-	parent.inFlight.Add(minFunctionalRetryBufferLength)
-
-	firstDone := make(chan struct{})
-	go func() {
-		parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
-			topic:     "topic",
-			partition: 0,
-			pSet:      first.msgs["topic"][0],
-		}}, ErrOutOfBrokers)
-		close(firstDone)
-	}()
-	waitForProducerBuffer(t, parent, minFunctionalRetryBufferLength, -1)
-
-	second := newProduceSet(parent)
-	safeAddMessage(t, second, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")})
-	if !parent.muter.tryMute(second) {
-		t.Fatal("expected second retry batch to mute partitions")
-	}
-	parent.inFlight.Add(1)
-	parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
-		topic:     "topic",
-		partition: 1,
-		pSet:      second.msgs["topic"][1],
-	}}, ErrOutOfBrokers)
-
-	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
-	require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
-	require.Equal(t, int32(1), producerErr.Msg.Partition)
-	waitForProducerBuffer(t, parent, minFunctionalRetryBufferLength, -1)
-
-	contender := newProduceSet(parent)
-	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
-	if !parent.muter.tryMute(contender) {
-		t.Fatal("expected overflowed retry batch to release partition mute")
-	}
-	parent.muter.unmute(contender)
-
-	close(retryBP.done)
-	assertDoneWithin(t, firstDone, 2*time.Second)
-	waitForProducerBuffer(t, parent, 0, 0)
-}
-
-func TestRetryBatchesAfterRefreshUsesSharedBufferBytesBudget(t *testing.T) {
-	config := NewTestConfig()
-	config.Producer.Idempotent = false
-	config.Producer.Retry.Max = 1
-	config.Producer.Retry.Backoff = 0
-	config.Producer.Return.Errors = true
-
-	parent, retryBP := newBlockingRetryProducer(config, 2)
-
-	firstMsg := &ProducerMessage{Topic: "topic", Partition: 0, Value: ByteEncoder(make([]byte, minFunctionalRetryBufferBytes))}
-	secondMsg := &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")}
-	version := parent.producerMessageByteSizeVersion()
-	firstBytes := int64(firstMsg.ByteSize(version))
-	secondBytes := int64(secondMsg.ByteSize(version))
-	config.Producer.Retry.MaxBufferBytes = firstBytes + secondBytes
-
-	first := newProduceSet(parent)
-	safeAddMessage(t, first, firstMsg)
-	if !parent.muter.tryMute(first) {
-		t.Fatal("expected first retry batch to mute partitions")
-	}
-	parent.inFlight.Add(1)
-
-	firstDone := make(chan struct{})
-	go func() {
-		parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
-			topic:     "topic",
-			partition: 0,
-			pSet:      first.msgs["topic"][0],
-		}}, ErrOutOfBrokers)
-		close(firstDone)
-	}()
-	waitForProducerBuffer(t, parent, -1, firstBytes)
-
-	second := newProduceSet(parent)
-	safeAddMessage(t, second, secondMsg)
-	if !parent.muter.tryMute(second) {
-		t.Fatal("expected second retry batch to mute partitions")
-	}
-	parent.inFlight.Add(1)
-	parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
-		topic:     "topic",
-		partition: 1,
-		pSet:      second.msgs["topic"][1],
-	}}, ErrOutOfBrokers)
-
-	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
-	require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
-	require.Equal(t, int32(1), producerErr.Msg.Partition)
-	waitForProducerBuffer(t, parent, -1, firstBytes)
-
-	contender := newProduceSet(parent)
-	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
-	if !parent.muter.tryMute(contender) {
-		t.Fatal("expected overflowed retry batch to release partition mute")
-	}
-	parent.muter.unmute(contender)
-
-	close(retryBP.done)
-	assertDoneWithin(t, firstDone, 2*time.Second)
-	waitForProducerBuffer(t, parent, 0, 0)
-}
-
 func TestHandleErrorNonIdempotentRetryReleasesMuteOnLeaderError(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
@@ -2925,10 +2846,7 @@ func TestHandleErrorNonIdempotentRetryReleasesMuteOnLeaderError(t *testing.T) {
 		errors:     make(chan *ProducerError, 1),
 		txnmgr:     &transactionManager{},
 	}
-	parent.client = &failingLeaderClient{
-		stubLeaderClient: stubLeaderClient{cfg: config},
-		err:              ErrOutOfBrokers,
-	}
+	parent.client = &stubLeaderClient{cfg: config, leaderErr: ErrOutOfBrokers}
 
 	bp := &brokerProducer{
 		parent:            parent,
@@ -2959,8 +2877,12 @@ func TestHandleErrorNonIdempotentRetryReleasesMuteOnLeaderError(t *testing.T) {
 }
 
 type stubLeaderClient struct {
-	cfg    *Config
-	leader *Broker
+	cfg             *Config
+	leader          *Broker
+	leaderFunc      func(string, int32) (*Broker, error)
+	leaderErr       error
+	leaders         map[string]map[int32]*Broker
+	refreshMetadata func(...string) error
 }
 
 func (c *stubLeaderClient) Config() *Config                            { return c.cfg }
@@ -2972,16 +2894,36 @@ func (c *stubLeaderClient) Topics() ([]string, error)                  { return 
 func (c *stubLeaderClient) Partitions(string) ([]int32, error)         { return nil, nil }
 func (c *stubLeaderClient) WritablePartitions(string) ([]int32, error) { return nil, nil }
 func (c *stubLeaderClient) Leader(topic string, partitionID int32) (*Broker, error) {
+	if c.leaderFunc != nil {
+		return c.leaderFunc(topic, partitionID)
+	}
+	if c.leaderErr != nil {
+		return nil, c.leaderErr
+	}
+	if partitions := c.leaders[topic]; partitions != nil {
+		if leader := partitions[partitionID]; leader != nil {
+			return leader, nil
+		}
+	}
+	if c.leaders != nil {
+		return nil, ErrLeaderNotAvailable
+	}
 	return c.leader, nil
 }
-func (c *stubLeaderClient) LeaderAndEpoch(string, int32) (*Broker, int32, error) {
-	return c.leader, 0, nil
+func (c *stubLeaderClient) LeaderAndEpoch(topic string, partition int32) (*Broker, int32, error) {
+	leader, err := c.Leader(topic, partition)
+	return leader, 0, err
 }
-func (c *stubLeaderClient) Replicas(string, int32) ([]int32, error)          { return nil, nil }
-func (c *stubLeaderClient) InSyncReplicas(string, int32) ([]int32, error)    { return nil, nil }
-func (c *stubLeaderClient) OfflineReplicas(string, int32) ([]int32, error)   { return nil, nil }
-func (c *stubLeaderClient) RefreshBrokers([]string) error                    { return nil }
-func (c *stubLeaderClient) RefreshMetadata(...string) error                  { return nil }
+func (c *stubLeaderClient) Replicas(string, int32) ([]int32, error)        { return nil, nil }
+func (c *stubLeaderClient) InSyncReplicas(string, int32) ([]int32, error)  { return nil, nil }
+func (c *stubLeaderClient) OfflineReplicas(string, int32) ([]int32, error) { return nil, nil }
+func (c *stubLeaderClient) RefreshBrokers([]string) error                  { return nil }
+func (c *stubLeaderClient) RefreshMetadata(topics ...string) error {
+	if c.refreshMetadata != nil {
+		return c.refreshMetadata(topics...)
+	}
+	return nil
+}
 func (c *stubLeaderClient) GetOffset(string, int32, int64) (int64, error)    { return 0, nil }
 func (c *stubLeaderClient) Coordinator(string) (*Broker, error)              { return nil, nil }
 func (c *stubLeaderClient) RefreshCoordinator(string) error                  { return nil }
@@ -2992,69 +2934,6 @@ func (c *stubLeaderClient) LeastLoadedBroker() *Broker                       { r
 func (c *stubLeaderClient) PartitionNotReadable(string, int32) bool          { return false }
 func (c *stubLeaderClient) Close() error                                     { return nil }
 func (c *stubLeaderClient) Closed() bool                                     { return false }
-
-type failingLeaderClient struct {
-	stubLeaderClient
-	err error
-}
-
-func (c *failingLeaderClient) Leader(string, int32) (*Broker, error) {
-	return nil, c.err
-}
-
-func (c *failingLeaderClient) LeaderAndEpoch(string, int32) (*Broker, int32, error) {
-	return nil, 0, c.err
-}
-
-type blockingRefreshClient struct {
-	stubLeaderClient
-	started chan struct{}
-	release chan struct{}
-}
-
-func (c *blockingRefreshClient) RefreshMetadata(...string) error {
-	select {
-	case c.started <- struct{}{}:
-	default:
-	}
-	<-c.release
-	return nil
-}
-
-type countingRefreshClient struct {
-	stubLeaderClient
-	calls chan []string
-}
-
-func (c *countingRefreshClient) RefreshMetadata(topics ...string) error {
-	c.calls <- append([]string(nil), topics...)
-	return nil
-}
-
-type routingLeaderClient struct {
-	stubLeaderClient
-	leaders map[string]map[int32]*Broker
-	calls   chan []string
-}
-
-func (c *routingLeaderClient) Leader(topic string, partition int32) (*Broker, error) {
-	if partitions := c.leaders[topic]; partitions != nil {
-		if leader := partitions[partition]; leader != nil {
-			return leader, nil
-		}
-	}
-	return nil, ErrLeaderNotAvailable
-}
-
-func (c *routingLeaderClient) LeaderAndEpoch(topic string, partition int32) (*Broker, int32, error) {
-	leader, err := c.Leader(topic, partition)
-	return leader, 0, err
-}
-
-func (c *routingLeaderClient) RefreshMetadata(topics ...string) error {
-	c.calls <- append([]string(nil), topics...)
-	return nil
-}
 
 func testProducerInterceptor(
 	t *testing.T,

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1737,6 +1737,8 @@ func TestBrokerProducerShutdown(t *testing.T) {
 	bp := producer.(*asyncProducer).getBrokerProducer(broker)
 	// Initiate the shutdown of all of them
 	producer.(*asyncProducer).unrefBrokerProducer(broker, bp)
+	assertDoneWithin(t, bp.done, time.Second)
+	require.NotPanics(t, bp.shutdown)
 
 	_ = producer.Close()
 	mockBroker.Close()
@@ -1839,7 +1841,7 @@ func newBlockingRetryProducer(config *Config, errorBuffer int) (*asyncProducer, 
 		brokers:    make(map[*Broker]*brokerProducer),
 		brokerRefs: make(map[*brokerProducer]int),
 		errors:     make(chan *ProducerError, errorBuffer),
-		shutdownCh: make(chan struct{}),
+		done:       make(chan struct{}),
 		txnmgr:     &transactionManager{},
 	}
 	leader := &Broker{id: 1}
@@ -2572,7 +2574,7 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 		brokers:    make(map[*Broker]*brokerProducer),
 		brokerRefs: make(map[*brokerProducer]int),
 		errors:     make(chan *ProducerError, 1),
-		shutdownCh: make(chan struct{}),
+		done:       make(chan struct{}),
 		txnmgr:     &transactionManager{},
 	}
 	leader := &Broker{id: 1}
@@ -2601,8 +2603,8 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 	}()
 	waitForProducerBuffer(t, parent, 1, -1)
 
-	if parent.shutdownChClosed.CompareAndSwap(false, true) {
-		close(parent.shutdownCh)
+	if parent.closed.CompareAndSwap(false, true) {
+		close(parent.done)
 	}
 
 	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
@@ -2741,7 +2743,7 @@ func TestRetryBatchesAfterRefreshReleasesMuteWhenBrokerProducerDone(t *testing.T
 		brokers:    make(map[*Broker]*brokerProducer),
 		brokerRefs: make(map[*brokerProducer]int),
 		errors:     make(chan *ProducerError, 1),
-		shutdownCh: make(chan struct{}),
+		done:       make(chan struct{}),
 		txnmgr:     &transactionManager{},
 	}
 	leader := &Broker{id: 1}

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2238,6 +2238,55 @@ func TestHandleErrorNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
 	}
 }
 
+func TestHandleErrorNonIdempotentRetryFailsWholeBatch(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Return.Errors = true
+
+	parent := &asyncProducer{
+		conf:    config,
+		muter:   newPartitionMuter(),
+		errors:  make(chan *ProducerError, 2),
+		retries: make(chan *ProducerMessage, 2),
+		txnmgr:  &transactionManager{},
+	}
+
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            &Broker{id: 1},
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+
+	exhausted := &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("exhausted"), retries: 1}
+	retryable := &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retryable")}
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, exhausted)
+	safeAddMessage(t, sent, retryable)
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+	parent.inFlight.Add(2)
+
+	bp.handleError(sent, ErrOutOfBrokers)
+
+	firstErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	secondErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, exhausted, firstErr.Msg)
+	require.Equal(t, ErrOutOfBrokers, firstErr.Err)
+	require.Equal(t, retryable, secondErr.Msg)
+	require.Equal(t, ErrOutOfBrokers, secondErr.Err)
+	assertNotDone(t, parent.retries, 50*time.Millisecond)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected partition mute to be released after whole-batch failure")
+	}
+	parent.muter.unmute(contender)
+}
+
 func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1406,7 +1406,7 @@ func TestAsyncProducerIdempotentRetryCheckBatch_2378(t *testing.T) {
 			return metadataResponse
 		case 22:
 			return initProducerIDResponse
-		case 0: // for msg, always return error to trigger retryBatch
+		case 0: // for msg, always return error to trigger response retry
 			return prodNotLeaderResponse
 		}
 		return nil
@@ -1447,9 +1447,9 @@ func TestAsyncProducerIdempotentRetryCheckBatch_2378(t *testing.T) {
 }
 
 // test case for https://github.com/IBM/sarama/issues/2469: idempotent producer
-// retries via retryBatch must honor Retry.Backoff / Retry.BackoffFunc when the
-// broker repeatedly returns a retriable error.
-func TestAsyncProducerIdempotentRetryBatchBackoff(t *testing.T) {
+// retries must honor Retry.Backoff / Retry.BackoffFunc when the broker repeatedly
+// returns a retriable produce response.
+func TestAsyncProducerIdempotentResponseRetryBackoff(t *testing.T) {
 	broker := NewMockBroker(t, 1)
 
 	metadataResponse := &MetadataResponse{
@@ -1510,7 +1510,7 @@ func TestAsyncProducerIdempotentRetryBatchBackoff(t *testing.T) {
 	closeProducer(t, producer)
 
 	assert.GreaterOrEqual(t, int(backoffCalls.Load()), config.Producer.Retry.Max,
-		"BackoffFunc should be called at least Retry.Max times during idempotent retryBatch")
+		"BackoffFunc should be called at least Retry.Max times during idempotent response retry")
 }
 
 func TestAsyncProducerIdempotentErrorOnOutOfSeq(t *testing.T) {
@@ -1837,7 +1837,7 @@ func newBlockingRetryProducer(config *Config, errorBuffer int) (*asyncProducer, 
 }
 
 // holdFirstRetryAfterReserve lets the test prove a second retry sees quota held by the first.
-func holdFirstRetryAfterReserve(parent *asyncProducer, retryBP *brokerProducer, afterRefresh bool) (<-chan struct{}, func()) {
+func holdFirstRetryAfterReserve(parent *asyncProducer, retryBP *brokerProducer) (<-chan struct{}, func()) {
 	firstRetryReserved := make(chan struct{}, 1)
 	blockFirstRetry := make(chan struct{}, 1)
 	releaseFirstRetry := make(chan struct{}, 1)
@@ -1858,25 +1858,13 @@ func holdFirstRetryAfterReserve(parent *asyncProducer, retryBP *brokerProducer, 
 		}
 	}
 
-	if afterRefresh {
-		parent.client = &stubLeaderClient{
-			leader: retryBP.broker,
-			cfg:    parent.conf,
-			refreshMetadata: func(...string) error {
-				hold()
-				return nil
-			},
-		}
-	} else {
-		parent.client = &stubLeaderClient{
-			cfg: parent.conf,
-			leaderFunc: func(_ string, partition int32) (*Broker, error) {
-				if partition == 0 {
-					hold()
-				}
-				return retryBP.broker, nil
-			},
-		}
+	parent.client = &stubLeaderClient{
+		leader: retryBP.broker,
+		cfg:    parent.conf,
+		refreshMetadata: func(...string) error {
+			hold()
+			return nil
+		},
 	}
 
 	return firstRetryReserved, release
@@ -2146,61 +2134,6 @@ func TestBrokerProducerRollOverClearsTimer(t *testing.T) {
 	case <-done:
 	case <-time.After(time.Second):
 		t.Fatal("brokerProducer did not shut down")
-	}
-}
-
-func TestRetryBatchRespectsPartitionMuter(t *testing.T) {
-	config := NewTestConfig()
-	config.Producer.Idempotent = true
-	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength
-	txnMgr := &transactionManager{
-		producerID:      0,
-		producerEpoch:   0,
-		sequenceNumbers: make(map[string]int32),
-	}
-
-	parent := &asyncProducer{
-		conf:             config,
-		muter:            newPartitionMuter(),
-		brokers:          make(map[*Broker]*brokerProducer),
-		brokerRefs:       make(map[*brokerProducer]int),
-		txnmgr:           txnMgr,
-		retryBufferQuota: newRetryBufferQuota(config),
-	}
-	leader := &Broker{}
-	parent.client = &stubLeaderClient{leader: leader, cfg: config}
-
-	output := make(chan *produceSet, 1)
-	bp := &brokerProducer{
-		parent: parent,
-		broker: leader,
-		output: output,
-		input:  make(chan *ProducerMessage),
-	}
-	parent.brokers[leader] = bp
-
-	retrySet := newProduceSet(parent)
-	safeAddMessage(t, retrySet, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
-	retryPartitionSet := retrySet.msgs["topic"][0]
-	if !parent.muter.tryMute(retrySet) {
-		t.Fatal("expected retry set to mute partitions")
-	}
-	parent.muter.unmute(retrySet)
-
-	parent.retryBatch("topic", 0, retryPartitionSet, ErrNotEnoughReplicas, false)
-
-	select {
-	case sent := <-output:
-		set := sent.msgs["topic"][0]
-		require.Equal(t, retryPartitionSet, set)
-	default:
-		t.Fatal("expected retry batch to be dispatched")
-	}
-
-	contender := newProduceSet(parent)
-	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
-	if parent.muter.tryMute(contender) {
-		t.Fatal("expected partition to remain muted by retry batch")
 	}
 }
 
@@ -2558,18 +2491,55 @@ func TestHandleErrorRetryGroupsByLeader(t *testing.T) {
 	assertNotDone(t, outputB, 50*time.Millisecond)
 }
 
-func TestHandleSuccessRetryUsesPartitionProducer(t *testing.T) {
+func TestHandleSuccessRetryKeepsMute(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
 	config.Producer.Retry.Backoff = 0
 
-	parent := &asyncProducer{
-		conf:    config,
-		muter:   newPartitionMuter(),
-		retries: make(chan *ProducerMessage, 1),
-		txnmgr:  &transactionManager{},
+	retryLeader := &Broker{id: 2}
+	refreshStarted := make(chan struct{}, 1)
+	releaseRefresh := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseRetry := func() {
+		releaseOnce.Do(func() {
+			close(releaseRefresh)
+		})
 	}
+	defer releaseRetry()
+
+	parent := &asyncProducer{
+		conf:             config,
+		muter:            newPartitionMuter(),
+		brokers:          make(map[*Broker]*brokerProducer),
+		brokerRefs:       make(map[*brokerProducer]int),
+		retries:          make(chan *ProducerMessage, 1),
+		done:             make(chan struct{}),
+		txnmgr:           &transactionManager{},
+		retryBufferQuota: newRetryBufferQuota(config),
+	}
+	parent.client = &stubLeaderClient{
+		leader: retryLeader,
+		cfg:    config,
+		refreshMetadata: func(...string) error {
+			select {
+			case refreshStarted <- struct{}{}:
+			default:
+			}
+			<-releaseRefresh
+			return nil
+		},
+	}
+
+	output := make(chan *produceSet)
+	retryBP := &brokerProducer{
+		parent: parent,
+		broker: retryLeader,
+		output: output,
+		input:  make(chan *ProducerMessage),
+		done:   make(chan struct{}),
+	}
+	parent.brokers[retryLeader] = retryBP
 
 	bp := &brokerProducer{
 		parent:            parent,
@@ -2582,6 +2552,7 @@ func TestHandleSuccessRetryUsesPartitionProducer(t *testing.T) {
 	sent := newProduceSet(parent)
 	msg := &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")}
 	safeAddMessage(t, sent, msg)
+	retryPartitionSet := sent.msgs["topic"][0]
 	if !parent.muter.tryMute(sent) {
 		t.Fatal("expected sent batch to mute partitions")
 	}
@@ -2590,104 +2561,36 @@ func TestHandleSuccessRetryUsesPartitionProducer(t *testing.T) {
 	response.AddTopicPartition("topic", 0, ErrNotLeaderForPartition)
 	bp.handleSuccess(sent, response)
 
-	retried := assertDoneWithin(t, parent.retries, 2*time.Second)
-	require.Equal(t, msg, retried)
-	require.Equal(t, 1, retried.retries)
+	assertDoneWithin(t, refreshStarted, 2*time.Second)
+	assertNotDone(t, parent.retries, 50*time.Millisecond)
 
 	contender := newProduceSet(parent)
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
-	if !parent.muter.tryMute(contender) {
-		t.Fatal("expected response retry to release sent mute before partitionProducer retry")
-	}
-	parent.muter.unmute(contender)
-}
-
-func TestRetryBatchShutdownReleasesMute(t *testing.T) {
-	config := NewTestConfig()
-	config.Producer.Idempotent = false
-	config.Producer.Retry.Max = 1
-	config.Producer.Retry.Backoff = 0
-	config.Producer.Return.Errors = true
-	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength
-
-	parent := &asyncProducer{
-		conf:             config,
-		muter:            newPartitionMuter(),
-		brokers:          make(map[*Broker]*brokerProducer),
-		brokerRefs:       make(map[*brokerProducer]int),
-		errors:           make(chan *ProducerError, 1),
-		done:             make(chan struct{}),
-		txnmgr:           &transactionManager{},
-		retryBufferQuota: newRetryBufferQuota(config),
-	}
-	leader := &Broker{id: 1}
-	leaderLookup := make(chan struct{}, 1)
-	parent.client = &stubLeaderClient{
-		cfg: config,
-		leaderFunc: func(string, int32) (*Broker, error) {
-			select {
-			case leaderLookup <- struct{}{}:
-			default:
-			}
-			return leader, nil
-		},
-	}
-	retryBP := &brokerProducer{
-		parent: parent,
-		broker: leader,
-		output: make(chan *produceSet),
-		input:  make(chan *ProducerMessage),
-		done:   make(chan struct{}),
-	}
-	parent.brokers[leader] = retryBP
-
-	sent := newProduceSet(parent)
-	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
-	retryPartitionSet := sent.msgs["topic"][0]
-	if !parent.muter.tryMute(sent) {
-		t.Fatal("expected sent batch to mute partitions")
-	}
-	parent.inFlight.Add(1)
-
-	done := make(chan struct{})
-	go func() {
-		parent.retryBatch("topic", 0, retryPartitionSet, ErrOutOfBrokers, true)
-		close(done)
-	}()
-	assertDoneWithin(t, leaderLookup, 2*time.Second)
-
-	if parent.closed.CompareAndSwap(false, true) {
-		close(parent.done)
+	if parent.muter.tryMute(contender) {
+		parent.muter.unmute(contender)
+		t.Fatal("expected response retry to keep sent partition muted")
 	}
 
-	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
-	require.Equal(t, ErrShuttingDown, producerErr.Err)
-	assertDoneWithin(t, done, 2*time.Second)
-
-	contender := newProduceSet(parent)
-	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
-	if !parent.muter.tryMute(contender) {
-		t.Fatal("expected partition mute to be released after aborted retry handoff")
-	}
-	parent.muter.unmute(contender)
+	releaseRetry()
+	retrySet := assertDoneWithin(t, output, 2*time.Second)
+	defer parent.muter.unmute(retrySet)
+	require.Same(t, retryPartitionSet, retrySet.msgs["topic"][0])
+	require.Equal(t, 1, msg.retries)
 }
 
 func TestRetryUsesSharedBufferBudget(t *testing.T) {
 	tests := []struct {
-		name         string
-		afterRefresh bool
-		bytesLimit   bool
+		name       string
+		bytesLimit bool
 	}{
-		{name: "retryBatch length"},
-		{name: "retryBatch bytes", bytesLimit: true},
-		{name: "retryBatchesAfterRefresh length", afterRefresh: true},
-		{name: "retryBatchesAfterRefresh bytes", afterRefresh: true, bytesLimit: true},
+		{name: "length"},
+		{name: "bytes", bytesLimit: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := NewTestConfig()
-			config.Producer.Idempotent = !tt.afterRefresh
+			config.Producer.Idempotent = false
 			config.Producer.Retry.Max = 1
 			config.Producer.Retry.Backoff = 0
 			config.Producer.Return.Errors = true
@@ -2710,17 +2613,13 @@ func TestRetryUsesSharedBufferBudget(t *testing.T) {
 			}
 
 			parent, retryBP := newBlockingRetryProducer(config, errorBuffer)
-			firstRetryReserved, releaseFirstRetry := holdFirstRetryAfterReserve(parent, retryBP, tt.afterRefresh)
+			firstRetryReserved, releaseFirstRetry := holdFirstRetryAfterReserve(parent, retryBP)
 			defer releaseFirstRetry()
 
 			retry := func(partition int32, pSet *partitionSet) {
-				if tt.afterRefresh {
-					retrySet := newProduceSet(parent)
-					retrySet.addPartitionSet("topic", partition, pSet)
-					parent.retryBatchesAfterRefresh(retrySet, ErrOutOfBrokers)
-					return
-				}
-				parent.retryBatch("topic", partition, pSet, ErrNotEnoughReplicas, true)
+				retrySet := newProduceSet(parent)
+				retrySet.addPartitionSet("topic", partition, pSet)
+				parent.retryBatchesAfterRefresh(retrySet, ErrOutOfBrokers)
 			}
 
 			first := newProduceSet(parent)

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2041,43 +2041,6 @@ func TestBrokerProducerWaitForSpaceAllMuted(t *testing.T) {
 	require.NoError(t, assertDoneWithin(t, done, 2*time.Second))
 }
 
-// TestPartitionMuterCloseWakesWait verifies that closing the muter wakes
-// goroutines blocked in waitUntilMuted.
-func TestPartitionMuterCloseWakesWait(t *testing.T) {
-	config := NewTestConfig()
-	parent := &asyncProducer{
-		conf:   config,
-		muter:  newPartitionMuter(),
-		txnmgr: &transactionManager{},
-	}
-
-	blockedSet := newProduceSet(parent)
-	safeAddMessage(t, blockedSet, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("held")})
-	if !parent.muter.tryMute(blockedSet) {
-		t.Fatal("expected to mute partition")
-	}
-
-	waitSet := newProduceSet(parent)
-	safeAddMessage(t, waitSet, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("waiting")})
-
-	done := make(chan bool, 1)
-	go func() {
-		done <- parent.muter.waitUntilMuted(waitSet)
-	}()
-
-	assertNotDone(t, done, 50*time.Millisecond)
-	parent.muter.close()
-
-	select {
-	case result := <-done:
-		if result {
-			t.Fatal("expected waitUntilMuted to return false after close")
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out")
-	}
-}
-
 // TestBrokerProducerRollOverClearsTimer ensures timer events from a previous batch
 // do not cause a flush of a fresh empty batch after rollOver.
 func TestBrokerProducerRollOverClearsTimer(t *testing.T) {

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1810,6 +1810,51 @@ func assertDoneWithin[T any](t *testing.T, ch <-chan T, timeout time.Duration) T
 	}
 }
 
+func waitForProducerBuffer(t *testing.T, parent *asyncProducer, messages, bytes int64) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		parent.retryBuffer.mu.Lock()
+		gotMessages := parent.retryBuffer.messages
+		gotBytes := parent.retryBuffer.bytes
+		parent.retryBuffer.mu.Unlock()
+		if (messages < 0 || gotMessages == messages) && (bytes < 0 || gotBytes == bytes) {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for buffer budget messages=%d bytes=%d, got messages=%d bytes=%d",
+				messages, bytes, gotMessages, gotBytes)
+		case <-ticker.C:
+		}
+	}
+}
+
+func newBlockingRetryProducer(config *Config, errorBuffer int) (*asyncProducer, *brokerProducer) {
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		errors:     make(chan *ProducerError, errorBuffer),
+		shutdownCh: make(chan struct{}),
+		txnmgr:     &transactionManager{},
+	}
+	leader := &Broker{id: 1}
+	parent.client = &stubLeaderClient{leader: leader, cfg: config}
+	retryBP := &brokerProducer{
+		parent: parent,
+		broker: leader,
+		output: make(chan *produceSet),
+		input:  make(chan *ProducerMessage),
+		done:   make(chan struct{}),
+	}
+	parent.brokers[leader] = retryBP
+	return parent, retryBP
+}
+
 // TestBrokerProducerWaitForSpaceRespectsExternalUnmute ensures waitForSpace does not
 // deadlock when partitions are muted by another producer and are unmuted elsewhere.
 func TestBrokerProducerWaitForSpaceRespectsExternalUnmute(t *testing.T) {
@@ -2080,6 +2125,7 @@ func TestBrokerProducerRollOverClearsTimer(t *testing.T) {
 func TestRetryBatchRespectsPartitionMuter(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = true
+	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength
 	txnMgr := &transactionManager{
 		producerID:      0,
 		producerEpoch:   0,
@@ -2122,6 +2168,7 @@ func TestRetryBatchRespectsPartitionMuter(t *testing.T) {
 	default:
 		t.Fatal("expected retry batch to be dispatched")
 	}
+	waitForProducerBuffer(t, parent, 0, 0)
 
 	contender := newProduceSet(parent)
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
@@ -2196,6 +2243,7 @@ func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T
 	config.Producer.Idempotent = false
 	config.Producer.Retry.Max = 1
 	config.Producer.Retry.Backoff = 0
+	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength
 
 	parent := &asyncProducer{
 		conf:       config,
@@ -2244,6 +2292,7 @@ func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T
 	}()
 	assertDoneWithin(t, done, 2*time.Second)
 	assertDoneWithin(t, client.started, 2*time.Second)
+	waitForProducerBuffer(t, parent, 1, -1)
 
 	contender := newProduceSet(parent)
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
@@ -2256,6 +2305,7 @@ func TestHandleErrorNonIdempotentRetryDoesNotWaitForMetadataRefresh(t *testing.T
 	retrySet := assertDoneWithin(t, output, 2*time.Second)
 	defer parent.muter.unmute(retrySet)
 	require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
+	waitForProducerBuffer(t, parent, 0, 0)
 }
 
 func TestHandleErrorNonIdempotentRetryRefreshesMetadataOncePerFailedRequest(t *testing.T) {
@@ -2309,21 +2359,110 @@ func TestHandleErrorNonIdempotentRetryRefreshesMetadataOncePerFailedRequest(t *t
 	bp.handleError(sent, ErrOutOfBrokers)
 
 	require.Equal(t, []string{"topic"}, assertDoneWithin(t, client.calls, 2*time.Second))
-	retrySet0 := assertDoneWithin(t, output, 2*time.Second)
-	defer parent.muter.unmute(retrySet0)
-	retrySet1 := assertDoneWithin(t, output, 2*time.Second)
-	defer parent.muter.unmute(retrySet1)
+	retrySet := assertDoneWithin(t, output, 2*time.Second)
+	defer parent.muter.unmute(retrySet)
 	assertNotDone(t, client.calls, 50*time.Millisecond)
+	assertNotDone(t, output, 50*time.Millisecond)
 
 	retriedPartitions := make(map[int32]*partitionSet)
-	retrySet0.eachPartition(func(_ string, partition int32, pSet *partitionSet) {
-		retriedPartitions[partition] = pSet
-	})
-	retrySet1.eachPartition(func(_ string, partition int32, pSet *partitionSet) {
+	retrySet.eachPartition(func(_ string, partition int32, pSet *partitionSet) {
 		retriedPartitions[partition] = pSet
 	})
 	require.Same(t, retryPartitionSet0, retriedPartitions[int32(0)])
 	require.Same(t, retryPartitionSet1, retriedPartitions[int32(1)])
+}
+
+func TestHandleErrorNonIdempotentRetryGroupsBatchesByLeader(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		txnmgr:     &transactionManager{},
+	}
+	failedBroker := &Broker{id: 1}
+	leaderA := &Broker{id: 2}
+	leaderB := &Broker{id: 3}
+	client := &routingLeaderClient{
+		stubLeaderClient: stubLeaderClient{cfg: config},
+		leaders: map[string]map[int32]*Broker{
+			"topic-a": {
+				0: leaderA,
+				1: leaderA,
+			},
+			"topic-b": {
+				0: leaderB,
+				1: leaderB,
+			},
+		},
+		calls: make(chan []string, 1),
+	}
+	parent.client = client
+
+	outputA := make(chan *produceSet, 1)
+	outputB := make(chan *produceSet, 1)
+	retryBPA := &brokerProducer{
+		parent: parent,
+		broker: leaderA,
+		output: outputA,
+		input:  make(chan *ProducerMessage),
+	}
+	retryBPB := &brokerProducer{
+		parent: parent,
+		broker: leaderB,
+		output: outputB,
+		input:  make(chan *ProducerMessage),
+	}
+	parent.brokers[leaderA] = retryBPA
+	parent.brokers[leaderB] = retryBPB
+
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            failedBroker,
+		input:             make(chan *ProducerMessage),
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic-a", Partition: 0, Value: StringEncoder("a-0")})
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic-a", Partition: 1, Value: StringEncoder("a-1")})
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic-b", Partition: 0, Value: StringEncoder("b-0")})
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic-b", Partition: 1, Value: StringEncoder("b-1")})
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+
+	bp.handleError(sent, ErrOutOfBrokers)
+
+	require.ElementsMatch(t, []string{"topic-a", "topic-b"}, assertDoneWithin(t, client.calls, 2*time.Second))
+	retrySetA := assertDoneWithin(t, outputA, 2*time.Second)
+	defer parent.muter.unmute(retrySetA)
+	retrySetB := assertDoneWithin(t, outputB, 2*time.Second)
+	defer parent.muter.unmute(retrySetB)
+
+	require.Len(t, retrySetA.msgs, 1)
+	require.Len(t, retrySetA.msgs["topic-a"], 2)
+	require.Len(t, retrySetB.msgs, 1)
+	require.Len(t, retrySetB.msgs["topic-b"], 2)
+	for _, partitions := range retrySetA.msgs {
+		for _, pSet := range partitions {
+			require.Equal(t, 1, pSet.msgs[0].retries)
+		}
+	}
+	for _, partitions := range retrySetB.msgs {
+		for _, pSet := range partitions {
+			require.Equal(t, 1, pSet.msgs[0].retries)
+		}
+	}
+
+	assertNotDone(t, outputA, 50*time.Millisecond)
+	assertNotDone(t, outputB, 50*time.Millisecond)
 }
 
 func TestHandleSuccessNonIdempotentRetryUsesPartitionProducer(t *testing.T) {
@@ -2376,6 +2515,7 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 	config.Producer.Retry.Max = 1
 	config.Producer.Retry.Backoff = 0
 	config.Producer.Return.Errors = true
+	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength
 
 	parent := &asyncProducer{
 		conf:       config,
@@ -2404,19 +2544,22 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 		t.Fatal("expected sent batch to mute partitions")
 	}
 	parent.inFlight.Add(1)
-	if parent.shutdownChClosed.CompareAndSwap(false, true) {
-		close(parent.shutdownCh)
-	}
 
 	done := make(chan struct{})
 	go func() {
 		parent.retryBatch("topic", 0, retryPartitionSet, ErrOutOfBrokers, true)
 		close(done)
 	}()
+	waitForProducerBuffer(t, parent, 1, -1)
+
+	if parent.shutdownChClosed.CompareAndSwap(false, true) {
+		close(parent.shutdownCh)
+	}
 
 	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
 	require.Equal(t, ErrShuttingDown, producerErr.Err)
 	assertDoneWithin(t, done, 2*time.Second)
+	waitForProducerBuffer(t, parent, 0, 0)
 
 	contender := newProduceSet(parent)
 	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
@@ -2424,6 +2567,296 @@ func TestRetryBatchReleasesMuteWhenHandoffAbortedByShutdown(t *testing.T) {
 		t.Fatal("expected partition mute to be released after aborted retry handoff")
 	}
 	parent.muter.unmute(contender)
+}
+
+func TestRetryBatchUsesSharedBufferLengthBudget(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = true
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+	config.Producer.Return.Errors = true
+	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength + 1
+
+	parent, retryBP := newBlockingRetryProducer(config, minFunctionalRetryBufferLength+1)
+
+	first := newProduceSet(parent)
+	for i := 0; i < minFunctionalRetryBufferLength; i++ {
+		safeAddMessage(t, first, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+	}
+	firstPartitionSet := first.msgs["topic"][0]
+	if !parent.muter.tryMute(first) {
+		t.Fatal("expected first retry batch to mute partitions")
+	}
+	parent.inFlight.Add(minFunctionalRetryBufferLength)
+
+	firstDone := make(chan struct{})
+	go func() {
+		parent.retryBatch("topic", 0, firstPartitionSet, ErrNotEnoughReplicas, true)
+		close(firstDone)
+	}()
+	waitForProducerBuffer(t, parent, minFunctionalRetryBufferLength, -1)
+
+	second := newProduceSet(parent)
+	safeAddMessage(t, second, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")})
+	secondPartitionSet := second.msgs["topic"][1]
+	if !parent.muter.tryMute(second) {
+		t.Fatal("expected second retry batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+	parent.retryBatch("topic", 1, secondPartitionSet, ErrNotEnoughReplicas, true)
+
+	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
+	require.Equal(t, int32(1), producerErr.Msg.Partition)
+	waitForProducerBuffer(t, parent, minFunctionalRetryBufferLength, -1)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected overflowed retry batch to release partition mute")
+	}
+	parent.muter.unmute(contender)
+
+	close(retryBP.done)
+	assertDoneWithin(t, firstDone, 2*time.Second)
+	waitForProducerBuffer(t, parent, 0, 0)
+}
+
+func TestRetryBatchUsesSharedBufferBytesBudget(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = true
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+	config.Producer.Return.Errors = true
+
+	parent, retryBP := newBlockingRetryProducer(config, 2)
+
+	firstMsg := &ProducerMessage{Topic: "topic", Partition: 0, Value: ByteEncoder(make([]byte, minFunctionalRetryBufferBytes))}
+	secondMsg := &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")}
+	version := parent.producerMessageByteSizeVersion()
+	firstBytes := int64(firstMsg.ByteSize(version))
+	secondBytes := int64(secondMsg.ByteSize(version))
+	config.Producer.Retry.MaxBufferBytes = firstBytes + secondBytes
+
+	first := newProduceSet(parent)
+	safeAddMessage(t, first, firstMsg)
+	firstPartitionSet := first.msgs["topic"][0]
+	if !parent.muter.tryMute(first) {
+		t.Fatal("expected first retry batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+
+	firstDone := make(chan struct{})
+	go func() {
+		parent.retryBatch("topic", 0, firstPartitionSet, ErrNotEnoughReplicas, true)
+		close(firstDone)
+	}()
+	waitForProducerBuffer(t, parent, -1, firstBytes)
+
+	second := newProduceSet(parent)
+	safeAddMessage(t, second, secondMsg)
+	secondPartitionSet := second.msgs["topic"][1]
+	if !parent.muter.tryMute(second) {
+		t.Fatal("expected second retry batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+	parent.retryBatch("topic", 1, secondPartitionSet, ErrNotEnoughReplicas, true)
+
+	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
+	require.Equal(t, int32(1), producerErr.Msg.Partition)
+	waitForProducerBuffer(t, parent, -1, firstBytes)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected overflowed retry batch to release partition mute")
+	}
+	parent.muter.unmute(contender)
+
+	close(retryBP.done)
+	assertDoneWithin(t, firstDone, 2*time.Second)
+	waitForProducerBuffer(t, parent, 0, 0)
+}
+
+func TestRetryBatchesAfterRefreshReleasesMuteWhenBrokerProducerDone(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+	config.Producer.Return.Errors = true
+
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		errors:     make(chan *ProducerError, 1),
+		shutdownCh: make(chan struct{}),
+		txnmgr:     &transactionManager{},
+	}
+	leader := &Broker{id: 1}
+	parent.client = &stubLeaderClient{leader: leader, cfg: config}
+	retryBP := &brokerProducer{
+		parent: parent,
+		broker: leader,
+		output: make(chan *produceSet),
+		input:  make(chan *ProducerMessage),
+		done:   make(chan struct{}),
+	}
+	parent.brokers[leader] = retryBP
+
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+	retryPartitionSet := sent.msgs["topic"][0]
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+
+	done := make(chan struct{})
+	go func() {
+		parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
+			topic:     "topic",
+			partition: 0,
+			pSet:      retryPartitionSet,
+		}}, ErrOutOfBrokers)
+		close(done)
+	}()
+
+	close(retryBP.done)
+	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, ErrShuttingDown, producerErr.Err)
+	assertDoneWithin(t, done, 2*time.Second)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected partition mute to be released after brokerProducer done")
+	}
+	parent.muter.unmute(contender)
+}
+
+func TestRetryBatchesAfterRefreshUsesSharedBufferLengthBudget(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+	config.Producer.Return.Errors = true
+	config.Producer.Retry.MaxBufferLength = minFunctionalRetryBufferLength + 1
+
+	parent, retryBP := newBlockingRetryProducer(config, minFunctionalRetryBufferLength+1)
+
+	first := newProduceSet(parent)
+	for i := 0; i < minFunctionalRetryBufferLength; i++ {
+		safeAddMessage(t, first, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+	}
+	if !parent.muter.tryMute(first) {
+		t.Fatal("expected first retry batch to mute partitions")
+	}
+	parent.inFlight.Add(minFunctionalRetryBufferLength)
+
+	firstDone := make(chan struct{})
+	go func() {
+		parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
+			topic:     "topic",
+			partition: 0,
+			pSet:      first.msgs["topic"][0],
+		}}, ErrOutOfBrokers)
+		close(firstDone)
+	}()
+	waitForProducerBuffer(t, parent, minFunctionalRetryBufferLength, -1)
+
+	second := newProduceSet(parent)
+	safeAddMessage(t, second, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")})
+	if !parent.muter.tryMute(second) {
+		t.Fatal("expected second retry batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+	parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
+		topic:     "topic",
+		partition: 1,
+		pSet:      second.msgs["topic"][1],
+	}}, ErrOutOfBrokers)
+
+	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
+	require.Equal(t, int32(1), producerErr.Msg.Partition)
+	waitForProducerBuffer(t, parent, minFunctionalRetryBufferLength, -1)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected overflowed retry batch to release partition mute")
+	}
+	parent.muter.unmute(contender)
+
+	close(retryBP.done)
+	assertDoneWithin(t, firstDone, 2*time.Second)
+	waitForProducerBuffer(t, parent, 0, 0)
+}
+
+func TestRetryBatchesAfterRefreshUsesSharedBufferBytesBudget(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+	config.Producer.Return.Errors = true
+
+	parent, retryBP := newBlockingRetryProducer(config, 2)
+
+	firstMsg := &ProducerMessage{Topic: "topic", Partition: 0, Value: ByteEncoder(make([]byte, minFunctionalRetryBufferBytes))}
+	secondMsg := &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("overflow")}
+	version := parent.producerMessageByteSizeVersion()
+	firstBytes := int64(firstMsg.ByteSize(version))
+	secondBytes := int64(secondMsg.ByteSize(version))
+	config.Producer.Retry.MaxBufferBytes = firstBytes + secondBytes
+
+	first := newProduceSet(parent)
+	safeAddMessage(t, first, firstMsg)
+	if !parent.muter.tryMute(first) {
+		t.Fatal("expected first retry batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+
+	firstDone := make(chan struct{})
+	go func() {
+		parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
+			topic:     "topic",
+			partition: 0,
+			pSet:      first.msgs["topic"][0],
+		}}, ErrOutOfBrokers)
+		close(firstDone)
+	}()
+	waitForProducerBuffer(t, parent, -1, firstBytes)
+
+	second := newProduceSet(parent)
+	safeAddMessage(t, second, secondMsg)
+	if !parent.muter.tryMute(second) {
+		t.Fatal("expected second retry batch to mute partitions")
+	}
+	parent.inFlight.Add(1)
+	parent.retryBatchesAfterRefresh([]string{"topic"}, []partitionBatchRetry{{
+		topic:     "topic",
+		partition: 1,
+		pSet:      second.msgs["topic"][1],
+	}}, ErrOutOfBrokers)
+
+	producerErr := assertDoneWithin(t, parent.errors, 2*time.Second)
+	require.Equal(t, ErrProducerRetryBufferOverflow, producerErr.Err)
+	require.Equal(t, int32(1), producerErr.Msg.Partition)
+	waitForProducerBuffer(t, parent, -1, firstBytes)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected overflowed retry batch to release partition mute")
+	}
+	parent.muter.unmute(contender)
+
+	close(retryBP.done)
+	assertDoneWithin(t, firstDone, 2*time.Second)
+	waitForProducerBuffer(t, parent, 0, 0)
 }
 
 func TestHandleErrorNonIdempotentRetryReleasesMuteOnLeaderError(t *testing.T) {
@@ -2543,6 +2976,31 @@ type countingRefreshClient struct {
 }
 
 func (c *countingRefreshClient) RefreshMetadata(topics ...string) error {
+	c.calls <- append([]string(nil), topics...)
+	return nil
+}
+
+type routingLeaderClient struct {
+	stubLeaderClient
+	leaders map[string]map[int32]*Broker
+	calls   chan []string
+}
+
+func (c *routingLeaderClient) Leader(topic string, partition int32) (*Broker, error) {
+	if partitions := c.leaders[topic]; partitions != nil {
+		if leader := partitions[partition]; leader != nil {
+			return leader, nil
+		}
+	}
+	return nil, ErrLeaderNotAvailable
+}
+
+func (c *routingLeaderClient) LeaderAndEpoch(topic string, partition int32) (*Broker, int32, error) {
+	leader, err := c.Leader(topic, partition)
+	return leader, 0, err
+}
+
+func (c *routingLeaderClient) RefreshMetadata(topics ...string) error {
 	c.calls <- append([]string(nil), topics...)
 	return nil
 }

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2191,6 +2191,50 @@ func TestHandleErrorNonIdempotentRetryKeepsPartitionMuted(t *testing.T) {
 	}
 }
 
+func TestHandleSuccessNonIdempotentRetryUsesPartitionProducer(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+
+	parent := &asyncProducer{
+		conf:    config,
+		muter:   newPartitionMuter(),
+		retries: make(chan *ProducerMessage, 1),
+		txnmgr:  &transactionManager{},
+	}
+
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            &Broker{id: 1},
+		input:             make(chan *ProducerMessage),
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+
+	sent := newProduceSet(parent)
+	msg := &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")}
+	safeAddMessage(t, sent, msg)
+	if !parent.muter.tryMute(sent) {
+		t.Fatal("expected sent batch to mute partitions")
+	}
+
+	response := new(ProduceResponse)
+	response.AddTopicPartition("topic", 0, ErrNotLeaderForPartition)
+	bp.handleSuccess(sent, response)
+
+	retried := assertDoneWithin(t, parent.retries, 2*time.Second)
+	require.Equal(t, msg, retried)
+	require.Equal(t, 1, retried.retries)
+
+	contender := newProduceSet(parent)
+	safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+	if !parent.muter.tryMute(contender) {
+		t.Fatal("expected response retry to release sent mute before partitionProducer retry")
+	}
+	parent.muter.unmute(contender)
+}
+
 func TestHandleErrorNonIdempotentRetryReleasesMuteOnLeaderError(t *testing.T) {
 	config := NewTestConfig()
 	config.Producer.Idempotent = false

--- a/config.go
+++ b/config.go
@@ -281,16 +281,20 @@ type Config struct {
 			// more sophisticated backoff strategies. This takes precedence over
 			// `Backoff` if set.
 			BackoffFunc func(retries, maxRetries int) time.Duration
-			// The maximum length of the bridging buffer between `input` and `retries` channels
-			// in AsyncProducer#retryHandler.
-			// The limit is to prevent this buffer from overflowing or causing OOM.
+			// The maximum number of messages in producer retry buffering, including
+			// the bridging buffer between `input` and `retries` channels in
+			// AsyncProducer#retryHandler and direct retries waiting for metadata
+			// refresh, retry backoff, leader lookup, partition mute, or broker handoff.
+			// The limit is to prevent retry buffering from overflowing or causing OOM.
 			// Defaults to 0 for unlimited.
 			// Any value between 0 and 4096 is pushed to 4096.
 			// A zero or negative value indicates unlimited.
 			MaxBufferLength int
-			// The maximum total byte size of messages in the bridging buffer between `input`
-			// and `retries` channels in AsyncProducer#retryHandler.
-			// This limit prevents the buffer from consuming excessive memory.
+			// The maximum total byte size of messages in producer retry buffering,
+			// including the bridging buffer between `input` and `retries` channels
+			// in AsyncProducer#retryHandler and direct retries waiting for metadata
+			// refresh, retry backoff, leader lookup, partition mute, or broker handoff.
+			// This limit prevents retry buffering from consuming excessive memory.
 			// Defaults to 0 for unlimited.
 			// Any value between 0 and 32 MB is pushed to 32 MB.
 			// A zero or negative value indicates unlimited.

--- a/produce_set.go
+++ b/produce_set.go
@@ -12,31 +12,6 @@ type partitionSet struct {
 	bufferBytes   int
 }
 
-// markPartitionMuteReusable lets the first message carry the retry batch's
-// right to reuse the partition mute that is still held by its failed send.
-// Only the first message is marked because one held mute represents one
-// in-flight retry permission; marking every message could let split retry
-// fragments bypass each other under the same reservation.
-func (ps *partitionSet) markPartitionMuteReusable() {
-	if len(ps.msgs) > 0 {
-		ps.msgs[0].reusePartitionMute = true
-	}
-}
-
-// canReusePartitionMute reports whether this retry batch may be flushed while
-// its partition is already muted by the previous send attempt.
-func (ps *partitionSet) canReusePartitionMute() bool {
-	return len(ps.msgs) > 0 && ps.msgs[0].reusePartitionMute
-}
-
-// clearPartitionMuteReuse consumes the one-shot reuse marker once the retry
-// batch is selected for flushing.
-func (ps *partitionSet) clearPartitionMuteReuse() {
-	for _, msg := range ps.msgs {
-		msg.reusePartitionMute = false
-	}
-}
-
 // canRetry prevents holding a partition mute when every message in the set will
 // be returned as an error instead of being retried.
 func (ps *partitionSet) canRetry(maxRetries int) bool {

--- a/produce_set.go
+++ b/produce_set.go
@@ -12,7 +12,7 @@ type partitionSet struct {
 	bufferBytes   int
 }
 
-// shouldKeepMuted matches retryBatch's whole-batch retry rule: if any message has
+// shouldKeepMuted matches the whole-batch retry rule: if any message has
 // exhausted retries, the batch will be failed instead of retried.
 func (ps *partitionSet) shouldKeepMuted(maxRetries int) bool {
 	if len(ps.msgs) == 0 {

--- a/produce_set.go
+++ b/produce_set.go
@@ -12,15 +12,18 @@ type partitionSet struct {
 	bufferBytes   int
 }
 
-// canRetry prevents holding a partition mute when every message in the set will
-// be returned as an error instead of being retried.
-func (ps *partitionSet) canRetry(maxRetries int) bool {
+// shouldKeepMuted matches retryBatch's whole-batch retry rule: if any message has
+// exhausted retries, the batch will be failed instead of retried.
+func (ps *partitionSet) shouldKeepMuted(maxRetries int) bool {
+	if len(ps.msgs) == 0 {
+		return false
+	}
 	for _, msg := range ps.msgs {
-		if msg.retries < maxRetries {
-			return true
+		if msg.retries >= maxRetries {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
 type produceSet struct {

--- a/produce_set.go
+++ b/produce_set.go
@@ -12,6 +12,42 @@ type partitionSet struct {
 	bufferBytes   int
 }
 
+// markPartitionMuteReusable lets the first message carry the retry batch's
+// right to reuse the partition mute that is still held by its failed send.
+// Only the first message is marked because one held mute represents one
+// in-flight retry permission; marking every message could let split retry
+// fragments bypass each other under the same reservation.
+func (ps *partitionSet) markPartitionMuteReusable() {
+	if len(ps.msgs) > 0 {
+		ps.msgs[0].reusePartitionMute = true
+	}
+}
+
+// canReusePartitionMute reports whether this retry batch may be flushed while
+// its partition is already muted by the previous send attempt.
+func (ps *partitionSet) canReusePartitionMute() bool {
+	return len(ps.msgs) > 0 && ps.msgs[0].reusePartitionMute
+}
+
+// clearPartitionMuteReuse consumes the one-shot reuse marker once the retry
+// batch is selected for flushing.
+func (ps *partitionSet) clearPartitionMuteReuse() {
+	for _, msg := range ps.msgs {
+		msg.reusePartitionMute = false
+	}
+}
+
+// canRetry prevents holding a partition mute when every message in the set will
+// be returned as an error instead of being retried.
+func (ps *partitionSet) canRetry(maxRetries int) bool {
+	for _, msg := range ps.msgs {
+		if msg.retries < maxRetries {
+			return true
+		}
+	}
+	return false
+}
+
 type produceSet struct {
 	parent        *asyncProducer
 	msgs          map[string]map[int32]*partitionSet

--- a/produce_set.go
+++ b/produce_set.go
@@ -50,6 +50,15 @@ func newProduceSetWithMeta(parent *asyncProducer, producerID int64, producerEpoc
 	}
 }
 
+func (ps *produceSet) addPartitionSet(topic string, partition int32, set *partitionSet) {
+	if ps.msgs[topic] == nil {
+		ps.msgs[topic] = make(map[int32]*partitionSet)
+	}
+	ps.msgs[topic][partition] = set
+	ps.bufferBytes += set.bufferBytes
+	ps.bufferCount += len(set.msgs)
+}
+
 func (ps *produceSet) add(msg *ProducerMessage) error {
 	var err error
 	var key, val []byte

--- a/produce_set_test.go
+++ b/produce_set_test.go
@@ -25,6 +25,24 @@ func safeAddMessage(t *testing.T, ps *produceSet, msg *ProducerMessage) {
 	}
 }
 
+func TestShouldKeepMuted(t *testing.T) {
+	if (&partitionSet{}).shouldKeepMuted(1) {
+		t.Fatal("empty partition set should not be retryable")
+	}
+	if !(&partitionSet{msgs: []*ProducerMessage{
+		{retries: 0},
+		{retries: 0},
+	}}).shouldKeepMuted(1) {
+		t.Fatal("expected batch to be retryable when every message is below retry max")
+	}
+	if (&partitionSet{msgs: []*ProducerMessage{
+		{retries: 0},
+		{retries: 1},
+	}}).shouldKeepMuted(1) {
+		t.Fatal("expected batch not to be retryable when any message has exhausted retries")
+	}
+}
+
 func TestProduceSetInitial(t *testing.T) {
 	_, ps := makeProduceSet()
 

--- a/produce_set_test.go
+++ b/produce_set_test.go
@@ -26,20 +26,29 @@ func safeAddMessage(t *testing.T, ps *produceSet, msg *ProducerMessage) {
 }
 
 func TestShouldKeepMuted(t *testing.T) {
-	if (&partitionSet{}).shouldKeepMuted(1) {
-		t.Fatal("empty partition set should not be retryable")
+	pSet := &partitionSet{}
+	if pSet.shouldKeepMuted(1) {
+		t.Error("empty partition set should not be retryable")
 	}
-	if !(&partitionSet{msgs: []*ProducerMessage{
-		{retries: 0},
-		{retries: 0},
-	}}).shouldKeepMuted(1) {
-		t.Fatal("expected batch to be retryable when every message is below retry max")
+
+	pSet = &partitionSet{
+		msgs: []*ProducerMessage{
+			{retries: 0},
+			{retries: 0},
+		},
 	}
-	if (&partitionSet{msgs: []*ProducerMessage{
-		{retries: 0},
-		{retries: 1},
-	}}).shouldKeepMuted(1) {
-		t.Fatal("expected batch not to be retryable when any message has exhausted retries")
+	if !pSet.shouldKeepMuted(1) {
+		t.Error("expected batch to be retryable when every message is below retry max")
+	}
+
+	pSet = &partitionSet{
+		msgs: []*ProducerMessage{
+			{retries: 0},
+			{retries: 1},
+		},
+	}
+	if pSet.shouldKeepMuted(1) {
+		t.Error("expected batch not to be retryable when any message has exhausted retries")
 	}
 }
 


### PR DESCRIPTION
## Problem

Ref #2860, #2619, #3422, #1203.

On `main`, the producer muter prevents concurrent in-flight requests for the same topic/partition. That keeps later batches from passing an earlier batch while the earlier batch is still owned by a broker request.

The remaining gap is the broker-level error path in `brokerProducer.handleError`. When a produce request fails without a per-partition `ProduceResponse` (for example EOF, broken pipe, or a read timeout), non-idempotent producers currently move the sent messages to the retry queue and release the sent partition mute. A later same-partition batch can then become flushable before the failed batch is handed back to a broker.

A possible ordering on `main` is:

1. batch A is sent and the broker connection fails
2. batch A is moved to the retry queue
3. the partition mute is released
4. batch B for the same partition flushes first
5. batch A is retried later

That breaks producer-side ordering for the same topic/partition. Enabling idempotence is not always available to users because some Kafka deployments require additional permissions such as `IdempotentWrite`.

## Change

This PR changes the broker-level error path for sent batches:

- `handleError` keeps sent topic/partition batches muted while they still have retry attempts left.
- Retryable sent partition batches are passed to one retry worker for the failed produce request.
- The retry worker refreshes metadata once, resolves refreshed leaders, groups retry batches by target broker, and hands one grouped `produceSet` to each broker.
- Unsent `accumulatingBatch` messages stay on the existing `retryMessages` path.
- Sent batches that cannot retry are unmuted and failed.

This keeps the failed sent batch ahead of later same-partition work without blocking the `brokerProducer` response loop.

## Retry Semantics

The direct retry worker uses the same batch boundary as `retryBatch`: if any message in a same-partition batch has exhausted retries, the whole partition batch fails. That avoids splitting one broker request's partition batch into partly failed and partly retried messages, which would weaken the ordering boundary this PR is preserving.

The worker also uses the producer retry backoff path and exits on producer shutdown. If shutdown or broker handoff prevents ownership transfer, it releases the partition mute and returns errors for the affected messages.

## What Is Not Changed

This PR does not change the non-idempotent `ProduceResponse` retry path in `handleSuccess`.

That path still uses `retryMessages` and goes back through `partitionProducer`, where the retry high watermark and per-partition dispatch state are maintained. The new direct retry worker is only for broker-level failures where there is no per-partition `ProduceResponse` to feed back through `partitionProducer`.

## Retry Buffer Accounting

`Producer.Retry.MaxBufferLength` and `Producer.Retry.MaxBufferBytes` now apply to producer retry buffering as a whole:

- the existing bridge between `input` and `retries` in `retryHandler`
- direct retry batches waiting for metadata refresh, backoff, leader lookup, partition mute, or broker handoff

Both limits remain disabled by default. Small positive limits still use the existing minimum functional thresholds.

## Tests

Added or updated coverage for:

- keeping non-idempotent broker-error retries muted
- failing a whole same-partition batch when any message has exhausted retries
- keeping metadata refresh out of the broker response loop
- refreshing metadata once per failed produce request
- grouping direct retry batches by refreshed leader
- keeping non-idempotent `ProduceResponse` retries on the `partitionProducer` path
- releasing mutes on leader lookup failure, shutdown, or broker handoff failure
- applying shared retry buffer length and byte budgets to direct retries and `retryHandler`
- waking `brokerProducer.run` after an external unmute

Local verification:

```sh
git diff --check
go test -run 'Test(HandleErrorNonIdempotentRetry|RetryBatchesAfterRefresh|RetryBatch|ProducerRetryBufferLimits|BrokerProducerRunFlushesAfterExternalUnmute|AsyncProducerRetryOrdering|AsyncProducerPartitionUnmuting)' .
go test ./...
```
