### PR TITLE
fix: correct typos in comments and godoc

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -101,7 +101,7 @@ type AccessToken struct {
 	Extensions map[string]string
 }
 
-// AccessTokenProvider is the interface that encapsulates how implementors
+// AccessTokenProvider is the interface that encapsulates how implementers
 // can generate access tokens for Kafka broker authentication.
 type AccessTokenProvider interface {
 	// Token returns an access token. The implementation should ensure token

--- a/client.go
+++ b/client.go
@@ -275,7 +275,7 @@ func (client *client) Broker(brokerID int32) (*Broker, error) {
 }
 
 func (client *client) InitProducerID() (*InitProducerIDResponse, error) {
-	// FIXME: this InitProducerID seems to only be called from client_test.go (TestInitProducerIDConnectionRefused) and has been superceded by transaction_manager.go?
+	// FIXME: this InitProducerID seems to only be called from client_test.go (TestInitProducerIDConnectionRefused) and has been superseded by transaction_manager.go?
 	brokerErrors := make([]error, 0)
 	for broker := client.LeastLoadedBroker(); broker != nil; broker = client.LeastLoadedBroker() {
 		request := &InitProducerIDRequest{}

--- a/consumer.go
+++ b/consumer.go
@@ -1311,7 +1311,7 @@ func (bc *brokerConsumer) fetchNewMessages() (*FetchResponse, error) {
 	// partitions are processed in the order they appear in the request.
 	case bc.consumer.conf.Version.IsAtLeast(V0_10_1_0):
 		request.Version = 3
-	// Starting in version 2, the requestor must be able to handle Kafka log
+	// Starting in version 2, the requester must be able to handle Kafka log
 	// message format version 1.
 	case bc.consumer.conf.Version.IsAtLeast(V0_10_0_0):
 		request.Version = 2

--- a/partitioner.go
+++ b/partitioner.go
@@ -194,7 +194,7 @@ func NewReferenceHashPartitioner(topic string) Partitioner {
 	return p
 }
 
-// NewConsistentCRCHashPartitioner is like NewHashPartitioner execpt that it uses the *unsigned* crc32 hash
+// NewConsistentCRCHashPartitioner is like NewHashPartitioner except that it uses the *unsigned* crc32 hash
 // of the encoded bytes of the message key modulus the number of partitions.  This is compatible with
 // librdkafka's `consistent_random` partitioner
 func NewConsistentCRCHashPartitioner(topic string) Partitioner {

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -775,7 +775,7 @@ func (t *transactionManager) maybeAddPartitionToCurrentTxn(topic string, partiti
 	t.pendingPartitionsInCurrentTxn[tp] = struct{}{}
 }
 
-// Makes a request to kafka to add a list of partitions ot the current transaction.
+// Makes a request to kafka to add a list of partitions to the current transaction.
 func (t *transactionManager) publishTxnPartitions() error {
 	t.partitionInTxnLock.Lock()
 	defer t.partitionInTxnLock.Unlock()


### PR DESCRIPTION
## Summary

Fix five typos in Go source comments and godoc strings.

| File | Typo | Correction |
|------|------|------------|
| `broker.go` | `implementors` | `implementers` |
| `client.go` | `superceded` | `superseded` |
| `consumer.go` | `requestor` | `requester` |
| `partitioner.go` | `execpt` | `except` |
| `transaction_manager.go` | `ot` | `to` |

No logic changes — comments and godoc only.