### PR TITLE
feat: support DescribeTransactions v0

### DIFF
--- a/api_versions.go
+++ b/api_versions.go
@@ -84,4 +84,5 @@ const (
 	apiKeyUpdateFeatures               = 57
 	apiKeyDescribeCluster              = 60
 	apiKeyDescribeProducers            = 61
+	apiKeyDescribeTransactions         = 65
 )

--- a/broker.go
+++ b/broker.go
@@ -1034,6 +1034,19 @@ func (b *Broker) DescribeProducers(req *DescribeProducersRequest) (*DescribeProd
 	return res, nil
 }
 
+// DescribeTransactions sends a request to retrieve the current state of
+// transactions from the transaction coordinator
+func (b *Broker) DescribeTransactions(req *DescribeTransactionsRequest) (*DescribeTransactionsResponse, error) {
+	res := new(DescribeTransactionsResponse)
+
+	err := b.sendAndReceive(req, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 // DescribeClientQuotas sends a request to get the broker's quotas
 func (b *Broker) DescribeClientQuotas(request *DescribeClientQuotasRequest) (*DescribeClientQuotasResponse, error) {
 	response := new(DescribeClientQuotasResponse)

--- a/describe_transactions_request.go
+++ b/describe_transactions_request.go
@@ -1,0 +1,59 @@
+package sarama
+
+type DescribeTransactionsRequest struct {
+	Version int16
+
+	// TransactionalIDs is the set of transactional ids to include in the
+	// describe results. If empty, then no results will be returned
+	TransactionalIDs []string
+}
+
+func (r *DescribeTransactionsRequest) setVersion(v int16) {
+	r.Version = v
+}
+
+func (r *DescribeTransactionsRequest) encode(pe packetEncoder) error {
+	if err := pe.putStringArray(r.TransactionalIDs); err != nil {
+		return err
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *DescribeTransactionsRequest) decode(pd packetDecoder, version int16) (err error) {
+	if r.TransactionalIDs, err = pd.getStringArray(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *DescribeTransactionsRequest) key() int16 {
+	return apiKeyDescribeTransactions
+}
+
+func (r *DescribeTransactionsRequest) version() int16 {
+	return r.Version
+}
+
+func (r *DescribeTransactionsRequest) headerVersion() int16 {
+	return 2
+}
+
+func (r *DescribeTransactionsRequest) isValidVersion() bool {
+	return r.Version == 0
+}
+
+func (r *DescribeTransactionsRequest) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *DescribeTransactionsRequest) isFlexibleVersion(version int16) bool {
+	return version >= 0
+}
+
+func (r *DescribeTransactionsRequest) requiredVersion() KafkaVersion {
+	return V3_0_0_0
+}

--- a/describe_transactions_request_test.go
+++ b/describe_transactions_request_test.go
@@ -1,0 +1,22 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+)
+
+var describeTransactionsRequestV0 = []byte{
+	2,                // TransactionalIds (one element array)
+	4, 't', 'x', 'n', // transactional id
+	0, // empty tagged fields
+}
+
+func TestDescribeTransactionsRequest(t *testing.T) {
+	request := &DescribeTransactionsRequest{
+		Version:          0,
+		TransactionalIDs: []string{"txn"},
+	}
+
+	testRequest(t, "v0", request, describeTransactionsRequestV0)
+}

--- a/describe_transactions_response.go
+++ b/describe_transactions_response.go
@@ -1,0 +1,227 @@
+package sarama
+
+import "time"
+
+type DescribeTransactionsResponse struct {
+	Version int16
+
+	ThrottleTime time.Duration
+
+	// TransactionStates contains the current state of each queried transaction
+	TransactionStates []TransactionState
+}
+
+func (r *DescribeTransactionsResponse) setVersion(v int16) {
+	r.Version = v
+}
+
+type TransactionState struct {
+	ErrorCode KError
+
+	// TransactionalID is the transactional id
+	TransactionalID string
+
+	// TransactionState is the current transaction state of the producer
+	TransactionState string
+
+	// TransactionTimeout is the timeout of the transaction
+	TransactionTimeout time.Duration
+
+	// TransactionStartTime is the start time of the transaction in
+	// milliseconds
+	TransactionStartTime int64
+
+	// ProducerID is the current producer id associated with the transaction
+	ProducerID int64
+
+	// ProducerEpoch is the current epoch associated with the producer id
+	ProducerEpoch int16
+
+	// Topics is the set of partitions included in the current transaction (if
+	// active). When a transaction is preparing to commit or abort, this will
+	// include only partitions which do not have markers
+	Topics []DescribeTransactionsResponseTopic
+}
+
+type DescribeTransactionsResponseTopic struct {
+	// Topic is the topic name
+	Topic string
+
+	// Partitions is the partition ids included in the current transaction
+	Partitions []int32
+}
+
+func (t *DescribeTransactionsResponseTopic) encode(pe packetEncoder) error {
+	if err := pe.putString(t.Topic); err != nil {
+		return err
+	}
+
+	if err := pe.putInt32Array(t.Partitions); err != nil {
+		return err
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (t *DescribeTransactionsResponseTopic) decode(pd packetDecoder, version int16) (err error) {
+	if t.Topic, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if t.Partitions, err = pd.getInt32Array(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (s *TransactionState) encode(pe packetEncoder) error {
+	pe.putKError(s.ErrorCode)
+
+	if err := pe.putString(s.TransactionalID); err != nil {
+		return err
+	}
+
+	if err := pe.putString(s.TransactionState); err != nil {
+		return err
+	}
+
+	pe.putDurationMs(s.TransactionTimeout)
+	pe.putInt64(s.TransactionStartTime)
+	pe.putInt64(s.ProducerID)
+	pe.putInt16(s.ProducerEpoch)
+
+	if err := pe.putArrayLength(len(s.Topics)); err != nil {
+		return err
+	}
+	for i := range s.Topics {
+		if err := s.Topics[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (s *TransactionState) decode(pd packetDecoder, version int16) (err error) {
+	if s.ErrorCode, err = pd.getKError(); err != nil {
+		return err
+	}
+
+	if s.TransactionalID, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if s.TransactionState, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if s.TransactionTimeout, err = pd.getDurationMs(); err != nil {
+		return err
+	}
+
+	if s.TransactionStartTime, err = pd.getInt64(); err != nil {
+		return err
+	}
+
+	if s.ProducerID, err = pd.getInt64(); err != nil {
+		return err
+	}
+
+	if s.ProducerEpoch, err = pd.getInt16(); err != nil {
+		return err
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	s.Topics = make([]DescribeTransactionsResponseTopic, n)
+	for i := range n {
+		if err := s.Topics[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *DescribeTransactionsResponse) encode(pe packetEncoder) error {
+	pe.putDurationMs(r.ThrottleTime)
+
+	if err := pe.putArrayLength(len(r.TransactionStates)); err != nil {
+		return err
+	}
+	for i := range r.TransactionStates {
+		if err := r.TransactionStates[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *DescribeTransactionsResponse) decode(pd packetDecoder, version int16) (err error) {
+	if r.ThrottleTime, err = pd.getDurationMs(); err != nil {
+		return err
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	r.TransactionStates = make([]TransactionState, n)
+	for i := range n {
+		if err := r.TransactionStates[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *DescribeTransactionsResponse) key() int16 {
+	return apiKeyDescribeTransactions
+}
+
+func (r *DescribeTransactionsResponse) version() int16 {
+	return r.Version
+}
+
+func (r *DescribeTransactionsResponse) headerVersion() int16 {
+	return 1
+}
+
+func (r *DescribeTransactionsResponse) isValidVersion() bool {
+	return r.Version == 0
+}
+
+func (r *DescribeTransactionsResponse) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *DescribeTransactionsResponse) isFlexibleVersion(version int16) bool {
+	return version >= 0
+}
+
+func (r *DescribeTransactionsResponse) requiredVersion() KafkaVersion {
+	return V3_0_0_0
+}
+
+func (r *DescribeTransactionsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/describe_transactions_response_test.go
+++ b/describe_transactions_response_test.go
@@ -1,0 +1,53 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+	"time"
+)
+
+var describeTransactionsResponseV0 = []byte{
+	0, 0, 0, 100, // throttleTimeMs
+	2,    // TransactionStates (one element array)
+	0, 0, // error code
+	4, 't', 'x', 'n', // transactional id
+	8, 'O', 'n', 'g', 'o', 'i', 'n', 'g', // transaction state
+	0, 0, 234, 96, // transaction timeout ms
+	0, 0, 0, 0, 0, 0, 0, 8, // transaction start time ms
+	0, 0, 0, 0, 0, 0, 3, 232, // producer id
+	0, 1, // producer epoch
+	2,                          // Topics (one element array)
+	6, 't', 'o', 'p', 'i', 'c', // topic
+	2,          // Partitions (one element array)
+	0, 0, 0, 0, // partition 0
+	0, // empty tagged fields
+	0, // empty tagged fields
+	0, // empty tagged fields
+}
+
+func TestDescribeTransactionsResponse(t *testing.T) {
+	response := &DescribeTransactionsResponse{
+		Version:      0,
+		ThrottleTime: 100 * time.Millisecond,
+		TransactionStates: []TransactionState{
+			{
+				ErrorCode:            ErrNoError,
+				TransactionalID:      "txn",
+				TransactionState:     "Ongoing",
+				TransactionTimeout:   time.Minute,
+				TransactionStartTime: 8,
+				ProducerID:           1000,
+				ProducerEpoch:        1,
+				Topics: []DescribeTransactionsResponseTopic{
+					{
+						Topic:      "topic",
+						Partitions: []int32{0},
+					},
+				},
+			},
+		},
+	}
+
+	testResponse(t, "v0", response, describeTransactionsResponseV0)
+}

--- a/encoder_decoder_fuzz_test.go
+++ b/encoder_decoder_fuzz_test.go
@@ -65,6 +65,7 @@ func FuzzVersionedDecodeRequest(f *testing.F) {
 		{key: apiKeyAlterUserScramCredentials, version: 0, body: emptyAlterUserScramCredentialsRequest},
 		{key: apiKeyUpdateFeatures, version: 0, body: updateFeaturesRequestV0},
 		{key: apiKeyDescribeProducers, version: 0, body: describeProducersRequestV0},
+		{key: apiKeyDescribeTransactions, version: 0, body: describeTransactionsRequestV0},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}
@@ -121,6 +122,7 @@ func FuzzVersionedDecodeResponse(f *testing.F) {
 		{key: apiKeyAlterUserScramCredentials, version: 0, body: emptyAlterUserScramCredentialsResponse},
 		{key: apiKeyUpdateFeatures, version: 0, body: updateFeaturesResponseV0},
 		{key: apiKeyDescribeProducers, version: 0, body: describeProducersResponseV0},
+		{key: apiKeyDescribeTransactions, version: 0, body: describeTransactionsResponseV0},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}

--- a/functional_describe_transactions_test.go
+++ b/functional_describe_transactions_test.go
@@ -1,0 +1,50 @@
+//go:build functional
+
+package sarama
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFuncDescribeTransactions(t *testing.T) {
+	checkKafkaVersion(t, "3.0.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	config := NewFunctionalTestConfig()
+	config.Producer.Idempotent = true
+	config.Producer.Transaction.ID = "TestFuncDescribeTransactions"
+	config.Producer.RequiredAcks = WaitForAll
+	config.Producer.Return.Successes = true
+	config.Net.MaxOpenRequests = 1
+
+	client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer safeClose(t, client)
+
+	// a transactional producer registers its transactional id with the
+	// transaction coordinator on startup via InitProducerId
+	producer, err := NewAsyncProducerFromClient(client)
+	require.NoError(t, err)
+	defer safeClose(t, producer)
+
+	coordinator, err := client.TransactionCoordinator(config.Producer.Transaction.ID)
+	require.NoError(t, err)
+
+	req := &DescribeTransactionsRequest{
+		TransactionalIDs: []string{config.Producer.Transaction.ID},
+	}
+	res, err := coordinator.DescribeTransactions(req)
+	require.NoError(t, err)
+
+	require.Len(t, res.TransactionStates, 1)
+
+	state := res.TransactionStates[0]
+	require.Equal(t, ErrNoError, state.ErrorCode)
+	assert.Equal(t, config.Producer.Transaction.ID, state.TransactionalID)
+	assert.NotEmpty(t, state.TransactionState)
+	assert.GreaterOrEqual(t, state.ProducerID, int64(0))
+}

--- a/request.go
+++ b/request.go
@@ -234,7 +234,8 @@ func allocateBody(key, version int16) protocolBody {
 		// 62: BrokerRegistrationRequest
 		// 63: BrokerHeartbeatRequest
 		// 64: UnregisterBrokerRequest
-		// 65: DescribeTransactionsRequest
+	case apiKeyDescribeTransactions:
+		return &DescribeTransactionsRequest{Version: version}
 		// 66: ListTransactionsRequest
 		// 67: AllocateProducerIdsRequest
 		// 68: ConsumerGroupHeartbeatRequest
@@ -339,6 +340,8 @@ func allocateResponseBody(key, version int16) protocolBody {
 		return &DescribeClusterResponse{Version: version}
 	case apiKeyDescribeProducers:
 		return &DescribeProducersResponse{Version: version}
+	case apiKeyDescribeTransactions:
+		return &DescribeTransactionsResponse{Version: version}
 	}
 	return nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -79,7 +79,7 @@ var names = map[int16]string{
 	62:                                 "BrokerRegistrationRequest",
 	63:                                 "BrokerHeartbeatRequest",
 	64:                                 "UnregisterBrokerRequest",
-	65:                                 "DescribeTransactionsRequest",
+	apiKeyDescribeTransactions:         "DescribeTransactionsRequest",
 	66:                                 "ListTransactionsRequest",
 	67:                                 "AllocateProducerIdsRequest",
 	68:                                 "ConsumerGroupHeartbeatRequest",
@@ -343,7 +343,8 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V3_0_0_0,
 			map[int16]int16{
-				apiKeyOffsetFetch: 8, // up from 7
+				apiKeyOffsetFetch:          8, // up from 7
+				apiKeyDescribeTransactions: 0, // new in 3.0
 				// TODO: ListOffsetsRequest v7 is not supported, but expected for KafkaVersion 3.0.0
 				// apiKeyListOffsets:     7, // up from 6
 				// TODO: FindCoordinatorRequest v4 is not supported, but expected for KafkaVersion 3.0.0
@@ -539,6 +540,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyUpdateFeatures:               maxVersion(&UpdateFeaturesRequest{}),
 				apiKeyDescribeCluster:              maxVersion(&DescribeClusterRequest{}),
 				apiKeyDescribeProducers:            maxVersion(&DescribeProducersRequest{}),
+				apiKeyDescribeTransactions:         maxVersion(&DescribeTransactionsRequest{}),
 			},
 		},
 	}


### PR DESCRIPTION
Add the DescribeTransactions API (key 65, KIP-664, Kafka 3.0.0):

- add DescribeTransactionsRequest/Response with flexible v0 encoding
- add Broker.DescribeTransactions helper
- add unit test fixtures and a functional test against the transaction coordinator

KIP-664: https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions

Contributes-to: #3655