### PR TITLE
feat: support DescribeProducers v0

### DIFF
--- a/api_versions.go
+++ b/api_versions.go
@@ -83,4 +83,5 @@ const (
 	apiKeyAlterUserScramCredentials    = 51
 	apiKeyUpdateFeatures               = 57
 	apiKeyDescribeCluster              = 60
+	apiKeyDescribeProducers            = 61
 )

--- a/broker.go
+++ b/broker.go
@@ -1021,6 +1021,19 @@ func (b *Broker) UpdateFeatures(req *UpdateFeaturesRequest) (*UpdateFeaturesResp
 	return res, nil
 }
 
+// DescribeProducers sends a request to list the active producer state for
+// topic partitions led by this broker
+func (b *Broker) DescribeProducers(req *DescribeProducersRequest) (*DescribeProducersResponse, error) {
+	res := new(DescribeProducersResponse)
+
+	err := b.sendAndReceive(req, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 // DescribeClientQuotas sends a request to get the broker's quotas
 func (b *Broker) DescribeClientQuotas(request *DescribeClientQuotasRequest) (*DescribeClientQuotasResponse, error) {
 	response := new(DescribeClientQuotasResponse)

--- a/describe_producers_request.go
+++ b/describe_producers_request.go
@@ -1,0 +1,108 @@
+package sarama
+
+type DescribeProducersRequest struct {
+	Version int16
+
+	// Topics is the set of topics (and their partitions) to list producers for
+	Topics []DescribeProducersRequestTopic
+}
+
+func (r *DescribeProducersRequest) setVersion(v int16) {
+	r.Version = v
+}
+
+type DescribeProducersRequestTopic struct {
+	// Name is the topic name
+	Name string
+
+	// PartitionIndexes is the indexes of the partitions to list producers for
+	PartitionIndexes []int32
+}
+
+func (t *DescribeProducersRequestTopic) encode(pe packetEncoder) error {
+	if err := pe.putString(t.Name); err != nil {
+		return err
+	}
+
+	if err := pe.putInt32Array(t.PartitionIndexes); err != nil {
+		return err
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (t *DescribeProducersRequestTopic) decode(pd packetDecoder, version int16) (err error) {
+	if t.Name, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if t.PartitionIndexes, err = pd.getInt32Array(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *DescribeProducersRequest) encode(pe packetEncoder) error {
+	if err := pe.putArrayLength(len(r.Topics)); err != nil {
+		return err
+	}
+	for i := range r.Topics {
+		if err := r.Topics[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *DescribeProducersRequest) decode(pd packetDecoder, version int16) (err error) {
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	r.Topics = make([]DescribeProducersRequestTopic, n)
+	for i := range n {
+		if err := r.Topics[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *DescribeProducersRequest) key() int16 {
+	return apiKeyDescribeProducers
+}
+
+func (r *DescribeProducersRequest) version() int16 {
+	return r.Version
+}
+
+func (r *DescribeProducersRequest) headerVersion() int16 {
+	return 2
+}
+
+func (r *DescribeProducersRequest) isValidVersion() bool {
+	return r.Version == 0
+}
+
+func (r *DescribeProducersRequest) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *DescribeProducersRequest) isFlexibleVersion(version int16) bool {
+	return version >= 0
+}
+
+func (r *DescribeProducersRequest) requiredVersion() KafkaVersion {
+	return V2_8_0_0
+}

--- a/describe_producers_request_test.go
+++ b/describe_producers_request_test.go
@@ -1,0 +1,31 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+)
+
+var describeProducersRequestV0 = []byte{
+	2,                          // Topics
+	6, 't', 'o', 'p', 'i', 'c', // name
+	3,          // PartitionIndexes
+	0, 0, 0, 0, // partition 0
+	0, 0, 0, 1, // partition 1
+	0, // empty tagged fields
+	0, // empty tagged fields
+}
+
+func TestDescribeProducersRequest(t *testing.T) {
+	request := &DescribeProducersRequest{
+		Version: 0,
+		Topics: []DescribeProducersRequestTopic{
+			{
+				Name:             "topic",
+				PartitionIndexes: []int32{0, 1},
+			},
+		},
+	}
+
+	testRequest(t, "v0", request, describeProducersRequestV0)
+}

--- a/describe_producers_response.go
+++ b/describe_producers_response.go
@@ -1,0 +1,265 @@
+package sarama
+
+import "time"
+
+type DescribeProducersResponse struct {
+	Version int16
+
+	ThrottleTime time.Duration
+
+	// Topics contains the per-topic results
+	Topics []DescribeProducersResponseTopic
+}
+
+func (r *DescribeProducersResponse) setVersion(v int16) {
+	r.Version = v
+}
+
+type DescribeProducersResponseTopic struct {
+	// Name is the topic name
+	Name string
+
+	// Partitions contains the per-partition results
+	Partitions []DescribeProducersResponsePartition
+}
+
+type DescribeProducersResponsePartition struct {
+	// PartitionIndex is the partition index
+	PartitionIndex int32
+
+	ErrorCode    KError
+	ErrorMessage *string
+
+	// ActiveProducers is the set of active producers for the partition
+	ActiveProducers []ProducerState
+}
+
+type ProducerState struct {
+	// ProducerID is the producer id
+	ProducerID int64
+
+	// ProducerEpoch is the producer epoch
+	ProducerEpoch int32
+
+	// LastSequence is the last sequence number sent by the producer, or -1
+	LastSequence int32
+
+	// LastTimestamp is the last timestamp sent by the producer, or -1
+	LastTimestamp int64
+
+	// CoordinatorEpoch is the current epoch of the producer group
+	CoordinatorEpoch int32
+
+	// CurrentTxnStartOffset is the current transaction start offset of the
+	// producer, or -1
+	CurrentTxnStartOffset int64
+}
+
+func (p *ProducerState) encode(pe packetEncoder) error {
+	pe.putInt64(p.ProducerID)
+	pe.putInt32(p.ProducerEpoch)
+	pe.putInt32(p.LastSequence)
+	pe.putInt64(p.LastTimestamp)
+	pe.putInt32(p.CoordinatorEpoch)
+	pe.putInt64(p.CurrentTxnStartOffset)
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (p *ProducerState) decode(pd packetDecoder, version int16) (err error) {
+	if p.ProducerID, err = pd.getInt64(); err != nil {
+		return err
+	}
+
+	if p.ProducerEpoch, err = pd.getInt32(); err != nil {
+		return err
+	}
+
+	if p.LastSequence, err = pd.getInt32(); err != nil {
+		return err
+	}
+
+	if p.LastTimestamp, err = pd.getInt64(); err != nil {
+		return err
+	}
+
+	if p.CoordinatorEpoch, err = pd.getInt32(); err != nil {
+		return err
+	}
+
+	if p.CurrentTxnStartOffset, err = pd.getInt64(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (p *DescribeProducersResponsePartition) encode(pe packetEncoder) error {
+	pe.putInt32(p.PartitionIndex)
+
+	pe.putKError(p.ErrorCode)
+
+	if err := pe.putNullableString(p.ErrorMessage); err != nil {
+		return err
+	}
+
+	if err := pe.putArrayLength(len(p.ActiveProducers)); err != nil {
+		return err
+	}
+	for i := range p.ActiveProducers {
+		if err := p.ActiveProducers[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (p *DescribeProducersResponsePartition) decode(pd packetDecoder, version int16) (err error) {
+	if p.PartitionIndex, err = pd.getInt32(); err != nil {
+		return err
+	}
+
+	if p.ErrorCode, err = pd.getKError(); err != nil {
+		return err
+	}
+
+	if p.ErrorMessage, err = pd.getNullableString(); err != nil {
+		return err
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	p.ActiveProducers = make([]ProducerState, n)
+	for i := range n {
+		if err := p.ActiveProducers[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (t *DescribeProducersResponseTopic) encode(pe packetEncoder) error {
+	if err := pe.putString(t.Name); err != nil {
+		return err
+	}
+
+	if err := pe.putArrayLength(len(t.Partitions)); err != nil {
+		return err
+	}
+	for i := range t.Partitions {
+		if err := t.Partitions[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (t *DescribeProducersResponseTopic) decode(pd packetDecoder, version int16) (err error) {
+	if t.Name, err = pd.getString(); err != nil {
+		return err
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	t.Partitions = make([]DescribeProducersResponsePartition, n)
+	for i := range n {
+		if err := t.Partitions[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *DescribeProducersResponse) encode(pe packetEncoder) error {
+	pe.putDurationMs(r.ThrottleTime)
+
+	if err := pe.putArrayLength(len(r.Topics)); err != nil {
+		return err
+	}
+	for i := range r.Topics {
+		if err := r.Topics[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *DescribeProducersResponse) decode(pd packetDecoder, version int16) (err error) {
+	if r.ThrottleTime, err = pd.getDurationMs(); err != nil {
+		return err
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	r.Topics = make([]DescribeProducersResponseTopic, n)
+	for i := range n {
+		if err := r.Topics[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *DescribeProducersResponse) key() int16 {
+	return apiKeyDescribeProducers
+}
+
+func (r *DescribeProducersResponse) version() int16 {
+	return r.Version
+}
+
+func (r *DescribeProducersResponse) headerVersion() int16 {
+	return 1
+}
+
+func (r *DescribeProducersResponse) isValidVersion() bool {
+	return r.Version == 0
+}
+
+func (r *DescribeProducersResponse) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *DescribeProducersResponse) isFlexibleVersion(version int16) bool {
+	return version >= 0
+}
+
+func (r *DescribeProducersResponse) requiredVersion() KafkaVersion {
+	return V2_8_0_0
+}
+
+func (r *DescribeProducersResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/describe_producers_response_test.go
+++ b/describe_producers_response_test.go
@@ -1,0 +1,59 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+	"time"
+)
+
+var describeProducersResponseV0 = []byte{
+	0, 0, 0, 100, // throttleTimeMs
+	2,                          // Topics
+	6, 't', 'o', 'p', 'i', 'c', // name
+	2,          // Partitions
+	0, 0, 0, 0, // partition index
+	0, 0, // error code
+	0,                        // error message
+	2,                        // ActiveProducers
+	0, 0, 0, 0, 0, 0, 3, 232, // producer id
+	0, 0, 0, 1, // producer epoch
+	0, 0, 0, 5, // last sequence
+	0, 0, 0, 0, 0, 0, 0, 8, // last timestamp
+	0, 0, 0, 2, // coordinator epoch
+	255, 255, 255, 255, 255, 255, 255, 255, // current txn start offset
+	0, // empty tagged fields
+	0, // empty tagged fields
+	0, // empty tagged fields
+	0, // empty tagged fields
+}
+
+func TestDescribeProducersResponse(t *testing.T) {
+	response := &DescribeProducersResponse{
+		Version:      0,
+		ThrottleTime: 100 * time.Millisecond,
+		Topics: []DescribeProducersResponseTopic{
+			{
+				Name: "topic",
+				Partitions: []DescribeProducersResponsePartition{
+					{
+						PartitionIndex: 0,
+						ErrorCode:      ErrNoError,
+						ActiveProducers: []ProducerState{
+							{
+								ProducerID:            1000,
+								ProducerEpoch:         1,
+								LastSequence:          5,
+								LastTimestamp:         8,
+								CoordinatorEpoch:      2,
+								CurrentTxnStartOffset: -1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	testResponse(t, "v0", response, describeProducersResponseV0)
+}

--- a/encoder_decoder_fuzz_test.go
+++ b/encoder_decoder_fuzz_test.go
@@ -64,6 +64,7 @@ func FuzzVersionedDecodeRequest(f *testing.F) {
 		{key: apiKeyDescribeUserScramCredentials, version: 0, body: emptyDescribeUserScramCredentialsRequest},
 		{key: apiKeyAlterUserScramCredentials, version: 0, body: emptyAlterUserScramCredentialsRequest},
 		{key: apiKeyUpdateFeatures, version: 0, body: updateFeaturesRequestV0},
+		{key: apiKeyDescribeProducers, version: 0, body: describeProducersRequestV0},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}
@@ -119,6 +120,7 @@ func FuzzVersionedDecodeResponse(f *testing.F) {
 		{key: apiKeyDescribeUserScramCredentials, version: 0, body: emptyDescribeUserScramCredentialsResponse},
 		{key: apiKeyAlterUserScramCredentials, version: 0, body: emptyAlterUserScramCredentialsResponse},
 		{key: apiKeyUpdateFeatures, version: 0, body: updateFeaturesResponseV0},
+		{key: apiKeyDescribeProducers, version: 0, body: describeProducersResponseV0},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}

--- a/functional_describe_producers_test.go
+++ b/functional_describe_producers_test.go
@@ -1,0 +1,59 @@
+//go:build functional
+
+package sarama
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFuncDescribeProducers(t *testing.T) {
+	checkKafkaVersion(t, "2.8.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	config := NewFunctionalTestConfig()
+	config.Producer.Idempotent = true
+	config.Producer.RequiredAcks = WaitForAll
+	config.Producer.Return.Successes = true
+	config.Net.MaxOpenRequests = 1
+
+	client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer safeClose(t, client)
+
+	// an idempotent producer is allocated a producer id on first send, which
+	// the partition leader then reports as active producer state
+	producer, err := NewSyncProducerFromClient(client)
+	require.NoError(t, err)
+	defer safeClose(t, producer)
+
+	_, _, err = producer.SendMessage(&ProducerMessage{Topic: "test.1", Value: StringEncoder("describe-producers")})
+	require.NoError(t, err)
+
+	leader, err := client.Leader("test.1", 0)
+	require.NoError(t, err)
+
+	req := &DescribeProducersRequest{
+		Topics: []DescribeProducersRequestTopic{
+			{Name: "test.1", PartitionIndexes: []int32{0}},
+		},
+	}
+	res, err := leader.DescribeProducers(req)
+	require.NoError(t, err)
+
+	require.Len(t, res.Topics, 1)
+	assert.Equal(t, "test.1", res.Topics[0].Name)
+	require.Len(t, res.Topics[0].Partitions, 1)
+
+	partition := res.Topics[0].Partitions[0]
+	assert.Equal(t, int32(0), partition.PartitionIndex)
+	require.Equal(t, ErrNoError, partition.ErrorCode)
+	require.NotEmpty(t, partition.ActiveProducers)
+
+	state := partition.ActiveProducers[0]
+	assert.GreaterOrEqual(t, state.ProducerID, int64(0))
+	assert.GreaterOrEqual(t, state.LastSequence, int32(0))
+}

--- a/request.go
+++ b/request.go
@@ -221,6 +221,8 @@ func allocateBody(key, version int16) protocolBody {
 		return &UpdateFeaturesRequest{Version: version}
 	case apiKeyDescribeCluster:
 		return &DescribeClusterRequest{Version: version}
+	case apiKeyDescribeProducers:
+		return &DescribeProducersRequest{Version: version}
 		// 52: VoteRequest
 		// 53: BeginQuorumEpochRequest
 		// 54: EndQuorumEpochRequest
@@ -229,7 +231,6 @@ func allocateBody(key, version int16) protocolBody {
 		// 58: EnvelopeRequest
 		// 59: FetchSnapshotRequest
 		// 60: DescribeClusterRequest
-		// 61: DescribeProducersRequest
 		// 62: BrokerRegistrationRequest
 		// 63: BrokerHeartbeatRequest
 		// 64: UnregisterBrokerRequest
@@ -336,6 +337,8 @@ func allocateResponseBody(key, version int16) protocolBody {
 		return &UpdateFeaturesResponse{Version: version}
 	case apiKeyDescribeCluster:
 		return &DescribeClusterResponse{Version: version}
+	case apiKeyDescribeProducers:
+		return &DescribeProducersResponse{Version: version}
 	}
 	return nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -75,7 +75,7 @@ var names = map[int16]string{
 	58:                                 "EnvelopeRequest",
 	59:                                 "FetchSnapshotRequest",
 	apiKeyDescribeCluster:              "DescribeClusterRequest",
-	61:                                 "DescribeProducersRequest",
+	apiKeyDescribeProducers:            "DescribeProducersRequest",
 	62:                                 "BrokerRegistrationRequest",
 	63:                                 "BrokerHeartbeatRequest",
 	64:                                 "UnregisterBrokerRequest",
@@ -323,6 +323,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDescribeConfigs:      4,  // up from 3
 				apiKeyAddPartitionsToTxn:   3,  // up from 2
 				apiKeyProduce:              9,  // up from 8
+				apiKeyDescribeProducers:    0,  // new in 2.8
 				// TODO: ListOffsetsRequest v6 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyListOffsets:          6, // up from 5
 				// TODO: AddOffsetsToTxnRequest v3 is not supported, but expected for KafkaVersion 2.8.0
@@ -337,8 +338,6 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				// apiKeyCreateTopics:         7, // up from 6
 				// TODO: DeleteTopicsRequest v6 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyDeleteTopics:         6, // up from 5
-				// TODO: DescribeProducersRequest v0 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyDescribeProducers /* (61) */: 0, // new in 2.8
 			},
 		},
 		{
@@ -539,6 +538,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyAlterUserScramCredentials:    maxVersion(&AlterUserScramCredentialsRequest{}),
 				apiKeyUpdateFeatures:               maxVersion(&UpdateFeaturesRequest{}),
 				apiKeyDescribeCluster:              maxVersion(&DescribeClusterRequest{}),
+				apiKeyDescribeProducers:            maxVersion(&DescribeProducersRequest{}),
 			},
 		},
 	}


### PR DESCRIPTION
Implement KIP-664 DescribeProducers (apiKey 61) v0, a flexible-version admin API served by partition leaders.

- add DescribeProducersRequest/Response with compact encode/decode
- register apiKey 61 in allocateBody and allocateResponseBody
- add Broker.DescribeProducers helper
- add unit test fixtures, fuzz seeds and protocol version parity entry
- add functional test gated on Kafka 2.8.0

KIP-664: https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions

Contributes-to: #3655