### PR TITLE
feat: support int64 arrays in flexible protocol

### DIFF
--- a/prep_encoder.go
+++ b/prep_encoder.go
@@ -257,6 +257,12 @@ func (pe *prepFlexibleEncoder) putNullableInt32Array(in []int32) error {
 	return nil
 }
 
+func (pe *prepFlexibleEncoder) putInt64Array(in []int64) error {
+	pe.putUVarint(uint64(len(in)) + 1)
+	pe.length += 8 * len(in)
+	return nil
+}
+
 func (pe *prepFlexibleEncoder) putEmptyTaggedFieldArray() {
 	pe.putUVarint(0)
 }

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -577,6 +577,40 @@ func (rd *realFlexibleDecoder) getNullableInt32Array() ([]int32, error) {
 	return ret, nil
 }
 
+func (rd *realFlexibleDecoder) getInt64Array() ([]int64, error) {
+	ret, err := rd.getNullableInt64Array()
+	if ret == nil && err == nil {
+		return nil, errInvalidArrayLength
+	}
+	return ret, err
+}
+
+func (rd *realFlexibleDecoder) getNullableInt64Array() ([]int64, error) {
+	n, err := rd.getUVarint()
+	if err != nil {
+		return nil, err
+	}
+
+	if n == 0 {
+		return nil, nil
+	}
+
+	arrayLength := n - 1
+
+	if uint64(rd.remaining()/8) < arrayLength { //nolint:gosec // G115 - remaining() is non-negative
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+
+	ret := make([]int64, int(arrayLength)) //nolint:gosec // G115 - value bounded by remaining() above
+
+	for i := range ret {
+		ret[i] = int64(binary.BigEndian.Uint64(rd.raw[rd.off:]))
+		rd.off += 8
+	}
+	return ret, nil
+}
+
 func (rd *realFlexibleDecoder) getStringArray() ([]string, error) {
 	n, err := rd.getArrayLength()
 	if err != nil {

--- a/real_decoder_test.go
+++ b/real_decoder_test.go
@@ -130,53 +130,14 @@ func TestRealDecoderGetNullableInt32Array(t *testing.T) {
 	}
 }
 
+// getInt32Array only diverges from getNullableInt32Array on null input
 func TestRealDecoderGetInt32Array(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   []byte
-		want    []int32
-		wantErr error
-	}{
-		{
-			name:    "null array",
-			input:   []byte{0xFF, 0xFF, 0xFF, 0xFF},
-			wantErr: errInvalidArrayLength,
-		},
-		{
-			name:  "empty array",
-			input: []byte{0x00, 0x00, 0x00, 0x00},
-			want:  []int32{},
-		},
-		{
-			name:  "valid array",
-			input: []byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02},
-			want:  []int32{1, 2},
-		},
-		{
-			name:    "insufficient data for length",
-			input:   []byte{0x00, 0x00, 0x00},
-			wantErr: ErrInsufficientData,
-		},
-		{
-			name:    "insufficient data for elements",
-			input:   []byte{0x00, 0x00, 0x00, 0x02},
-			wantErr: ErrInsufficientData,
-		},
-		{
-			name:    "invalid length",
-			input:   []byte{0x80, 0x00, 0x00, 0x00},
-			wantErr: errInvalidArrayLength,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rd := &realDecoder{raw: tt.input}
-			got, err := rd.getInt32Array()
-			require.ErrorIs(t, err, tt.wantErr)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+	t.Run("returns errInvalidArrayLength for null array", func(t *testing.T) {
+		rd := &realDecoder{raw: []byte{0xFF, 0xFF, 0xFF, 0xFF}}
+		got, err := rd.getInt32Array()
+		require.ErrorIs(t, err, errInvalidArrayLength)
+		assert.Nil(t, got)
+	})
 }
 
 func TestRealFlexibleDecoderGetNullableInt32Array(t *testing.T) {
@@ -215,30 +176,52 @@ func TestRealFlexibleDecoderGetNullableInt32Array(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+	t.Run("returns insufficient data for compact length exceeding int64", func(t *testing.T) {
+		var input [binary.MaxVarintLen64]byte
+		n := binary.PutUvarint(input[:], 1<<63)
+
+		rd := &realFlexibleDecoder{&realDecoder{raw: input[:n]}}
+		array, err := rd.getNullableInt32Array()
+
+		require.ErrorIs(t, err, ErrInsufficientData)
+		assert.Nil(t, array)
+	})
 }
 
+// getInt32Array only diverges from getNullableInt32Array on null input
 func TestRealFlexibleDecoderGetInt32Array(t *testing.T) {
+	t.Run("returns errInvalidArrayLength for null array", func(t *testing.T) {
+		rd := &realFlexibleDecoder{&realDecoder{raw: []byte{0x00}}}
+		got, err := rd.getInt32Array()
+		require.ErrorIs(t, err, errInvalidArrayLength)
+		assert.Nil(t, got)
+	})
+}
+
+func TestRealFlexibleDecoderGetNullableInt64Array(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   []byte
-		want    []int32
+		want    []int64
 		wantErr error
 	}{
 		{
-			name:    "null array",
-			input:   []byte{0x00},
-			wantErr: errInvalidArrayLength,
+			name:  "null array",
+			input: []byte{0x00},
 		},
 		{
 			name:  "empty array",
 			input: []byte{0x01},
-			want:  []int32{},
+			want:  []int64{},
 		},
 		{
-			name:    "valid array",
-			input:   []byte{0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02},
-			want:    []int32{1, 2},
-			wantErr: nil,
+			name: "valid array",
+			input: []byte{
+				0x03,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+			},
+			want: []int64{1, 2},
 		},
 		{
 			name:    "insufficient data",
@@ -250,7 +233,7 @@ func TestRealFlexibleDecoderGetInt32Array(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rd := &realFlexibleDecoder{&realDecoder{raw: tt.input}}
-			got, err := rd.getInt32Array()
+			got, err := rd.getNullableInt64Array()
 			require.ErrorIs(t, err, tt.wantErr)
 			assert.Equal(t, tt.want, got)
 		})
@@ -260,9 +243,19 @@ func TestRealFlexibleDecoderGetInt32Array(t *testing.T) {
 		n := binary.PutUvarint(input[:], 1<<63)
 
 		rd := &realFlexibleDecoder{&realDecoder{raw: input[:n]}}
-		array, err := rd.getInt32Array()
+		array, err := rd.getNullableInt64Array()
 
 		require.ErrorIs(t, err, ErrInsufficientData)
 		assert.Nil(t, array)
+	})
+}
+
+// getInt64Array only diverges from getNullableInt64Array on null input
+func TestRealFlexibleDecoderGetInt64Array(t *testing.T) {
+	t.Run("returns errInvalidArrayLength for null array", func(t *testing.T) {
+		rd := &realFlexibleDecoder{&realDecoder{raw: []byte{0x00}}}
+		got, err := rd.getInt64Array()
+		require.ErrorIs(t, err, errInvalidArrayLength)
+		assert.Nil(t, got)
 	})
 }

--- a/real_encoder.go
+++ b/real_encoder.go
@@ -267,6 +267,15 @@ func (re *realFlexibleEncoder) putNullableInt32Array(in []int32) error {
 	return nil
 }
 
+func (re *realFlexibleEncoder) putInt64Array(in []int64) error {
+	// 0 represents a null array, so +1 has to be added
+	re.putUVarint(uint64(len(in)) + 1)
+	for _, val := range in {
+		re.putInt64(val)
+	}
+	return nil
+}
+
 func (re *realFlexibleEncoder) putEmptyTaggedFieldArray() {
 	re.putUVarint(0)
 }


### PR DESCRIPTION
- add compact putInt64Array to the flexible encoders
- add getInt64Array/getNullableInt64Array to the flexible decoder
- slim the duplicated int32 array decoder test tables

Contributes-to: #3655