### PR TITLE
fix: map new metadata request v8 to kafka 2.3.0

### DIFF
--- a/metadata_request.go
+++ b/metadata_request.go
@@ -31,7 +31,7 @@ func NewMetadataRequest(version KafkaVersion, topics []string) *MetadataRequest 
 		m.Version = 11
 	} else if version.IsAtLeast(V2_4_0_0) {
 		m.Version = 9
-	} else if version.IsAtLeast(V2_4_0_0) {
+	} else if version.IsAtLeast(V2_3_0_0) {
 		m.Version = 8
 	} else if version.IsAtLeast(V2_1_0_0) {
 		m.Version = 7

--- a/metadata_request_test.go
+++ b/metadata_request_test.go
@@ -314,3 +314,29 @@ func TestMetadataRequestV11(t *testing.T) {
 	request.IncludeTopicAuthorizedOperations = true
 	testRequest(t, "two topics, auto create, topic auth", request, metadataRequestAutoCreateTopicAuthV11)
 }
+
+func TestNewMetadataRequestVersionMapping(t *testing.T) {
+	// NewMetadataRequest must select the highest metadata request version
+	// supported by the configured Kafka version. A duplicate V2_4_0_0 check
+	// previously shadowed the V8 branch, so Kafka 2.3.0 fell through to V7.
+	tests := []struct {
+		version KafkaVersion
+		want    int16
+	}{
+		{V2_8_0_0, 11},
+		{V2_4_0_0, 9},
+		{V2_3_0_0, 8},
+		{V2_1_0_0, 7},
+		{V2_0_0_0, 6},
+		{V1_0_0_0, 5},
+		{V0_11_0_0, 4},
+		{V0_10_1_0, 2},
+		{V0_10_0_0, 1},
+	}
+	for _, tt := range tests {
+		got := NewMetadataRequest(tt.version, nil).Version
+		if got != tt.want {
+			t.Errorf("NewMetadataRequest(%s).Version = %d, want %d", tt.version, got, tt.want)
+		}
+	}
+}

--- a/metadata_request_test.go
+++ b/metadata_request_test.go
@@ -2,7 +2,11 @@
 
 package sarama
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 var (
 	// The v0 metadata request has a non-nullable array of topic names
@@ -315,28 +319,19 @@ func TestMetadataRequestV11(t *testing.T) {
 	testRequest(t, "two topics, auto create, topic auth", request, metadataRequestAutoCreateTopicAuthV11)
 }
 
-func TestNewMetadataRequestVersionMapping(t *testing.T) {
-	// NewMetadataRequest must select the highest metadata request version
-	// supported by the configured Kafka version. A duplicate V2_4_0_0 check
-	// previously shadowed the V8 branch, so Kafka 2.3.0 fell through to V7.
-	tests := []struct {
-		version KafkaVersion
-		want    int16
-	}{
-		{V2_8_0_0, 11},
-		{V2_4_0_0, 9},
-		{V2_3_0_0, 8},
-		{V2_1_0_0, 7},
-		{V2_0_0_0, 6},
-		{V1_0_0_0, 5},
-		{V0_11_0_0, 4},
-		{V0_10_1_0, 2},
-		{V0_10_0_0, 1},
-	}
-	for _, tt := range tests {
-		got := NewMetadataRequest(tt.version, nil).Version
-		if got != tt.want {
-			t.Errorf("NewMetadataRequest(%s).Version = %d, want %d", tt.version, got, tt.want)
+func TestNewMetadataRequest(t *testing.T) {
+	// NewMetadataRequest and requiredVersion map between KafkaVersion and protocol
+	// version in opposite directions and must stay consistent: configuring the
+	// client at a protocol version's requiredVersion must select at least that version
+	r := &MetadataRequest{}
+	for v := int16(0); ; v++ {
+		r.Version = v
+		if !r.isValidVersion() {
+			break
 		}
+		got := NewMetadataRequest(r.requiredVersion(), nil).Version
+		assert.GreaterOrEqualf(t, got, v,
+			"NewMetadataRequest(%s) selected v%d, below v%d which requires it",
+			r.requiredVersion(), got, v)
 	}
 }


### PR DESCRIPTION
Hi,

I've built a static analyzer for Go called [Ghoul](https://fereidani.com/ghoul), and I ran it against the Sarama codebase. It flagged a duplicate condition in `NewMetadataRequest`, where two consecutive `else if` branches both check `version.IsAtLeast(V2_4_0_0)`, which makes the second branch unreachable.

Ghoul related reports:
```txt
metadata_request.go:34:12: [duplicate-elseif-condition] this condition already appeared earlier in the if/else-if chain, so this branch is unreachable (confidence: 8.0/10, CWE-571)
```

Because the second `V2_4_0_0` check can never be reached, `MetadataRequest` version 8 is never selected. Kafka metadata v8 corresponds to Kafka 2.3.0, so clients configured for `V2_3_0_0` silently fell through to v7. This matches `MetadataRequest.requiredVersion()`, which maps version 8 back to `V2_3_0_0`.

The fix changes the duplicate check to `V2_3_0_0`, restoring the intended mapping. I also added a table test, `TestNewMetadataRequestVersionMapping`, that pins each Kafka version to the metadata request version it selects, so this cannot regress unnoticed.