### PR TITLE
feat: support ListTransactions v0 and v1

### DIFF
--- a/api_versions.go
+++ b/api_versions.go
@@ -85,4 +85,5 @@ const (
 	apiKeyDescribeCluster              = 60
 	apiKeyDescribeProducers            = 61
 	apiKeyDescribeTransactions         = 65
+	apiKeyListTransactions             = 66
 )

--- a/broker.go
+++ b/broker.go
@@ -1047,6 +1047,19 @@ func (b *Broker) DescribeTransactions(req *DescribeTransactionsRequest) (*Descri
 	return res, nil
 }
 
+// ListTransactions sends a request to list the transactions known to the
+// transaction coordinator
+func (b *Broker) ListTransactions(req *ListTransactionsRequest) (*ListTransactionsResponse, error) {
+	res := new(ListTransactionsResponse)
+
+	err := b.sendAndReceive(req, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
 // DescribeClientQuotas sends a request to get the broker's quotas
 func (b *Broker) DescribeClientQuotas(request *DescribeClientQuotasRequest) (*DescribeClientQuotasResponse, error) {
 	response := new(DescribeClientQuotasResponse)

--- a/encoder_decoder_fuzz_test.go
+++ b/encoder_decoder_fuzz_test.go
@@ -66,6 +66,8 @@ func FuzzVersionedDecodeRequest(f *testing.F) {
 		{key: apiKeyUpdateFeatures, version: 0, body: updateFeaturesRequestV0},
 		{key: apiKeyDescribeProducers, version: 0, body: describeProducersRequestV0},
 		{key: apiKeyDescribeTransactions, version: 0, body: describeTransactionsRequestV0},
+		{key: apiKeyListTransactions, version: 0, body: listTransactionsRequestV0},
+		{key: apiKeyListTransactions, version: 1, body: listTransactionsRequestV1},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}
@@ -123,6 +125,7 @@ func FuzzVersionedDecodeResponse(f *testing.F) {
 		{key: apiKeyUpdateFeatures, version: 0, body: updateFeaturesResponseV0},
 		{key: apiKeyDescribeProducers, version: 0, body: describeProducersResponseV0},
 		{key: apiKeyDescribeTransactions, version: 0, body: describeTransactionsResponseV0},
+		{key: apiKeyListTransactions, version: 0, body: listTransactionsResponseV0},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}

--- a/functional_list_transactions_test.go
+++ b/functional_list_transactions_test.go
@@ -1,0 +1,47 @@
+//go:build functional
+
+package sarama
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFuncListTransactions(t *testing.T) {
+	checkKafkaVersion(t, "3.0.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	config := NewFunctionalTestConfig()
+	config.Producer.Idempotent = true
+	config.Producer.Transaction.ID = "TestFuncListTransactions"
+	config.Producer.RequiredAcks = WaitForAll
+	config.Producer.Return.Successes = true
+	config.Net.MaxOpenRequests = 1
+
+	client, err := NewClient(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer safeClose(t, client)
+
+	// a transactional producer registers its transactional id with the
+	// transaction coordinator on startup via InitProducerId
+	producer, err := NewAsyncProducerFromClient(client)
+	require.NoError(t, err)
+	defer safeClose(t, producer)
+
+	coordinator, err := client.TransactionCoordinator(config.Producer.Transaction.ID)
+	require.NoError(t, err)
+
+	res, err := coordinator.ListTransactions(&ListTransactionsRequest{})
+	require.NoError(t, err)
+	require.Equal(t, ErrNoError, res.ErrorCode)
+	assert.Empty(t, res.UnknownStateFilters)
+
+	ids := make([]string, 0, len(res.TransactionStates))
+	for _, state := range res.TransactionStates {
+		ids = append(ids, state.TransactionalID)
+	}
+	assert.Contains(t, ids, config.Producer.Transaction.ID)
+}

--- a/list_transactions_request.go
+++ b/list_transactions_request.go
@@ -1,0 +1,108 @@
+package sarama
+
+// Transaction states as reported by the transaction coordinator, valid for
+// use in ListTransactionsRequest.StateFilters
+const (
+	TransactionStateEmpty             = "Empty"
+	TransactionStateOngoing           = "Ongoing"
+	TransactionStatePrepareCommit     = "PrepareCommit"
+	TransactionStatePrepareAbort      = "PrepareAbort"
+	TransactionStateCompleteCommit    = "CompleteCommit"
+	TransactionStateCompleteAbort     = "CompleteAbort"
+	TransactionStateDead              = "Dead"
+	TransactionStatePrepareEpochFence = "PrepareEpochFence"
+)
+
+type ListTransactionsRequest struct {
+	Version int16
+
+	// StateFilters is the set of transaction states to filter by: if empty,
+	// all transactions are returned; otherwise, only transactions matching
+	// one of the filtered states are returned
+	StateFilters []string
+
+	// ProducerIDFilters is the set of producer ids to filter by: if empty,
+	// all transactions are returned; otherwise, only transactions matching
+	// one of the filtered producer ids are returned
+	ProducerIDFilters []int64
+
+	// DurationFilter is the duration in milliseconds to filter by: if less
+	// than 0, all transactions are returned; otherwise, only transactions
+	// running longer than this duration are returned (v1+)
+	DurationFilter int64
+}
+
+func (r *ListTransactionsRequest) setVersion(v int16) {
+	r.Version = v
+}
+
+func (r *ListTransactionsRequest) encode(pe packetEncoder) error {
+	if err := pe.putStringArray(r.StateFilters); err != nil {
+		return err
+	}
+
+	if err := pe.putInt64Array(r.ProducerIDFilters); err != nil {
+		return err
+	}
+
+	if r.Version >= 1 {
+		pe.putInt64(r.DurationFilter)
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *ListTransactionsRequest) decode(pd packetDecoder, version int16) (err error) {
+	if r.StateFilters, err = pd.getStringArray(); err != nil {
+		return err
+	}
+
+	if r.ProducerIDFilters, err = pd.getInt64Array(); err != nil {
+		return err
+	}
+
+	if version >= 1 {
+		if r.DurationFilter, err = pd.getInt64(); err != nil {
+			return err
+		}
+	} else {
+		r.DurationFilter = -1
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *ListTransactionsRequest) key() int16 {
+	return apiKeyListTransactions
+}
+
+func (r *ListTransactionsRequest) version() int16 {
+	return r.Version
+}
+
+func (r *ListTransactionsRequest) headerVersion() int16 {
+	return 2
+}
+
+func (r *ListTransactionsRequest) isValidVersion() bool {
+	return r.Version >= 0 && r.Version <= 1
+}
+
+func (r *ListTransactionsRequest) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *ListTransactionsRequest) isFlexibleVersion(version int16) bool {
+	return version >= 0
+}
+
+func (r *ListTransactionsRequest) requiredVersion() KafkaVersion {
+	switch r.Version {
+	case 1:
+		return V3_8_0_0
+	default:
+		return V3_0_0_0
+	}
+}

--- a/list_transactions_request_test.go
+++ b/list_transactions_request_test.go
@@ -1,0 +1,39 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+)
+
+var listTransactionsRequestV0 = []byte{
+	2,                                    // StateFilters (one element array)
+	8, 'O', 'n', 'g', 'o', 'i', 'n', 'g', // state filter
+	2,                        // ProducerIdFilters (one element array)
+	0, 0, 0, 0, 0, 0, 3, 232, // producer id filter
+	0, // empty tagged fields
+}
+
+var listTransactionsRequestV1 = []byte{
+	2,                                    // StateFilters (one element array)
+	8, 'O', 'n', 'g', 'o', 'i', 'n', 'g', // state filter
+	2,                        // ProducerIdFilters (one element array)
+	0, 0, 0, 0, 0, 0, 3, 232, // producer id filter
+	0, 0, 0, 0, 0, 0, 0, 100, // duration filter ms
+	0, // empty tagged fields
+}
+
+func TestListTransactionsRequest(t *testing.T) {
+	request := &ListTransactionsRequest{
+		Version:           0,
+		StateFilters:      []string{TransactionStateOngoing},
+		ProducerIDFilters: []int64{1000},
+		DurationFilter:    -1,
+	}
+
+	testRequest(t, "v0", request, listTransactionsRequestV0)
+
+	request.Version = 1
+	request.DurationFilter = 100
+	testRequest(t, "v1", request, listTransactionsRequestV1)
+}

--- a/list_transactions_response.go
+++ b/list_transactions_response.go
@@ -1,0 +1,158 @@
+package sarama
+
+import "time"
+
+type ListTransactionsResponse struct {
+	Version int16
+
+	ThrottleTime time.Duration
+
+	ErrorCode KError
+
+	// UnknownStateFilters is the set of state filters provided in the request
+	// which were unknown to the transaction coordinator
+	UnknownStateFilters []string
+
+	// TransactionStates contains the current state of each matched transaction
+	TransactionStates []ListTransactionsResponseTransactionState
+}
+
+func (r *ListTransactionsResponse) setVersion(v int16) {
+	r.Version = v
+}
+
+type ListTransactionsResponseTransactionState struct {
+	// TransactionalID is the transactional id
+	TransactionalID string
+
+	// ProducerID is the producer id
+	ProducerID int64
+
+	// TransactionState is the current transaction state of the producer
+	TransactionState string
+}
+
+func (s *ListTransactionsResponseTransactionState) encode(pe packetEncoder) error {
+	if err := pe.putString(s.TransactionalID); err != nil {
+		return err
+	}
+
+	pe.putInt64(s.ProducerID)
+
+	if err := pe.putString(s.TransactionState); err != nil {
+		return err
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (s *ListTransactionsResponseTransactionState) decode(pd packetDecoder, version int16) (err error) {
+	if s.TransactionalID, err = pd.getString(); err != nil {
+		return err
+	}
+
+	if s.ProducerID, err = pd.getInt64(); err != nil {
+		return err
+	}
+
+	if s.TransactionState, err = pd.getString(); err != nil {
+		return err
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *ListTransactionsResponse) encode(pe packetEncoder) error {
+	pe.putDurationMs(r.ThrottleTime)
+
+	pe.putKError(r.ErrorCode)
+
+	if err := pe.putStringArray(r.UnknownStateFilters); err != nil {
+		return err
+	}
+
+	if err := pe.putArrayLength(len(r.TransactionStates)); err != nil {
+		return err
+	}
+	for i := range r.TransactionStates {
+		if err := r.TransactionStates[i].encode(pe); err != nil {
+			return err
+		}
+	}
+
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *ListTransactionsResponse) decode(pd packetDecoder, version int16) (err error) {
+	r.Version = version
+
+	if r.ThrottleTime, err = pd.getDurationMs(); err != nil {
+		return err
+	}
+
+	if r.ErrorCode, err = pd.getKError(); err != nil {
+		return err
+	}
+
+	if r.UnknownStateFilters, err = pd.getStringArray(); err != nil {
+		return err
+	}
+
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+
+	r.TransactionStates = make([]ListTransactionsResponseTransactionState, n)
+	for i := range n {
+		if err := r.TransactionStates[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *ListTransactionsResponse) key() int16 {
+	return apiKeyListTransactions
+}
+
+func (r *ListTransactionsResponse) version() int16 {
+	return r.Version
+}
+
+func (r *ListTransactionsResponse) headerVersion() int16 {
+	return 1
+}
+
+func (r *ListTransactionsResponse) isValidVersion() bool {
+	return r.Version >= 0 && r.Version <= 1
+}
+
+func (r *ListTransactionsResponse) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *ListTransactionsResponse) isFlexibleVersion(version int16) bool {
+	return version >= 0
+}
+
+func (r *ListTransactionsResponse) requiredVersion() KafkaVersion {
+	switch r.Version {
+	case 1:
+		return V3_8_0_0
+	default:
+		return V3_0_0_0
+	}
+}
+
+func (r *ListTransactionsResponse) throttleTime() time.Duration {
+	return r.ThrottleTime
+}

--- a/list_transactions_response_test.go
+++ b/list_transactions_response_test.go
@@ -1,0 +1,43 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+	"time"
+)
+
+// v1 has the same wire format as v0
+var listTransactionsResponseV0 = []byte{
+	0, 0, 0, 100, // throttleTimeMs
+	0, 0, // error code
+	2,                // UnknownStateFilters (one element array)
+	4, 'f', 'o', 'o', // unknown state filter
+	2,                // TransactionStates (one element array)
+	4, 't', 'x', 'n', // transactional id
+	0, 0, 0, 0, 0, 0, 3, 232, // producer id
+	8, 'O', 'n', 'g', 'o', 'i', 'n', 'g', // transaction state
+	0, // empty tagged fields
+	0, // empty tagged fields
+}
+
+func TestListTransactionsResponse(t *testing.T) {
+	response := &ListTransactionsResponse{
+		Version:             0,
+		ThrottleTime:        100 * time.Millisecond,
+		ErrorCode:           ErrNoError,
+		UnknownStateFilters: []string{"foo"},
+		TransactionStates: []ListTransactionsResponseTransactionState{
+			{
+				TransactionalID:  "txn",
+				ProducerID:       1000,
+				TransactionState: TransactionStateOngoing,
+			},
+		},
+	}
+
+	testResponse(t, "v0", response, listTransactionsResponseV0)
+
+	response.Version = 1
+	testResponse(t, "v1", response, listTransactionsResponseV0)
+}

--- a/prep_encoder.go
+++ b/prep_encoder.go
@@ -257,6 +257,12 @@ func (pe *prepFlexibleEncoder) putNullableInt32Array(in []int32) error {
 	return nil
 }
 
+func (pe *prepFlexibleEncoder) putInt64Array(in []int64) error {
+	pe.putUVarint(uint64(len(in)) + 1)
+	pe.length += 8 * len(in)
+	return nil
+}
+
 func (pe *prepFlexibleEncoder) putEmptyTaggedFieldArray() {
 	pe.putUVarint(0)
 }

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -577,6 +577,40 @@ func (rd *realFlexibleDecoder) getNullableInt32Array() ([]int32, error) {
 	return ret, nil
 }
 
+func (rd *realFlexibleDecoder) getInt64Array() ([]int64, error) {
+	ret, err := rd.getNullableInt64Array()
+	if ret == nil && err == nil {
+		return nil, errInvalidArrayLength
+	}
+	return ret, err
+}
+
+func (rd *realFlexibleDecoder) getNullableInt64Array() ([]int64, error) {
+	n, err := rd.getUVarint()
+	if err != nil {
+		return nil, err
+	}
+
+	if n == 0 {
+		return nil, nil
+	}
+
+	arrayLength := n - 1
+
+	if uint64(rd.remaining()/8) < arrayLength { //nolint:gosec // G115 - remaining() is non-negative
+		rd.off = len(rd.raw)
+		return nil, ErrInsufficientData
+	}
+
+	ret := make([]int64, int(arrayLength)) //nolint:gosec // G115 - value bounded by remaining() above
+
+	for i := range ret {
+		ret[i] = int64(binary.BigEndian.Uint64(rd.raw[rd.off:]))
+		rd.off += 8
+	}
+	return ret, nil
+}
+
 func (rd *realFlexibleDecoder) getStringArray() ([]string, error) {
 	n, err := rd.getArrayLength()
 	if err != nil {

--- a/real_decoder_test.go
+++ b/real_decoder_test.go
@@ -130,53 +130,14 @@ func TestRealDecoderGetNullableInt32Array(t *testing.T) {
 	}
 }
 
+// getInt32Array only diverges from getNullableInt32Array on null input
 func TestRealDecoderGetInt32Array(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   []byte
-		want    []int32
-		wantErr error
-	}{
-		{
-			name:    "null array",
-			input:   []byte{0xFF, 0xFF, 0xFF, 0xFF},
-			wantErr: errInvalidArrayLength,
-		},
-		{
-			name:  "empty array",
-			input: []byte{0x00, 0x00, 0x00, 0x00},
-			want:  []int32{},
-		},
-		{
-			name:  "valid array",
-			input: []byte{0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02},
-			want:  []int32{1, 2},
-		},
-		{
-			name:    "insufficient data for length",
-			input:   []byte{0x00, 0x00, 0x00},
-			wantErr: ErrInsufficientData,
-		},
-		{
-			name:    "insufficient data for elements",
-			input:   []byte{0x00, 0x00, 0x00, 0x02},
-			wantErr: ErrInsufficientData,
-		},
-		{
-			name:    "invalid length",
-			input:   []byte{0x80, 0x00, 0x00, 0x00},
-			wantErr: errInvalidArrayLength,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rd := &realDecoder{raw: tt.input}
-			got, err := rd.getInt32Array()
-			require.ErrorIs(t, err, tt.wantErr)
-			assert.Equal(t, tt.want, got)
-		})
-	}
+	t.Run("returns errInvalidArrayLength for null array", func(t *testing.T) {
+		rd := &realDecoder{raw: []byte{0xFF, 0xFF, 0xFF, 0xFF}}
+		got, err := rd.getInt32Array()
+		require.ErrorIs(t, err, errInvalidArrayLength)
+		assert.Nil(t, got)
+	})
 }
 
 func TestRealFlexibleDecoderGetNullableInt32Array(t *testing.T) {
@@ -215,30 +176,52 @@ func TestRealFlexibleDecoderGetNullableInt32Array(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+	t.Run("returns insufficient data for compact length exceeding int64", func(t *testing.T) {
+		var input [binary.MaxVarintLen64]byte
+		n := binary.PutUvarint(input[:], 1<<63)
+
+		rd := &realFlexibleDecoder{&realDecoder{raw: input[:n]}}
+		array, err := rd.getNullableInt32Array()
+
+		require.ErrorIs(t, err, ErrInsufficientData)
+		assert.Nil(t, array)
+	})
 }
 
+// getInt32Array only diverges from getNullableInt32Array on null input
 func TestRealFlexibleDecoderGetInt32Array(t *testing.T) {
+	t.Run("returns errInvalidArrayLength for null array", func(t *testing.T) {
+		rd := &realFlexibleDecoder{&realDecoder{raw: []byte{0x00}}}
+		got, err := rd.getInt32Array()
+		require.ErrorIs(t, err, errInvalidArrayLength)
+		assert.Nil(t, got)
+	})
+}
+
+func TestRealFlexibleDecoderGetNullableInt64Array(t *testing.T) {
 	tests := []struct {
 		name    string
 		input   []byte
-		want    []int32
+		want    []int64
 		wantErr error
 	}{
 		{
-			name:    "null array",
-			input:   []byte{0x00},
-			wantErr: errInvalidArrayLength,
+			name:  "null array",
+			input: []byte{0x00},
 		},
 		{
 			name:  "empty array",
 			input: []byte{0x01},
-			want:  []int32{},
+			want:  []int64{},
 		},
 		{
-			name:    "valid array",
-			input:   []byte{0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02},
-			want:    []int32{1, 2},
-			wantErr: nil,
+			name: "valid array",
+			input: []byte{
+				0x03,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+			},
+			want: []int64{1, 2},
 		},
 		{
 			name:    "insufficient data",
@@ -250,7 +233,7 @@ func TestRealFlexibleDecoderGetInt32Array(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			rd := &realFlexibleDecoder{&realDecoder{raw: tt.input}}
-			got, err := rd.getInt32Array()
+			got, err := rd.getNullableInt64Array()
 			require.ErrorIs(t, err, tt.wantErr)
 			assert.Equal(t, tt.want, got)
 		})
@@ -260,9 +243,19 @@ func TestRealFlexibleDecoderGetInt32Array(t *testing.T) {
 		n := binary.PutUvarint(input[:], 1<<63)
 
 		rd := &realFlexibleDecoder{&realDecoder{raw: input[:n]}}
-		array, err := rd.getInt32Array()
+		array, err := rd.getNullableInt64Array()
 
 		require.ErrorIs(t, err, ErrInsufficientData)
 		assert.Nil(t, array)
+	})
+}
+
+// getInt64Array only diverges from getNullableInt64Array on null input
+func TestRealFlexibleDecoderGetInt64Array(t *testing.T) {
+	t.Run("returns errInvalidArrayLength for null array", func(t *testing.T) {
+		rd := &realFlexibleDecoder{&realDecoder{raw: []byte{0x00}}}
+		got, err := rd.getInt64Array()
+		require.ErrorIs(t, err, errInvalidArrayLength)
+		assert.Nil(t, got)
 	})
 }

--- a/real_encoder.go
+++ b/real_encoder.go
@@ -267,6 +267,15 @@ func (re *realFlexibleEncoder) putNullableInt32Array(in []int32) error {
 	return nil
 }
 
+func (re *realFlexibleEncoder) putInt64Array(in []int64) error {
+	// 0 represents a null array, so +1 has to be added
+	re.putUVarint(uint64(len(in)) + 1)
+	for _, val := range in {
+		re.putInt64(val)
+	}
+	return nil
+}
+
 func (re *realFlexibleEncoder) putEmptyTaggedFieldArray() {
 	re.putUVarint(0)
 }

--- a/request.go
+++ b/request.go
@@ -236,7 +236,8 @@ func allocateBody(key, version int16) protocolBody {
 		// 64: UnregisterBrokerRequest
 	case apiKeyDescribeTransactions:
 		return &DescribeTransactionsRequest{Version: version}
-		// 66: ListTransactionsRequest
+	case apiKeyListTransactions:
+		return &ListTransactionsRequest{Version: version}
 		// 67: AllocateProducerIdsRequest
 		// 68: ConsumerGroupHeartbeatRequest
 	}
@@ -342,6 +343,8 @@ func allocateResponseBody(key, version int16) protocolBody {
 		return &DescribeProducersResponse{Version: version}
 	case apiKeyDescribeTransactions:
 		return &DescribeTransactionsResponse{Version: version}
+	case apiKeyListTransactions:
+		return &ListTransactionsResponse{Version: version}
 	}
 	return nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -80,7 +80,7 @@ var names = map[int16]string{
 	63:                                 "BrokerHeartbeatRequest",
 	64:                                 "UnregisterBrokerRequest",
 	apiKeyDescribeTransactions:         "DescribeTransactionsRequest",
-	66:                                 "ListTransactionsRequest",
+	apiKeyListTransactions:             "ListTransactionsRequest",
 	67:                                 "AllocateProducerIdsRequest",
 	68:                                 "ConsumerGroupHeartbeatRequest",
 }
@@ -345,6 +345,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 			map[int16]int16{
 				apiKeyOffsetFetch:          8, // up from 7
 				apiKeyDescribeTransactions: 0, // new in 3.0
+				apiKeyListTransactions:     0, // new in 3.0
 				// TODO: ListOffsetsRequest v7 is not supported, but expected for KafkaVersion 3.0.0
 				// apiKeyListOffsets:     7, // up from 6
 				// TODO: FindCoordinatorRequest v4 is not supported, but expected for KafkaVersion 3.0.0
@@ -418,7 +419,8 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V3_8_0_0,
 			map[int16]int16{
-				apiKeyListGroups: 5, // up from 4
+				apiKeyListGroups:       5, // up from 4
+				apiKeyListTransactions: 1, // up from 0
 				// TODO: ProduceRequest v11 is not supported, but expected for KafkaVersion 3.8.0
 				// apiKeyProduce:            11, // up from 10
 				// TODO: FindCoordinatorRequest v5 is not supported, but expected for KafkaVersion 3.8.0
@@ -541,6 +543,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDescribeCluster:              maxVersion(&DescribeClusterRequest{}),
 				apiKeyDescribeProducers:            maxVersion(&DescribeProducersRequest{}),
 				apiKeyDescribeTransactions:         maxVersion(&DescribeTransactionsRequest{}),
+				apiKeyListTransactions:             maxVersion(&ListTransactionsRequest{}),
 			},
 		},
 	}


### PR DESCRIPTION
Add the ListTransactions API (key 66, KIP-664, Kafka 3.0.0) and its v1 duration filter (KIP-994, Kafka 3.8.0):

- add ListTransactionsRequest/Response with flexible v0 encoding
- add v1 DurationFilter, defaulted to -1 (no filter) on v0 decode
- add TransactionState constants for use in StateFilters
- add Broker.ListTransactions helper
- add unit test fixtures and a functional test against the transaction coordinator

KIP-664: https://cwiki.apache.org/confluence/display/KAFKA/KIP-664%3A+Provide+tooling+to+detect+and+abort+hanging+transactions
KIP-994: https://cwiki.apache.org/confluence/display/KAFKA/KIP-994%3A+Minor+Enhancements+to+ListTransactions+and+DescribeTransactions+APIs

Contributes-to: #3655