### PR TITLE
feat: more flexible protocols for kafka28 parity

### DIFF
--- a/add_offsets_to_txn_request.go
+++ b/add_offsets_to_txn_request.go
@@ -26,10 +26,13 @@ func (a *AddOffsetsToTxnRequest) encode(pe packetEncoder) error {
 		return err
 	}
 
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
 func (a *AddOffsetsToTxnRequest) decode(pd packetDecoder, version int16) (err error) {
+	a.Version = version
 	if a.TransactionalID, err = pd.getString(); err != nil {
 		return err
 	}
@@ -40,6 +43,9 @@ func (a *AddOffsetsToTxnRequest) decode(pd packetDecoder, version int16) (err er
 		return err
 	}
 	if a.GroupID, err = pd.getString(); err != nil {
+		return err
+	}
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
 		return err
 	}
 	return nil
@@ -54,15 +60,28 @@ func (a *AddOffsetsToTxnRequest) version() int16 {
 }
 
 func (a *AddOffsetsToTxnRequest) headerVersion() int16 {
+	if a.Version >= 3 {
+		return 2
+	}
 	return 1
 }
 
 func (a *AddOffsetsToTxnRequest) isValidVersion() bool {
-	return a.Version >= 0 && a.Version <= 2
+	return a.Version >= 0 && a.Version <= 3
+}
+
+func (a *AddOffsetsToTxnRequest) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *AddOffsetsToTxnRequest) isFlexibleVersion(version int16) bool {
+	return version >= 3
 }
 
 func (a *AddOffsetsToTxnRequest) requiredVersion() KafkaVersion {
 	switch a.Version {
+	case 3:
+		return V2_8_0_0
 	case 2:
 		return V2_7_0_0
 	case 1:
@@ -70,6 +89,6 @@ func (a *AddOffsetsToTxnRequest) requiredVersion() KafkaVersion {
 	case 0:
 		return V0_11_0_0
 	default:
-		return V2_7_0_0
+		return V2_8_0_0
 	}
 }

--- a/add_offsets_to_txn_request_test.go
+++ b/add_offsets_to_txn_request_test.go
@@ -4,12 +4,22 @@ package sarama
 
 import "testing"
 
-var addOffsetsToTxnRequest = []byte{
-	0, 3, 't', 'x', 'n',
-	0, 0, 0, 0, 0, 0, 31, 64,
-	0, 0,
-	0, 7, 'g', 'r', 'o', 'u', 'p', 'i', 'd',
-}
+var (
+	addOffsetsToTxnRequest = []byte{
+		0, 3, 't', 'x', 'n',
+		0, 0, 0, 0, 0, 0, 31, 64,
+		0, 0,
+		0, 7, 'g', 'r', 'o', 'u', 'p', 'i', 'd',
+	}
+
+	addOffsetsToTxnRequestV3 = []byte{
+		4, 't', 'x', 'n', // TransactionalId
+		0, 0, 0, 0, 0, 0, 31, 64, // ProducerId
+		0, 0, // ProducerEpoch
+		8, 'g', 'r', 'o', 'u', 'p', 'i', 'd', // GroupId
+		0, // tagged fields
+	}
+)
 
 func TestAddOffsetsToTxnRequest(t *testing.T) {
 	req := &AddOffsetsToTxnRequest{
@@ -19,5 +29,8 @@ func TestAddOffsetsToTxnRequest(t *testing.T) {
 		GroupID:         "groupid",
 	}
 
-	testRequest(t, "", req, addOffsetsToTxnRequest)
+	testRequest(t, "v0", req, addOffsetsToTxnRequest)
+
+	req.Version = 3
+	testRequest(t, "v3", req, addOffsetsToTxnRequestV3)
 }

--- a/add_offsets_to_txn_response.go
+++ b/add_offsets_to_txn_response.go
@@ -18,16 +18,22 @@ func (a *AddOffsetsToTxnResponse) setVersion(v int16) {
 func (a *AddOffsetsToTxnResponse) encode(pe packetEncoder) error {
 	pe.putDurationMs(a.ThrottleTime)
 	pe.putKError(a.Err)
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
 func (a *AddOffsetsToTxnResponse) decode(pd packetDecoder, version int16) (err error) {
+	a.Version = version
 	if a.ThrottleTime, err = pd.getDurationMs(); err != nil {
 		return err
 	}
 
 	a.Err, err = pd.getKError()
 	if err != nil {
+		return err
+	}
+
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
 		return err
 	}
 
@@ -43,15 +49,28 @@ func (a *AddOffsetsToTxnResponse) version() int16 {
 }
 
 func (a *AddOffsetsToTxnResponse) headerVersion() int16 {
+	if a.Version >= 3 {
+		return 1
+	}
 	return 0
 }
 
 func (a *AddOffsetsToTxnResponse) isValidVersion() bool {
-	return a.Version >= 0 && a.Version <= 2
+	return a.Version >= 0 && a.Version <= 3
+}
+
+func (a *AddOffsetsToTxnResponse) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *AddOffsetsToTxnResponse) isFlexibleVersion(version int16) bool {
+	return version >= 3
 }
 
 func (a *AddOffsetsToTxnResponse) requiredVersion() KafkaVersion {
 	switch a.Version {
+	case 3:
+		return V2_8_0_0
 	case 2:
 		return V2_7_0_0
 	case 1:
@@ -59,7 +78,7 @@ func (a *AddOffsetsToTxnResponse) requiredVersion() KafkaVersion {
 	case 0:
 		return V0_11_0_0
 	default:
-		return V2_7_0_0
+		return V2_8_0_0
 	}
 }
 

--- a/add_offsets_to_txn_response_test.go
+++ b/add_offsets_to_txn_response_test.go
@@ -7,10 +7,18 @@ import (
 	"time"
 )
 
-var addOffsetsToTxnResponse = []byte{
-	0, 0, 0, 100,
-	0, 47,
-}
+var (
+	addOffsetsToTxnResponse = []byte{
+		0, 0, 0, 100,
+		0, 47,
+	}
+
+	addOffsetsToTxnResponseV3 = []byte{
+		0, 0, 0, 100, // ThrottleTimeMs
+		0, 47, // ErrorCode
+		0, // tagged fields
+	}
+)
 
 func TestAddOffsetsToTxnResponse(t *testing.T) {
 	resp := &AddOffsetsToTxnResponse{
@@ -18,5 +26,8 @@ func TestAddOffsetsToTxnResponse(t *testing.T) {
 		Err:          ErrInvalidProducerEpoch,
 	}
 
-	testResponse(t, "", resp, addOffsetsToTxnResponse)
+	testResponse(t, "v0", resp, addOffsetsToTxnResponse)
+
+	resp.Version = 3
+	testResponse(t, "v3", resp, addOffsetsToTxnResponseV3)
 }

--- a/admin.go
+++ b/admin.go
@@ -965,7 +965,10 @@ func (ca *clusterAdmin) AlterConfig(resourceType ConfigResourceType, name string
 		Resources:    resources,
 		ValidateOnly: validateOnly,
 	}
-	if ca.conf.Version.IsAtLeast(V2_0_0_0) {
+	if ca.conf.Version.IsAtLeast(V2_8_0_0) {
+		// Version 2 enables flexible versions.
+		request.Version = 2
+	} else if ca.conf.Version.IsAtLeast(V2_0_0_0) {
 		request.Version = 1
 	}
 

--- a/admin.go
+++ b/admin.go
@@ -1700,6 +1700,10 @@ func (ca *clusterAdmin) AlterClientQuotas(entity []QuotaEntityComponent, op Clie
 		Entries:      []AlterClientQuotasEntry{entry},
 		ValidateOnly: validateOnly,
 	}
+	if ca.conf.Version.IsAtLeast(V2_8_0_0) {
+		// Version 1 enables flexible versions.
+		request.Version = 1
+	}
 
 	b, err := ca.Controller()
 	if err != nil {

--- a/alter_client_quotas_request.go
+++ b/alter_client_quotas_request.go
@@ -46,10 +46,13 @@ func (a *AlterClientQuotasRequest) encode(pe packetEncoder) error {
 	// ValidateOnly
 	pe.putBool(a.ValidateOnly)
 
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
 func (a *AlterClientQuotasRequest) decode(pd packetDecoder, version int16) error {
+	a.Version = version
 	// Entries
 	entryCount, err := pd.getArrayLength()
 	if err != nil {
@@ -78,6 +81,10 @@ func (a *AlterClientQuotasRequest) decode(pd packetDecoder, version int16) error
 	}
 	a.ValidateOnly = validateOnly
 
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -101,6 +108,8 @@ func (a *AlterClientQuotasEntry) encode(pe packetEncoder) error {
 			return err
 		}
 	}
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -148,6 +157,10 @@ func (a *AlterClientQuotasEntry) decode(pd packetDecoder, version int16) error {
 		a.Ops = []ClientQuotasOp{}
 	}
 
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -162,6 +175,8 @@ func (c *ClientQuotasOp) encode(pe packetEncoder) error {
 
 	// Remove
 	pe.putBool(c.Remove)
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -188,6 +203,10 @@ func (c *ClientQuotasOp) decode(pd packetDecoder, version int16) error {
 	}
 	c.Remove = remove
 
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -200,13 +219,29 @@ func (a *AlterClientQuotasRequest) version() int16 {
 }
 
 func (a *AlterClientQuotasRequest) headerVersion() int16 {
+	if a.Version >= 1 {
+		return 2
+	}
 	return 1
 }
 
 func (a *AlterClientQuotasRequest) isValidVersion() bool {
-	return a.Version == 0
+	return a.Version >= 0 && a.Version <= 1
+}
+
+func (a *AlterClientQuotasRequest) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *AlterClientQuotasRequest) isFlexibleVersion(version int16) bool {
+	return version >= 1
 }
 
 func (a *AlterClientQuotasRequest) requiredVersion() KafkaVersion {
-	return V2_6_0_0
+	switch a.Version {
+	case 1:
+		return V2_8_0_0
+	default:
+		return V2_6_0_0
+	}
 }

--- a/alter_client_quotas_request_test.go
+++ b/alter_client_quotas_request_test.go
@@ -17,6 +17,22 @@ var (
 		0, // validate only
 	}
 
+	alterClientQuotasRequestSingleOpV1 = []byte{
+		2,                     // Entries
+		2,                     // Entity
+		5, 'u', 's', 'e', 'r', // EntityType
+		0,                                                                                            // EntityName
+		0,                                                                                            // tagged fields (entity)
+		2,                                                                                            // Ops
+		19, 'p', 'r', 'o', 'd', 'u', 'c', 'e', 'r', '_', 'b', 'y', 't', 'e', '_', 'r', 'a', 't', 'e', // Key
+		65, 46, 132, 128, 0, 0, 0, 0, // Value
+		0, // Remove
+		0, // tagged fields (op)
+		0, // tagged fields (entry)
+		0, // ValidateOnly
+		0, // tagged fields
+	}
+
 	alterClientQuotasRequestRemoveSingleOp = []byte{
 		0, 0, 0, 1, // entries len
 		0, 0, 0, 1, // entity len
@@ -92,6 +108,9 @@ func TestAlterClientQuotasRequest(t *testing.T) {
 		ValidateOnly: false,
 	}
 	testRequest(t, "Add single Quota op", req, alterClientQuotasRequestSingleOp)
+
+	req.Version = 1
+	testRequest(t, "Add single Quota op v1", req, alterClientQuotasRequestSingleOpV1)
 
 	// Remove Quota from default user
 	op = ClientQuotasOp{

--- a/alter_client_quotas_response.go
+++ b/alter_client_quotas_response.go
@@ -42,10 +42,13 @@ func (a *AlterClientQuotasResponse) encode(pe packetEncoder) error {
 		}
 	}
 
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
 func (a *AlterClientQuotasResponse) decode(pd packetDecoder, version int16) (err error) {
+	a.Version = version
 	if a.ThrottleTime, err = pd.getDurationMs(); err != nil {
 		return err
 	}
@@ -70,6 +73,10 @@ func (a *AlterClientQuotasResponse) decode(pd packetDecoder, version int16) (err
 		a.Entries = []AlterClientQuotasEntryResponse{}
 	}
 
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -91,6 +98,8 @@ func (a *AlterClientQuotasEntryResponse) encode(pe packetEncoder) error {
 			return err
 		}
 	}
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -127,6 +136,10 @@ func (a *AlterClientQuotasEntryResponse) decode(pd packetDecoder, version int16)
 		a.Entity = []QuotaEntityComponent{}
 	}
 
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -139,15 +152,31 @@ func (a *AlterClientQuotasResponse) version() int16 {
 }
 
 func (a *AlterClientQuotasResponse) headerVersion() int16 {
+	if a.Version >= 1 {
+		return 1
+	}
 	return 0
 }
 
 func (a *AlterClientQuotasResponse) isValidVersion() bool {
-	return a.Version == 0
+	return a.Version >= 0 && a.Version <= 1
+}
+
+func (a *AlterClientQuotasResponse) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *AlterClientQuotasResponse) isFlexibleVersion(version int16) bool {
+	return version >= 1
 }
 
 func (a *AlterClientQuotasResponse) requiredVersion() KafkaVersion {
-	return V2_6_0_0
+	switch a.Version {
+	case 1:
+		return V2_8_0_0
+	default:
+		return V2_6_0_0
+	}
 }
 
 func (r *AlterClientQuotasResponse) throttleTime() time.Duration {

--- a/alter_client_quotas_response_test.go
+++ b/alter_client_quotas_response_test.go
@@ -25,6 +25,19 @@ var (
 		255, 255, // entityName
 	}
 
+	alterClientQuotasResponseSingleEntryV1 = []byte{
+		0, 0, 0, 0, // ThrottleTime
+		2,    // Entries
+		0, 0, // ErrorCode
+		0,                     // ErrorMsg
+		2,                     // Entity
+		5, 'u', 's', 'e', 'r', // EntityType
+		0, // EntityName
+		0, // tagged fields (entity)
+		0, // tagged fields (entry)
+		0, // tagged fields
+	}
+
 	alterClientQuotasResponseMultipleEntries = []byte{
 		0, 0, 0, 0, // ThrottleTime
 		0, 0, 0, 2, // Entries len
@@ -80,6 +93,10 @@ func TestAlterClientQuotasResponse(t *testing.T) {
 		Entries:      []AlterClientQuotasEntryResponse{entry},
 	}
 	testResponse(t, "Altered single entry", res, alterClientQuotasResponseSingleEntry)
+
+	res.Version = 1
+	testResponse(t, "Altered single entry v1", res, alterClientQuotasResponseSingleEntryV1)
+	res.Version = 0
 
 	// Response Altered multiple entries
 	entry1 := AlterClientQuotasEntryResponse{

--- a/alter_configs_request.go
+++ b/alter_configs_request.go
@@ -30,10 +30,14 @@ func (a *AlterConfigsRequest) encode(pe packetEncoder) error {
 	}
 
 	pe.putBool(a.ValidateOnly)
+
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
 func (a *AlterConfigsRequest) decode(pd packetDecoder, version int16) error {
+	a.Version = version
 	resourceCount, err := pd.getArrayLength()
 	if err != nil {
 		return err
@@ -59,6 +63,10 @@ func (a *AlterConfigsRequest) decode(pd packetDecoder, version int16) error {
 
 	a.ValidateOnly = validateOnly
 
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -80,6 +88,8 @@ func (a *AlterConfigsResource) encode(pe packetEncoder) error {
 			return err
 		}
 	}
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -117,6 +127,11 @@ func (a *AlterConfigsResource) decode(pd packetDecoder, version int16) error {
 			}
 		}
 	}
+
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return err
 }
 
@@ -129,20 +144,33 @@ func (a *AlterConfigsRequest) version() int16 {
 }
 
 func (a *AlterConfigsRequest) headerVersion() int16 {
+	if a.Version >= 2 {
+		return 2
+	}
 	return 1
 }
 
 func (a *AlterConfigsRequest) isValidVersion() bool {
-	return a.Version >= 0 && a.Version <= 1
+	return a.Version >= 0 && a.Version <= 2
+}
+
+func (a *AlterConfigsRequest) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *AlterConfigsRequest) isFlexibleVersion(version int16) bool {
+	return version >= 2
 }
 
 func (a *AlterConfigsRequest) requiredVersion() KafkaVersion {
 	switch a.Version {
+	case 2:
+		return V2_8_0_0
 	case 1:
 		return V2_0_0_0
 	case 0:
 		return V0_11_0_0
 	default:
-		return V2_0_0_0
+		return V2_8_0_0
 	}
 }

--- a/alter_configs_request_test.go
+++ b/alter_configs_request_test.go
@@ -22,6 +22,18 @@ var (
 		0, // don't validate
 	}
 
+	singleAlterConfigsRequestV2 = []byte{
+		2,                // Resources
+		2,                // ResourceType
+		4, 'f', 'o', 'o', // ResourceName
+		2,                                                    // Configs
+		11, 's', 'e', 'g', 'm', 'e', 'n', 't', '.', 'm', 's', // Name
+		5, '1', '0', '0', '0', // Value
+		0, // tagged fields (resource)
+		0, // ValidateOnly
+		0, // tagged fields
+	}
+
 	doubleAlterConfigsRequest = []byte{
 		0, 0, 0, 2, // 2 config
 		2,                   // a topic
@@ -64,6 +76,10 @@ func TestAlterConfigsRequest(t *testing.T) {
 	}
 
 	testRequest(t, "one config", request, singleAlterConfigsRequest)
+
+	request.Version = 2
+	testRequest(t, "one config v2", request, singleAlterConfigsRequestV2)
+	request.Version = 0
 
 	request = &AlterConfigsRequest{
 		Resources: []*AlterConfigsResource{

--- a/alter_configs_response.go
+++ b/alter_configs_response.go
@@ -54,10 +54,13 @@ func (a *AlterConfigsResponse) encode(pe packetEncoder) error {
 		}
 	}
 
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
 func (a *AlterConfigsResponse) decode(pd packetDecoder, version int16) (err error) {
+	a.Version = version
 	if a.ThrottleTime, err = pd.getDurationMs(); err != nil {
 		return err
 	}
@@ -78,6 +81,10 @@ func (a *AlterConfigsResponse) decode(pd packetDecoder, version int16) (err erro
 		if err := a.Resources[i].decode(pd, version); err != nil {
 			return err
 		}
+	}
+
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
 	}
 
 	return nil
@@ -140,21 +147,34 @@ func (a *AlterConfigsResponse) version() int16 {
 }
 
 func (a *AlterConfigsResponse) headerVersion() int16 {
+	if a.Version >= 2 {
+		return 1
+	}
 	return 0
 }
 
 func (a *AlterConfigsResponse) isValidVersion() bool {
-	return a.Version >= 0 && a.Version <= 1
+	return a.Version >= 0 && a.Version <= 2
+}
+
+func (a *AlterConfigsResponse) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *AlterConfigsResponse) isFlexibleVersion(version int16) bool {
+	return version >= 2
 }
 
 func (a *AlterConfigsResponse) requiredVersion() KafkaVersion {
 	switch a.Version {
+	case 2:
+		return V2_8_0_0
 	case 1:
 		return V2_0_0_0
 	case 0:
 		return V0_11_0_0
 	default:
-		return V2_0_0_0
+		return V2_8_0_0
 	}
 }
 

--- a/alter_configs_response_test.go
+++ b/alter_configs_response_test.go
@@ -21,6 +21,17 @@ var (
 		2, // topic
 		0, 3, 'f', 'o', 'o',
 	}
+
+	alterResponsePopulatedV2 = []byte{
+		0, 0, 0, 0, // ThrottleTimeMs
+		2,    // Responses
+		0, 0, // ErrorCode
+		1,                // ErrorMessage
+		2,                // ResourceType
+		4, 'f', 'o', 'o', // ResourceName
+		0, // tagged fields (resource)
+		0, // tagged fields
+	}
 )
 
 func TestAlterConfigsResponse(t *testing.T) {
@@ -45,6 +56,9 @@ func TestAlterConfigsResponse(t *testing.T) {
 		},
 	}
 	testResponse(t, "response with error", response, alterResponsePopulated)
+
+	response.Version = 2
+	testResponse(t, "response with error v2", response, alterResponsePopulatedV2)
 }
 
 func TestAlterConfigError(t *testing.T) {

--- a/end_txn_request.go
+++ b/end_txn_request.go
@@ -23,10 +23,13 @@ func (a *EndTxnRequest) encode(pe packetEncoder) error {
 
 	pe.putBool(a.TransactionResult)
 
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
 func (a *EndTxnRequest) decode(pd packetDecoder, version int16) (err error) {
+	a.Version = version
 	if a.TransactionalID, err = pd.getString(); err != nil {
 		return err
 	}
@@ -37,6 +40,9 @@ func (a *EndTxnRequest) decode(pd packetDecoder, version int16) (err error) {
 		return err
 	}
 	if a.TransactionResult, err = pd.getBool(); err != nil {
+		return err
+	}
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
 		return err
 	}
 	return nil
@@ -51,15 +57,28 @@ func (a *EndTxnRequest) version() int16 {
 }
 
 func (r *EndTxnRequest) headerVersion() int16 {
+	if r.Version >= 3 {
+		return 2
+	}
 	return 1
 }
 
 func (a *EndTxnRequest) isValidVersion() bool {
-	return a.Version >= 0 && a.Version <= 2
+	return a.Version >= 0 && a.Version <= 3
+}
+
+func (a *EndTxnRequest) isFlexible() bool {
+	return a.isFlexibleVersion(a.Version)
+}
+
+func (a *EndTxnRequest) isFlexibleVersion(version int16) bool {
+	return version >= 3
 }
 
 func (a *EndTxnRequest) requiredVersion() KafkaVersion {
 	switch a.Version {
+	case 3:
+		return V2_8_0_0
 	case 2:
 		return V2_7_0_0
 	case 1:

--- a/end_txn_request_test.go
+++ b/end_txn_request_test.go
@@ -4,12 +4,22 @@ package sarama
 
 import "testing"
 
-var endTxnRequest = []byte{
-	0, 3, 't', 'x', 'n',
-	0, 0, 0, 0, 0, 0, 31, 64,
-	0, 1,
-	1,
-}
+var (
+	endTxnRequest = []byte{
+		0, 3, 't', 'x', 'n',
+		0, 0, 0, 0, 0, 0, 31, 64,
+		0, 1,
+		1,
+	}
+
+	endTxnRequestV3 = []byte{
+		4, 't', 'x', 'n', // TransactionalId
+		0, 0, 0, 0, 0, 0, 31, 64, // ProducerId
+		0, 1, // ProducerEpoch
+		1, // Committed
+		0, // tagged fields
+	}
+)
 
 func TestEndTxnRequest(t *testing.T) {
 	req := &EndTxnRequest{
@@ -19,5 +29,8 @@ func TestEndTxnRequest(t *testing.T) {
 		TransactionResult: true,
 	}
 
-	testRequest(t, "", req, endTxnRequest)
+	testRequest(t, "v0", req, endTxnRequest)
+
+	req.Version = 3
+	testRequest(t, "v3", req, endTxnRequestV3)
 }

--- a/end_txn_response.go
+++ b/end_txn_response.go
@@ -17,16 +17,22 @@ func (e *EndTxnResponse) setVersion(v int16) {
 func (e *EndTxnResponse) encode(pe packetEncoder) error {
 	pe.putDurationMs(e.ThrottleTime)
 	pe.putKError(e.Err)
+	pe.putEmptyTaggedFieldArray()
 	return nil
 }
 
 func (e *EndTxnResponse) decode(pd packetDecoder, version int16) (err error) {
+	e.Version = version
 	if e.ThrottleTime, err = pd.getDurationMs(); err != nil {
 		return err
 	}
 
 	e.Err, err = pd.getKError()
 	if err != nil {
+		return err
+	}
+
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
 		return err
 	}
 
@@ -42,15 +48,28 @@ func (e *EndTxnResponse) version() int16 {
 }
 
 func (r *EndTxnResponse) headerVersion() int16 {
+	if r.Version >= 3 {
+		return 1
+	}
 	return 0
 }
 
 func (e *EndTxnResponse) isValidVersion() bool {
-	return e.Version >= 0 && e.Version <= 2
+	return e.Version >= 0 && e.Version <= 3
+}
+
+func (e *EndTxnResponse) isFlexible() bool {
+	return e.isFlexibleVersion(e.Version)
+}
+
+func (e *EndTxnResponse) isFlexibleVersion(version int16) bool {
+	return version >= 3
 }
 
 func (e *EndTxnResponse) requiredVersion() KafkaVersion {
 	switch e.Version {
+	case 3:
+		return V2_8_0_0
 	case 2:
 		return V2_7_0_0
 	case 1:

--- a/end_txn_response_test.go
+++ b/end_txn_response_test.go
@@ -7,10 +7,18 @@ import (
 	"time"
 )
 
-var endTxnResponse = []byte{
-	0, 0, 0, 100,
-	0, 49,
-}
+var (
+	endTxnResponse = []byte{
+		0, 0, 0, 100,
+		0, 49,
+	}
+
+	endTxnResponseV3 = []byte{
+		0, 0, 0, 100, // ThrottleTimeMs
+		0, 49, // ErrorCode
+		0, // tagged fields
+	}
+)
 
 func TestEndTxnResponse(t *testing.T) {
 	resp := &EndTxnResponse{
@@ -18,5 +26,8 @@ func TestEndTxnResponse(t *testing.T) {
 		Err:          ErrInvalidProducerIDMapping,
 	}
 
-	testResponse(t, "", resp, endTxnResponse)
+	testResponse(t, "v0", resp, endTxnResponse)
+
+	resp.Version = 3
+	testResponse(t, "v3", resp, endTxnResponseV3)
 }

--- a/offset_request.go
+++ b/offset_request.go
@@ -20,6 +20,8 @@ func (b *offsetRequestBlock) encode(pe packetEncoder, version int16) error {
 		pe.putInt32(b.maxNumOffsets)
 	}
 
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
@@ -41,6 +43,10 @@ func (b *offsetRequestBlock) decode(pd packetDecoder, version int16) (err error)
 		}
 	}
 
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -54,7 +60,10 @@ type OffsetRequest struct {
 
 func NewOffsetRequest(version KafkaVersion) *OffsetRequest {
 	request := &OffsetRequest{}
-	if version.IsAtLeast(V2_2_0_0) {
+	if version.IsAtLeast(V2_8_0_0) {
+		// Version 6 enables flexible versions.
+		request.Version = 6
+	} else if version.IsAtLeast(V2_2_0_0) {
 		// Version 5 adds a new error code, OFFSET_NOT_AVAILABLE.
 		request.Version = 5
 	} else if version.IsAtLeast(V2_1_0_0) {
@@ -109,7 +118,11 @@ func (r *OffsetRequest) encode(pe packetEncoder) error {
 				return err
 			}
 		}
+		pe.putEmptyTaggedFieldArray()
 	}
+
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
@@ -143,35 +156,42 @@ func (r *OffsetRequest) decode(pd packetDecoder, version int16) error {
 	if blockCount < 0 {
 		return errInvalidArrayLength
 	}
-	if blockCount == 0 {
-		return nil
-	}
-	r.blocks = make(map[string]map[int32]*offsetRequestBlock)
-	for range blockCount {
-		topic, err := pd.getString()
-		if err != nil {
-			return err
-		}
-		partitionCount, err := pd.getArrayLength()
-		if err != nil {
-			return err
-		}
-		if partitionCount < 0 {
-			return errInvalidArrayLength
-		}
-		r.blocks[topic] = make(map[int32]*offsetRequestBlock)
-		for range partitionCount {
-			partition, err := pd.getInt32()
+	if blockCount > 0 {
+		r.blocks = make(map[string]map[int32]*offsetRequestBlock)
+		for range blockCount {
+			topic, err := pd.getString()
 			if err != nil {
 				return err
 			}
-			block := &offsetRequestBlock{}
-			if err := block.decode(pd, version); err != nil {
+			partitionCount, err := pd.getArrayLength()
+			if err != nil {
 				return err
 			}
-			r.blocks[topic][partition] = block
+			if partitionCount < 0 {
+				return errInvalidArrayLength
+			}
+			r.blocks[topic] = make(map[int32]*offsetRequestBlock)
+			for range partitionCount {
+				partition, err := pd.getInt32()
+				if err != nil {
+					return err
+				}
+				block := &offsetRequestBlock{}
+				if err := block.decode(pd, version); err != nil {
+					return err
+				}
+				r.blocks[topic][partition] = block
+			}
+			if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+				return err
+			}
 		}
 	}
+
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -184,15 +204,28 @@ func (r *OffsetRequest) version() int16 {
 }
 
 func (r *OffsetRequest) headerVersion() int16 {
+	if r.Version >= 6 {
+		return 2
+	}
 	return 1
 }
 
 func (r *OffsetRequest) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 5
+	return r.Version >= 0 && r.Version <= 6
+}
+
+func (r *OffsetRequest) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *OffsetRequest) isFlexibleVersion(version int16) bool {
+	return version >= 6
 }
 
 func (r *OffsetRequest) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 6:
+		return V2_8_0_0
 	case 5:
 		return V2_2_0_0
 	case 4:

--- a/offset_request_test.go
+++ b/offset_request_test.go
@@ -60,6 +60,20 @@ var (
 		0xff, 0xff, 0xff, 0xff, // leader epoch
 		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // timestamp
 	}
+
+	offsetRequestV6 = []byte{
+		0xff, 0xff, 0xff, 0xff, // ReplicaId
+		0x01,                         // IsolationLevel
+		0x02,                         // Topics
+		0x05, 0x64, 0x6e, 0x77, 0x65, // Name
+		0x02,                   // Partitions
+		0x00, 0x00, 0x00, 0x09, // PartitionIndex
+		0xff, 0xff, 0xff, 0xff, // CurrentLeaderEpoch
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // Timestamp
+		0x00, // tagged fields (partition)
+		0x00, // tagged fields (topic)
+		0x00, // tagged fields
+	}
 )
 
 func TestOffsetRequest(t *testing.T) {
@@ -107,4 +121,12 @@ func TestOffsetRequestV4(t *testing.T) {
 	request.IsolationLevel = ReadCommitted
 	request.AddBlock("dnwe", 9, -1, -1)
 	testRequest(t, "V4", request, offsetRequestV4)
+}
+
+func TestOffsetRequestV6(t *testing.T) {
+	request := new(OffsetRequest)
+	request.Version = 6
+	request.IsolationLevel = ReadCommitted
+	request.AddBlock("dnwe", 9, -1, -1)
+	testRequest(t, "V6", request, offsetRequestV6)
 }

--- a/offset_response.go
+++ b/offset_response.go
@@ -46,6 +46,10 @@ func (b *OffsetResponseBlock) decode(pd packetDecoder, version int16) (err error
 		}
 	}
 
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -65,6 +69,8 @@ func (b *OffsetResponseBlock) encode(pe packetEncoder, version int16) (err error
 		pe.putInt32(b.LeaderEpoch)
 	}
 
+	pe.putEmptyTaggedFieldArray()
+
 	return nil
 }
 
@@ -79,6 +85,7 @@ func (r *OffsetResponse) setVersion(v int16) {
 }
 
 func (r *OffsetResponse) decode(pd packetDecoder, version int16) (err error) {
+	r.Version = version
 	if version >= 2 {
 		r.ThrottleTimeMs, err = pd.getInt32()
 		if err != nil {
@@ -124,6 +131,14 @@ func (r *OffsetResponse) decode(pd packetDecoder, version int16) (err error) {
 			}
 			r.Blocks[name][id] = block
 		}
+
+		if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+			return err
+		}
+	}
+
+	if _, err = pd.getEmptyTaggedFieldArray(); err != nil {
+		return err
 	}
 
 	return nil
@@ -177,7 +192,10 @@ func (r *OffsetResponse) encode(pe packetEncoder) (err error) {
 				return err
 			}
 		}
+		pe.putEmptyTaggedFieldArray()
 	}
+
+	pe.putEmptyTaggedFieldArray()
 
 	return nil
 }
@@ -191,15 +209,28 @@ func (r *OffsetResponse) version() int16 {
 }
 
 func (r *OffsetResponse) headerVersion() int16 {
+	if r.Version >= 6 {
+		return 1
+	}
 	return 0
 }
 
 func (r *OffsetResponse) isValidVersion() bool {
-	return r.Version >= 0 && r.Version <= 5
+	return r.Version >= 0 && r.Version <= 6
+}
+
+func (r *OffsetResponse) isFlexible() bool {
+	return r.isFlexibleVersion(r.Version)
+}
+
+func (r *OffsetResponse) isFlexibleVersion(version int16) bool {
+	return version >= 6
 }
 
 func (r *OffsetResponse) requiredVersion() KafkaVersion {
 	switch r.Version {
+	case 6:
+		return V2_8_0_0
 	case 5:
 		return V2_2_0_0
 	case 4:

--- a/offset_response_test.go
+++ b/offset_response_test.go
@@ -52,6 +52,21 @@ var (
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // offset
 		0xff, 0xff, 0xff, 0xff, // leaderEpoch
 	}
+
+	offsetResponseV6 = []byte{
+		0x00, 0x00, 0x00, 0x00, // ThrottleTimeMs
+		0x02,                         // Topics
+		0x05, 0x64, 0x6e, 0x77, 0x65, // Name
+		0x02,                   // Partitions
+		0x00, 0x00, 0x00, 0x09, // PartitionIndex
+		0x00, 0x00, // ErrorCode
+		0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // Timestamp
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Offset
+		0xff, 0xff, 0xff, 0xff, // LeaderEpoch
+		0x00, // tagged fields (partition)
+		0x00, // tagged fields (topic)
+		0x00, // tagged fields
+	}
 )
 
 func TestEmptyOffsetResponse(t *testing.T) {
@@ -134,4 +149,23 @@ func TestOffsetResponseV4(t *testing.T) {
 	response := OffsetResponse{}
 
 	testVersionDecodable(t, "v4", &response, offsetResponseV4, 4)
+}
+
+func TestOffsetResponseV6(t *testing.T) {
+	response := &OffsetResponse{
+		Version: 6,
+		Blocks: map[string]map[int32]*OffsetResponseBlock{
+			"dnwe": {
+				9: {
+					Err:         ErrNoError,
+					Offsets:     []int64{0},
+					Timestamp:   -1,
+					Offset:      0,
+					LeaderEpoch: -1,
+				},
+			},
+		},
+	}
+
+	testResponse(t, "v6", response, offsetResponseV6)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -324,12 +324,11 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyAddPartitionsToTxn:   3,  // up from 2
 				apiKeyProduce:              9,  // up from 8
 				apiKeyDescribeProducers:    0,  // new in 2.8
-				// TODO: ListOffsetsRequest v6 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyListOffsets:          6, // up from 5
-				apiKeyAddOffsetsToTxn:   3, // up from 2
-				apiKeyEndTxn:            3, // up from 2
-				apiKeyAlterConfigs:      2, // up from 1
-				apiKeyAlterClientQuotas: 1, // up from 0
+				apiKeyListOffsets:          6,  // up from 5
+				apiKeyAddOffsetsToTxn:      3,  // up from 2
+				apiKeyEndTxn:               3,  // up from 2
+				apiKeyAlterConfigs:         2,  // up from 1
+				apiKeyAlterClientQuotas:    1,  // up from 0
 				// TODO: CreateTopicsRequest v7 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyCreateTopics:         7, // up from 6
 				// TODO: DeleteTopicsRequest v6 is not supported, but expected for KafkaVersion 2.8.0

--- a/request_test.go
+++ b/request_test.go
@@ -326,11 +326,10 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDescribeProducers:    0,  // new in 2.8
 				// TODO: ListOffsetsRequest v6 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyListOffsets:          6, // up from 5
-				apiKeyAddOffsetsToTxn: 3, // up from 2
-				apiKeyEndTxn:          3, // up from 2
-				apiKeyAlterConfigs:    2, // up from 1
-				// TODO: AlterClientQuotasRequest v1 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyAlterClientQuotas:    1, // up from 0
+				apiKeyAddOffsetsToTxn:   3, // up from 2
+				apiKeyEndTxn:            3, // up from 2
+				apiKeyAlterConfigs:      2, // up from 1
+				apiKeyAlterClientQuotas: 1, // up from 0
 				// TODO: CreateTopicsRequest v7 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyCreateTopics:         7, // up from 6
 				// TODO: DeleteTopicsRequest v6 is not supported, but expected for KafkaVersion 2.8.0

--- a/request_test.go
+++ b/request_test.go
@@ -328,8 +328,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				// apiKeyListOffsets:          6, // up from 5
 				apiKeyAddOffsetsToTxn: 3, // up from 2
 				apiKeyEndTxn:          3, // up from 2
-				// TODO: AlterConfigsRequest v2 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyAlterConfigs:         2, // up from 1
+				apiKeyAlterConfigs:    2, // up from 1
 				// TODO: AlterClientQuotasRequest v1 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyAlterClientQuotas:    1, // up from 0
 				// TODO: CreateTopicsRequest v7 is not supported, but expected for KafkaVersion 2.8.0

--- a/request_test.go
+++ b/request_test.go
@@ -326,8 +326,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDescribeProducers:    0,  // new in 2.8
 				// TODO: ListOffsetsRequest v6 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyListOffsets:          6, // up from 5
-				// TODO: AddOffsetsToTxnRequest v3 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyAddOffsetsToTxn:      3, // up from 2
+				apiKeyAddOffsetsToTxn: 3, // up from 2
 				// TODO: EndTxnRequest v3 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyEndTxn:               3, // up from 2
 				// TODO: AlterConfigsRequest v2 is not supported, but expected for KafkaVersion 2.8.0

--- a/request_test.go
+++ b/request_test.go
@@ -327,8 +327,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				// TODO: ListOffsetsRequest v6 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyListOffsets:          6, // up from 5
 				apiKeyAddOffsetsToTxn: 3, // up from 2
-				// TODO: EndTxnRequest v3 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyEndTxn:               3, // up from 2
+				apiKeyEndTxn:          3, // up from 2
 				// TODO: AlterConfigsRequest v2 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyAlterConfigs:         2, // up from 1
 				// TODO: AlterClientQuotasRequest v1 is not supported, but expected for KafkaVersion 2.8.0

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -664,7 +664,10 @@ func (t *transactionManager) endTxn(commit bool) error {
 			ProducerID:        t.producerID,
 			TransactionResult: commit,
 		}
-		if t.client.Config().Version.IsAtLeast(V2_7_0_0) {
+		if t.client.Config().Version.IsAtLeast(V2_8_0_0) {
+			// Version 3 enables flexible versions.
+			request.Version = 3
+		} else if t.client.Config().Version.IsAtLeast(V2_7_0_0) {
 			// Version 2 adds the support for new error code PRODUCER_FENCED.
 			request.Version = 2
 		} else if t.client.Config().Version.IsAtLeast(V2_0_0_0) {

--- a/transaction_manager.go
+++ b/transaction_manager.go
@@ -330,7 +330,10 @@ func (t *transactionManager) publishOffsetsToTxn(offsets topicPartitionOffsets, 
 			ProducerID:      t.producerID,
 			GroupID:         groupId,
 		}
-		if t.client.Config().Version.IsAtLeast(V2_7_0_0) {
+		if t.client.Config().Version.IsAtLeast(V2_8_0_0) {
+			// Version 3 enables flexible versions.
+			request.Version = 3
+		} else if t.client.Config().Version.IsAtLeast(V2_7_0_0) {
 			// Version 2 adds the support for new error code PRODUCER_FENCED.
 			request.Version = 2
 		} else if t.client.Config().Version.IsAtLeast(V2_0_0_0) {


### PR DESCRIPTION
In the remaining protocols for Kafka 2.8 parity, this batch only add flexible encoding and no additional fields or behavioural changes so can be grouped as one PR. The create and delete topics add topic uuids so will be done separately 