### PR TITLE
feat: support KIP-516 topic ids

### DIFF
--- a/create_topics_request.go
+++ b/create_topics_request.go
@@ -32,6 +32,9 @@ func NewCreateTopicsRequest(
 		ValidateOnly: validateOnly,
 	}
 	switch {
+	case version.IsAtLeast(V2_8_0_0):
+		// Version 7 returns the topic ID of the newly created topic in the response
+		r.Version = 7
 	case version.IsAtLeast(V2_7_0_0):
 		// version 6 may return THROTTLING_QUOTA_EXCEEDED
 		r.Version = 6
@@ -139,11 +142,13 @@ func (c *CreateTopicsRequest) isFlexibleVersion(version int16) bool {
 }
 
 func (c *CreateTopicsRequest) isValidVersion() bool {
-	return c.Version >= 0 && c.Version <= 6
+	return c.Version >= 0 && c.Version <= 7
 }
 
 func (c *CreateTopicsRequest) requiredVersion() KafkaVersion {
 	switch c.Version {
+	case 7:
+		return V2_8_0_0
 	case 6:
 		return V2_7_0_0
 	case 5:

--- a/create_topics_request_test.go
+++ b/create_topics_request_test.go
@@ -43,6 +43,8 @@ var (
 	}
 
 	createTopicsRequestV6 = createTopicsRequestV5
+
+	createTopicsRequestV7 = createTopicsRequestV5
 )
 
 func TestCreateTopicsRequest(t *testing.T) {
@@ -76,4 +78,7 @@ func TestCreateTopicsRequest(t *testing.T) {
 
 	req.Version = 6
 	testRequest(t, "version 6", req, createTopicsRequestV6)
+
+	req.Version = 7
+	testRequest(t, "version 7", req, createTopicsRequestV7)
 }

--- a/create_topics_response.go
+++ b/create_topics_response.go
@@ -33,14 +33,23 @@ func (c *CreateTopicsResponse) encode(pe packetEncoder) error {
 		if err := pe.putString(topic); err != nil {
 			return err
 		}
+		var result *CreatableTopicResult
+		if c.Version >= 5 {
+			var ok bool
+			result, ok = c.TopicResults[topic]
+			if !ok {
+				return fmt.Errorf("expected TopicResult for topic, %s, for V5 protocol", topic)
+			}
+		}
+		if c.Version >= 7 {
+			if err := pe.putUuid(result.TopicID); err != nil {
+				return err
+			}
+		}
 		if err := topicError.encode(pe, c.Version); err != nil {
 			return err
 		}
 		if c.Version >= 5 {
-			result, ok := c.TopicResults[topic]
-			if !ok {
-				return fmt.Errorf("expected TopicResult for topic, %s, for V5 protocol", topic)
-			}
 			if err := result.encode(pe, c.Version); err != nil {
 				return err
 			}
@@ -77,12 +86,19 @@ func (c *CreateTopicsResponse) decode(pd packetDecoder, version int16) (err erro
 		if err != nil {
 			return err
 		}
+		if version >= 5 {
+			c.TopicResults[topic] = &CreatableTopicResult{}
+		}
+		if version >= 7 {
+			if c.TopicResults[topic].TopicID, err = pd.getUuid(); err != nil {
+				return err
+			}
+		}
 		c.TopicErrors[topic] = new(TopicError)
 		if err := c.TopicErrors[topic].decode(pd, version); err != nil {
 			return err
 		}
 		if version >= 5 {
-			c.TopicResults[topic] = &CreatableTopicResult{}
 			if err := c.TopicResults[topic].decode(pd, version); err != nil {
 				return err
 			}
@@ -119,11 +135,13 @@ func (c *CreateTopicsResponse) isFlexibleVersion(version int16) bool {
 }
 
 func (c *CreateTopicsResponse) isValidVersion() bool {
-	return c.Version >= 0 && c.Version <= 6
+	return c.Version >= 0 && c.Version <= 7
 }
 
 func (c *CreateTopicsResponse) requiredVersion() KafkaVersion {
 	switch c.Version {
+	case 7:
+		return V2_8_0_0
 	case 6:
 		return V2_7_0_0
 	case 5:
@@ -193,6 +211,8 @@ func (t *TopicError) decode(pd packetDecoder, version int16) (err error) {
 
 // CreatableTopicResult struct {
 type CreatableTopicResult struct {
+	// TopicID contains the unique topic ID.
+	TopicID Uuid // v7, topic_id (KIP-516)
 	// TopicConfigErrorCode contains a Optional topic config error returned if configs are not returned in the response.
 	TopicConfigErrorCode KError
 	// NumPartitions contains a Number of partitions of the topic.

--- a/create_topics_response_test.go
+++ b/create_topics_response_test.go
@@ -68,6 +68,26 @@ var (
 		0, // empty tagged fields
 	}
 
+	createTopicsResponseV7 = []byte{
+		0, 0, 0, 100,
+		2,
+		6, 't', 'o', 'p', 'i', 'c',
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, // topic ID
+		0, 42, // invalid request error
+		4, 'm', 's', 'g', // error message
+		0, 0, 0, 1, // num partitions
+		0, 2, // replication factor
+		2,                // 1 config
+		4, 'b', 'a', 'r', // name
+		4, 'b', 'a', 'z', // value
+		0, // read only
+		5, // source default
+		0, // is sensitive
+		0, // empty tagged fields
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
+
 	createTopicsResponseV5WithTopicConfigError = []byte{
 		0, 0, 0, 100,
 		2,
@@ -136,6 +156,11 @@ func TestCreateTopicsResponse(t *testing.T) {
 	resp.TopicErrors["topic"].Err = ErrInvalidRequest
 	resp.TopicResults["topic"].TopicConfigErrorCode = ErrTopicAuthorizationFailed
 	testResponse(t, "version 5", resp, createTopicsResponseV5WithTopicConfigError)
+
+	resp.Version = 7
+	resp.TopicResults["topic"].TopicConfigErrorCode = ErrNoError
+	resp.TopicResults["topic"].TopicID = Uuid{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	testResponse(t, "version 7", resp, createTopicsResponseV7)
 }
 
 func TestTopicError(t *testing.T) {

--- a/delete_topics_request.go
+++ b/delete_topics_request.go
@@ -18,7 +18,10 @@ func NewDeleteTopicsRequest(version KafkaVersion, topics []string, timeout time.
 		Timeout: timeout,
 	}
 	// Versions 0, 1, 2, and 3 are the same.
-	if version.IsAtLeast(V2_7_0_0) {
+	if version.IsAtLeast(V2_8_0_0) {
+		// Version 6 reorganizes topics, adds topic IDs and allows topic names to be null (KIP-516)
+		d.Version = 6
+	} else if version.IsAtLeast(V2_7_0_0) {
 		// version 5 may return THROTTLING_QUOTA_EXCEEDED
 		d.Version = 5
 	} else if version.IsAtLeast(V2_4_0_0) {
@@ -35,8 +38,24 @@ func NewDeleteTopicsRequest(version KafkaVersion, topics []string, timeout time.
 }
 
 func (d *DeleteTopicsRequest) encode(pe packetEncoder) error {
-	if err := pe.putStringArray(d.Topics); err != nil {
-		return err
+	if d.Version >= 6 {
+		if err := pe.putArrayLength(len(d.Topics)); err != nil {
+			return err
+		}
+		for _, topic := range d.Topics {
+			// deletion by topic ID is not supported, so send the name with a null topic ID
+			if err := pe.putNullableString(&topic); err != nil {
+				return err
+			}
+			if err := pe.putUuid(Uuid{}); err != nil {
+				return err
+			}
+			pe.putEmptyTaggedFieldArray()
+		}
+	} else {
+		if err := pe.putStringArray(d.Topics); err != nil {
+			return err
+		}
 	}
 	pe.putInt32(int32(d.Timeout / time.Millisecond))
 	pe.putEmptyTaggedFieldArray()
@@ -44,15 +63,40 @@ func (d *DeleteTopicsRequest) encode(pe packetEncoder) error {
 }
 
 func (d *DeleteTopicsRequest) decode(pd packetDecoder, version int16) (err error) {
-	if d.Topics, err = pd.getStringArray(); err != nil {
-		return err
+	d.Version = version
+	if version >= 6 {
+		n, err := pd.getArrayLength()
+		if err != nil {
+			return err
+		}
+		if n < 0 {
+			return errInvalidArrayLength
+		}
+		for range n {
+			name, err := pd.getNullableString()
+			if err != nil {
+				return err
+			}
+			if _, err := pd.getUuid(); err != nil {
+				return err
+			}
+			if name != nil {
+				d.Topics = append(d.Topics, *name)
+			}
+			if _, err := pd.getEmptyTaggedFieldArray(); err != nil {
+				return err
+			}
+		}
+	} else {
+		if d.Topics, err = pd.getStringArray(); err != nil {
+			return err
+		}
 	}
 	timeout, err := pd.getInt32()
 	if err != nil {
 		return err
 	}
 	d.Timeout = time.Duration(timeout) * time.Millisecond
-	d.Version = version
 
 	_, err = pd.getEmptyTaggedFieldArray()
 	return err
@@ -82,11 +126,13 @@ func (d *DeleteTopicsRequest) isFlexibleVersion(version int16) bool {
 }
 
 func (d *DeleteTopicsRequest) isValidVersion() bool {
-	return d.Version >= 0 && d.Version <= 5
+	return d.Version >= 0 && d.Version <= 6
 }
 
 func (d *DeleteTopicsRequest) requiredVersion() KafkaVersion {
 	switch d.Version {
+	case 6:
+		return V2_8_0_0
 	case 5:
 		return V2_7_0_0
 	case 4:

--- a/delete_topics_request_test.go
+++ b/delete_topics_request_test.go
@@ -23,6 +23,18 @@ var (
 	}
 
 	deleteTopicsRequestV5 = deleteTopicsRequestV4
+
+	deleteTopicsRequestV6 = []byte{
+		3,                          // Topics
+		6, 't', 'o', 'p', 'i', 'c', // Name
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // TopicId
+		0,                          // tagged fields (topic)
+		6, 'o', 't', 'h', 'e', 'r', // Name
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // TopicId
+		0,            // tagged fields (topic)
+		0, 0, 0, 100, // TimeoutMs
+		0, // tagged fields
+	}
 )
 
 func TestDeleteTopicsRequestV0(t *testing.T) {
@@ -63,4 +75,14 @@ func TestDeleteTopicsRequestV5(t *testing.T) {
 	}
 
 	testRequest(t, "", req, deleteTopicsRequestV5)
+}
+
+func TestDeleteTopicsRequestV6(t *testing.T) {
+	req := &DeleteTopicsRequest{
+		Version: 6,
+		Topics:  []string{"topic", "other"},
+		Timeout: 100 * time.Millisecond,
+	}
+
+	testRequest(t, "", req, deleteTopicsRequestV6)
 }

--- a/delete_topics_response.go
+++ b/delete_topics_response.go
@@ -9,6 +9,7 @@ type DeleteTopicsResponse struct {
 	ThrottleTime       time.Duration
 	TopicErrorCodes    map[string]KError
 	TopicErrorMessages map[string]*string // v5, ErrorMessage
+	TopicIDs           map[string]Uuid    // v6, TopicId (KIP-516)
 }
 
 func (d *DeleteTopicsResponse) setVersion(v int16) {
@@ -24,8 +25,17 @@ func (d *DeleteTopicsResponse) encode(pe packetEncoder) error {
 		return err
 	}
 	for topic, errorCode := range d.TopicErrorCodes {
-		if err := pe.putString(topic); err != nil {
-			return err
+		if d.Version >= 6 {
+			if err := pe.putNullableString(&topic); err != nil {
+				return err
+			}
+			if err := pe.putUuid(d.TopicIDs[topic]); err != nil {
+				return err
+			}
+		} else {
+			if err := pe.putString(topic); err != nil {
+				return err
+			}
 		}
 		pe.putKError(errorCode)
 		if d.Version >= 5 {
@@ -61,11 +71,27 @@ func (d *DeleteTopicsResponse) decode(pd packetDecoder, version int16) (err erro
 	if version >= 5 {
 		d.TopicErrorMessages = make(map[string]*string, n)
 	}
+	if version >= 6 {
+		d.TopicIDs = make(map[string]Uuid, n)
+	}
 
 	for range n {
-		topic, err := pd.getString()
-		if err != nil {
-			return err
+		var topic string
+		if version >= 6 {
+			name, err := pd.getNullableString()
+			if err != nil {
+				return err
+			}
+			if name != nil {
+				topic = *name
+			}
+			if d.TopicIDs[topic], err = pd.getUuid(); err != nil {
+				return err
+			}
+		} else {
+			if topic, err = pd.getString(); err != nil {
+				return err
+			}
 		}
 		d.TopicErrorCodes[topic], err = pd.getKError()
 		if err != nil {
@@ -110,11 +136,13 @@ func (d *DeleteTopicsResponse) isFlexibleVersion(version int16) bool {
 }
 
 func (d *DeleteTopicsResponse) isValidVersion() bool {
-	return d.Version >= 0 && d.Version <= 5
+	return d.Version >= 0 && d.Version <= 6
 }
 
 func (d *DeleteTopicsResponse) requiredVersion() KafkaVersion {
 	switch d.Version {
+	case 6:
+		return V2_8_0_0
 	case 5:
 		return V2_7_0_0
 	case 4:

--- a/delete_topics_response_test.go
+++ b/delete_topics_response_test.go
@@ -39,6 +39,17 @@ var (
 		0, // empty tagged fields
 		0, // empty tagged fields
 	}
+
+	deleteTopicsResponseV6 = []byte{
+		0, 0, 0, 100,
+		2,
+		6, 't', 'o', 'p', 'i', 'c',
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, // topic ID
+		0, 89, // throttling quota exceeded error
+		4, 'm', 's', 'g', // error message
+		0, // empty tagged fields
+		0, // empty tagged fields
+	}
 )
 
 func TestDeleteTopicsResponse(t *testing.T) {
@@ -64,4 +75,10 @@ func TestDeleteTopicsResponse(t *testing.T) {
 		"topic": nullString("msg"),
 	}
 	testResponse(t, "version 5", resp, deleteTopicsResponseV5)
+
+	resp.Version = 6
+	resp.TopicIDs = map[string]Uuid{
+		"topic": {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+	}
+	testResponse(t, "version 6", resp, deleteTopicsResponseV6)
 }

--- a/metadata_request.go
+++ b/metadata_request.go
@@ -8,8 +8,6 @@ func (u Uuid) String() string {
 	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(u[:])
 }
 
-var NullUUID = []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
-
 type MetadataRequest struct {
 	// Version defines the protocol version to use for encode and decode
 	Version int16
@@ -66,7 +64,7 @@ func (r *MetadataRequest) encode(pe packetEncoder) (err error) {
 			}
 		} else { // r.Version >= 10
 			for _, topicName := range r.Topics {
-				if err := pe.putRawBytes(NullUUID); err != nil {
+				if err := pe.putUuid(Uuid{}); err != nil {
 					return err
 				}
 				// Avoid implicit memory aliasing in for loop
@@ -118,7 +116,7 @@ func (r *MetadataRequest) decode(pd packetDecoder, version int16) (err error) {
 		}
 	} else {
 		for i := range r.Topics {
-			if _, err = pd.getRawBytes(16); err != nil { // skip UUID
+			if _, err = pd.getUuid(); err != nil { // skip UUID
 				return err
 			}
 			topic, err := pd.getNullableString()

--- a/metadata_response.go
+++ b/metadata_response.go
@@ -126,13 +126,9 @@ func (t *TopicMetadata) decode(pd packetDecoder, version int16) (err error) {
 	}
 
 	if t.Version >= 10 {
-		uuid, err := pd.getRawBytes(16)
+		t.Uuid, err = pd.getUuid()
 		if err != nil {
 			return err
-		}
-		t.Uuid = [16]byte{}
-		for i := range 16 {
-			t.Uuid[i] = uuid[i]
 		}
 	}
 
@@ -180,7 +176,7 @@ func (t *TopicMetadata) encode(pe packetEncoder, version int16) (err error) {
 	}
 
 	if t.Version >= 10 {
-		err = pe.putRawBytes(t.Uuid[:])
+		err = pe.putUuid(t.Uuid)
 		if err != nil {
 			return err
 		}

--- a/packet_decoder.go
+++ b/packet_decoder.go
@@ -32,6 +32,7 @@ type packetDecoder interface {
 	getBytes() ([]byte, error)
 	getVarintBytes() ([]byte, error)
 	getRawBytes(length int) ([]byte, error)
+	getUuid() (Uuid, error)
 	getString() (string, error)
 	getNullableString() (*string, error)
 	getInt32Array() ([]int32, error)

--- a/packet_encoder.go
+++ b/packet_encoder.go
@@ -27,6 +27,7 @@ type packetEncoder interface {
 	putBytes(in []byte) error
 	putVarintBytes(in []byte) error
 	putRawBytes(in []byte) error
+	putUuid(in Uuid) error
 	putString(in string) error
 	putNullableString(in *string) error
 	putStringArray(in []string) error

--- a/prep_encoder.go
+++ b/prep_encoder.go
@@ -98,6 +98,11 @@ func (pe *prepEncoder) putRawBytes(in []byte) error {
 	return nil
 }
 
+func (pe *prepEncoder) putUuid(in Uuid) error {
+	pe.length += 16
+	return nil
+}
+
 func (pe *prepEncoder) putNullableString(in *string) error {
 	if in == nil {
 		pe.length += 2

--- a/real_decoder.go
+++ b/real_decoder.go
@@ -323,6 +323,16 @@ func (rd *realDecoder) getSubset(length int) (packetDecoder, error) {
 	return &realDecoder{raw: buf}, nil
 }
 
+func (rd *realDecoder) getUuid() (Uuid, error) {
+	var uuid Uuid
+	raw, err := rd.getRawBytes(16)
+	if err != nil {
+		return uuid, err
+	}
+	copy(uuid[:], raw)
+	return uuid, nil
+}
+
 func (rd *realDecoder) getRawBytes(length int) ([]byte, error) {
 	if length < 0 {
 		return nil, errInvalidByteSliceLength

--- a/real_encoder.go
+++ b/real_encoder.go
@@ -84,6 +84,10 @@ func (re *realEncoder) putRawBytes(in []byte) error {
 	return nil
 }
 
+func (re *realEncoder) putUuid(in Uuid) error {
+	return re.putRawBytes(in[:])
+}
+
 func (re *realEncoder) putBytes(in []byte) error {
 	if in == nil {
 		re.putInt32(-1)

--- a/request_test.go
+++ b/request_test.go
@@ -329,9 +329,8 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyEndTxn:               3,  // up from 2
 				apiKeyAlterConfigs:         2,  // up from 1
 				apiKeyAlterClientQuotas:    1,  // up from 0
-				// TODO: CreateTopicsRequest v7 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyCreateTopics:         7, // up from 6
-				apiKeyDeleteTopics: 6, // up from 5
+				apiKeyCreateTopics:         7,  // up from 6
+				apiKeyDeleteTopics:         6,  // up from 5
 			},
 		},
 		{

--- a/request_test.go
+++ b/request_test.go
@@ -331,8 +331,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyAlterClientQuotas:    1,  // up from 0
 				// TODO: CreateTopicsRequest v7 is not supported, but expected for KafkaVersion 2.8.0
 				// apiKeyCreateTopics:         7, // up from 6
-				// TODO: DeleteTopicsRequest v6 is not supported, but expected for KafkaVersion 2.8.0
-				// apiKeyDeleteTopics:         6, // up from 5
+				apiKeyDeleteTopics: 6, // up from 5
 			},
 		},
 		{


### PR DESCRIPTION
The remaining protocol support for Kafka 2.8 

https://cwiki.apache.org/confluence/spaces/KAFKA/pages/127406437/KIP-516+Topic+Identifiers