### PR TITLE
feat(consumer): add rebalance protocol plumbing

### DIFF
--- a/config.go
+++ b/config.go
@@ -607,6 +607,14 @@ func NewConfig() *Config {
 	return c
 }
 
+// groupStrategies gives the deprecated Strategy field precedence when set
+func (c *Config) groupStrategies() []BalanceStrategy {
+	if strategy := c.Consumer.Group.Rebalance.Strategy; strategy != nil {
+		return []BalanceStrategy{strategy}
+	}
+	return c.Consumer.Group.Rebalance.GroupStrategies
+}
+
 // Validate checks a Config instance. It will return a
 // ConfigurationError if the specified values don't make sense.
 //
@@ -881,6 +889,16 @@ func (c *Config) Validate() error {
 	for _, strategy := range c.Consumer.Group.Rebalance.GroupStrategies {
 		if strategy == nil {
 			return ConfigurationError("elements in Consumer.Group.Rebalance.Strategies must not be empty")
+		}
+	}
+
+	if strategies := c.groupStrategies(); len(strategies) > 0 {
+		protocol, err := selectRebalanceProtocol(strategies)
+		if err != nil {
+			return err
+		}
+		if protocol >= RebalanceProtocolCooperative && !c.Version.IsAtLeast(V2_4_0_0) {
+			return ConfigurationError("cooperative balance strategies require Version >= 2.4")
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -575,11 +575,39 @@ func TestGroupInstanceIdAndVersionValidation(t *testing.T) {
 }
 
 func TestConsumerGroupStrategyCompatibility(t *testing.T) {
-	config := NewTestConfig()
-	config.Consumer.Group.Rebalance.Strategy = NewBalanceStrategySticky()
-	if err := config.Validate(); err != nil {
-		t.Error("Expected passing config validation, got ", err)
-	}
+	t.Run("deprecated singular strategy is accepted", func(t *testing.T) {
+		config := NewTestConfig()
+		config.Consumer.Group.Rebalance.Strategy = NewBalanceStrategySticky()
+		assert.NoError(t, config.Validate())
+	})
+
+	t.Run("strategies with no common rebalance protocol are rejected", func(t *testing.T) {
+		config := NewTestConfig()
+		config.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{
+			&stubProtocolStrategy{
+				BalanceStrategy: NewBalanceStrategyRange(),
+				protocols:       []RebalanceProtocol{RebalanceProtocolCooperative},
+			},
+			NewBalanceStrategyRange(), // eager-only
+		}
+		assert.Error(t, config.Validate())
+	})
+
+	t.Run("cooperative strategies require Version >= 2.4", func(t *testing.T) {
+		config := NewTestConfig()
+		config.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{
+			&stubProtocolStrategy{
+				BalanceStrategy: NewBalanceStrategyRange(),
+				protocols:       []RebalanceProtocol{RebalanceProtocolCooperative},
+			},
+		}
+
+		config.Version = V2_3_0_0
+		assert.Error(t, config.Validate())
+
+		config.Version = V2_4_0_0
+		assert.NoError(t, config.Validate())
+	})
 }
 
 // This example shows how to integrate with an existing registry as well as publishing metrics

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -109,6 +109,9 @@ type consumerGroup struct {
 
 	userData []byte
 
+	// protocol is fixed at construction from the configured balance strategies
+	protocol RebalanceProtocol
+
 	metricRegistry metrics.Registry
 }
 
@@ -145,6 +148,11 @@ func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 		return nil, ConfigurationError("consumer groups require Version to be >= V0_10_2_0")
 	}
 
+	protocol, err := selectRebalanceProtocol(config.groupStrategies())
+	if err != nil {
+		return nil, err
+	}
+
 	consumer, err := newConsumer(client)
 	if err != nil {
 		return nil, err
@@ -158,6 +166,7 @@ func newConsumerGroup(groupID string, client Client) (ConsumerGroup, error) {
 		errors:         make(chan error, config.ChannelBufferSize),
 		closed:         make(chan none),
 		userData:       config.Consumer.Group.Member.UserData,
+		protocol:       protocol,
 		metricRegistry: newCleanupRegistry(config.MetricRegistry),
 	}
 	if config.Consumer.Group.InstanceId != "" && config.Version.IsAtLeast(V2_3_0_0) {
@@ -514,19 +523,30 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 		c.lastSessionCause = nil
 	}
 
-	if strategy := c.config.Consumer.Group.Rebalance.Strategy; strategy != nil {
-		if err := req.AddGroupProtocolMetadata(strategy.Name(), c.subscriptionMetadata(strategy, topics)); err != nil {
+	// Under the eager protocol the previous session has already been torn down
+	// by the time we rejoin, so this member owns nothing and has no generation
+	// to report. The cooperative path supplies both.
+	for _, strategy := range c.config.groupStrategies() {
+		meta := c.subscriptionMetadata(strategy, topics, nil, defaultGeneration)
+		if err := req.AddGroupProtocolMetadata(strategy.Name(), meta); err != nil {
 			return nil, err
-		}
-	} else {
-		for _, strategy := range c.config.Consumer.Group.Rebalance.GroupStrategies {
-			if err := req.AddGroupProtocolMetadata(strategy.Name(), c.subscriptionMetadata(strategy, topics)); err != nil {
-				return nil, err
-			}
 		}
 	}
 
 	return coordinator.JoinGroup(req)
+}
+
+// subscriptionVersion is based on the broker version rather than the rebalance
+// protocol so owned partitions are available during a rolling upgrade
+func (c *consumerGroup) subscriptionVersion() int16 {
+	switch {
+	case c.config.Version.IsAtLeast(V3_2_0_0):
+		return 2 // KIP-792: GenerationID
+	case c.config.Version.IsAtLeast(V2_4_0_0):
+		return 1 // KIP-429: OwnedPartitions
+	default:
+		return 0
+	}
 }
 
 // subscriptionMetadata builds the ConsumerGroupMemberMetadata for a single
@@ -534,26 +554,32 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 // SubscriptionUserDataBalanceStrategy, its SubscriptionUserData hook is invoked
 // to obtain per-cycle UserData; on error the statically configured
 // Consumer.Group.Member.UserData is used and the error is logged.
-func (c *consumerGroup) subscriptionMetadata(strategy BalanceStrategy, topics []string) *ConsumerGroupMemberMetadata {
-	if p, ok := strategy.(SubscriptionUserDataBalanceStrategy); ok {
-		// Hand the provider a throwaway copy so it cannot mutate the slice
-		// we later attach to the JoinGroup request.
-		userData, err := p.SubscriptionUserData(slices.Clone(topics))
-		if err == nil {
-			return &ConsumerGroupMemberMetadata{
-				Topics:   topics,
-				UserData: userData,
-			}
-		}
+func (c *consumerGroup) subscriptionMetadata(strategy BalanceStrategy, topics []string, owned map[string][]int32, generationID int32) *ConsumerGroupMemberMetadata {
+	meta := &ConsumerGroupMemberMetadata{
+		Version:         c.subscriptionVersion(),
+		Topics:          topics,
+		UserData:        c.userData,
+		OwnedPartitions: ownedPartitions(owned),
+		GenerationID:    generationID,
+	}
+
+	p, ok := strategy.(SubscriptionUserDataBalanceStrategy)
+	if !ok {
+		return meta
+	}
+
+	// Hand the provider a throwaway copy so it cannot mutate the slice
+	// we later attach to the JoinGroup request.
+	userData, err := p.SubscriptionUserData(slices.Clone(topics))
+	if err != nil {
 		Logger.Printf(
 			"consumergroup/%s: falling back to static user data for strategy %q due to %v\n",
 			c.groupID, strategy.Name(), err,
 		)
+		return meta
 	}
-	return &ConsumerGroupMemberMetadata{
-		Topics:   topics,
-		UserData: c.userData,
-	}
+	meta.UserData = userData
+	return meta
 }
 
 // findStrategy returns the BalanceStrategy with the specified protocolName

--- a/consumer_group_members.go
+++ b/consumer_group_members.go
@@ -1,6 +1,10 @@
 package sarama
 
-import "errors"
+import (
+	"errors"
+	"maps"
+	"slices"
+)
 
 // ConsumerGroupMemberMetadata holds the metadata for consumer group
 // https://github.com/apache/kafka/blob/trunk/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
@@ -100,6 +104,20 @@ func (m *ConsumerGroupMemberMetadata) decode(pd packetDecoder) (err error) {
 type OwnedPartition struct {
 	Topic      string
 	Partitions []int32
+}
+
+// ownedPartitions sorts the wire representation to keep subscriptions stable
+func ownedPartitions(owned map[string][]int32) []*OwnedPartition {
+	if len(owned) == 0 {
+		return nil
+	}
+	result := make([]*OwnedPartition, 0, len(owned))
+	for _, topic := range slices.Sorted(maps.Keys(owned)) {
+		partitions := slices.Clone(owned[topic])
+		slices.Sort(partitions)
+		result = append(result, &OwnedPartition{Topic: topic, Partitions: partitions})
+	}
+	return result
 }
 
 func (m *OwnedPartition) encode(pe packetEncoder) error {

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -272,61 +272,67 @@ func (s *strategyWithSubscriptionUserData) SubscriptionUserData(topics []string)
 	return s.data, s.err
 }
 
+func newSubscriptionMetadataTestGroup(userData []byte, version KafkaVersion) *consumerGroup {
+	config := NewTestConfig()
+	config.Version = version
+	return &consumerGroup{config: config, userData: userData}
+}
+
 func TestSubscriptionMetadata(t *testing.T) {
 	staticUserData := []byte("static")
 	topics := []string{"my-topic"}
 
 	t.Run("strategy without provider uses static user data", func(t *testing.T) {
-		c := &consumerGroup{userData: staticUserData}
-		meta := c.subscriptionMetadata(NewBalanceStrategyRange(), topics)
+		c := newSubscriptionMetadataTestGroup(staticUserData, V2_4_0_0)
+		meta := c.subscriptionMetadata(NewBalanceStrategyRange(), topics, nil, defaultGeneration)
 		assert.Equal(t, topics, meta.Topics)
 		assert.Equal(t, staticUserData, meta.UserData)
 	})
 
 	t.Run("provider returning bytes overrides static user data", func(t *testing.T) {
-		c := &consumerGroup{userData: staticUserData}
+		c := newSubscriptionMetadataTestGroup(staticUserData, V2_4_0_0)
 		strategy := &strategyWithSubscriptionUserData{
 			BalanceStrategy: NewBalanceStrategyRange(),
 			data:            []byte("per-cycle"),
 		}
-		meta := c.subscriptionMetadata(strategy, topics)
+		meta := c.subscriptionMetadata(strategy, topics, nil, defaultGeneration)
 		assert.Equal(t, []byte("per-cycle"), meta.UserData)
 		assert.Equal(t, [][]string{topics}, strategy.called)
 	})
 
 	t.Run("provider returning nil clears static user data", func(t *testing.T) {
-		c := &consumerGroup{userData: staticUserData}
+		c := newSubscriptionMetadataTestGroup(staticUserData, V2_4_0_0)
 		strategy := &strategyWithSubscriptionUserData{
 			BalanceStrategy: NewBalanceStrategyRange(),
 			data:            nil,
 		}
-		meta := c.subscriptionMetadata(strategy, topics)
+		meta := c.subscriptionMetadata(strategy, topics, nil, defaultGeneration)
 		assert.Nil(t, meta.UserData)
 	})
 
 	t.Run("provider returning empty slice clears static user data", func(t *testing.T) {
-		c := &consumerGroup{userData: staticUserData}
+		c := newSubscriptionMetadataTestGroup(staticUserData, V2_4_0_0)
 		strategy := &strategyWithSubscriptionUserData{
 			BalanceStrategy: NewBalanceStrategyRange(),
 			data:            []byte{},
 		}
-		meta := c.subscriptionMetadata(strategy, topics)
+		meta := c.subscriptionMetadata(strategy, topics, nil, defaultGeneration)
 		assert.Equal(t, []byte{}, meta.UserData)
 	})
 
 	t.Run("provider returning error falls back to static user data", func(t *testing.T) {
-		c := &consumerGroup{userData: staticUserData}
+		c := newSubscriptionMetadataTestGroup(staticUserData, V2_4_0_0)
 		strategy := &strategyWithSubscriptionUserData{
 			BalanceStrategy: NewBalanceStrategyRange(),
 			data:            []byte("ignored"),
 			err:             errors.New("boom"),
 		}
-		meta := c.subscriptionMetadata(strategy, topics)
+		meta := c.subscriptionMetadata(strategy, topics, nil, defaultGeneration)
 		assert.Equal(t, staticUserData, meta.UserData)
 	})
 
 	t.Run("each strategy in GroupStrategies receives its own user data", func(t *testing.T) {
-		c := &consumerGroup{userData: staticUserData}
+		c := newSubscriptionMetadataTestGroup(staticUserData, V2_4_0_0)
 		s1 := &strategyWithSubscriptionUserData{
 			BalanceStrategy: NewBalanceStrategyRange(),
 			data:            []byte("from-s1"),
@@ -335,8 +341,59 @@ func TestSubscriptionMetadata(t *testing.T) {
 			BalanceStrategy: NewBalanceStrategyRoundRobin(),
 			data:            []byte("from-s2"),
 		}
-		assert.Equal(t, []byte("from-s1"), c.subscriptionMetadata(s1, topics).UserData)
-		assert.Equal(t, []byte("from-s2"), c.subscriptionMetadata(s2, topics).UserData)
+		assert.Equal(t, []byte("from-s1"), c.subscriptionMetadata(s1, topics, nil, defaultGeneration).UserData)
+		assert.Equal(t, []byte("from-s2"), c.subscriptionMetadata(s2, topics, nil, defaultGeneration).UserData)
+	})
+
+	t.Run("subscription version tracks the configured Kafka version", func(t *testing.T) {
+		for _, tc := range []struct {
+			version KafkaVersion
+			want    int16
+		}{
+			{V2_3_0_0, 0},
+			{V2_4_0_0, 1}, // KIP-429 OwnedPartitions
+			{V3_1_0_0, 1},
+			{V3_2_0_0, 2}, // KIP-792 GenerationID
+			{MaxVersion, 2},
+		} {
+			c := newSubscriptionMetadataTestGroup(staticUserData, tc.version)
+			meta := c.subscriptionMetadata(NewBalanceStrategyRange(), topics, nil, defaultGeneration)
+			assert.Equal(t, tc.want, meta.Version, "for Kafka version %s", tc.version)
+		}
+	})
+
+	t.Run("owned partitions are reported sorted by topic and partition", func(t *testing.T) {
+		c := newSubscriptionMetadataTestGroup(staticUserData, V3_2_0_0)
+		owned := map[string][]int32{"b-topic": {2, 0, 1}, "a-topic": {5}}
+		meta := c.subscriptionMetadata(NewBalanceStrategyRange(), topics, owned, 7)
+		assert.Equal(t, []*OwnedPartition{
+			{Topic: "a-topic", Partitions: []int32{5}},
+			{Topic: "b-topic", Partitions: []int32{0, 1, 2}},
+		}, meta.OwnedPartitions)
+		assert.Equal(t, int32(7), meta.GenerationID)
+	})
+
+	t.Run("owning nothing reports no partitions", func(t *testing.T) {
+		c := newSubscriptionMetadataTestGroup(staticUserData, V3_2_0_0)
+		meta := c.subscriptionMetadata(NewBalanceStrategyRange(), topics, nil, defaultGeneration)
+		assert.Empty(t, meta.OwnedPartitions)
+		assert.Equal(t, int32(defaultGeneration), meta.GenerationID)
+	})
+
+	t.Run("owned partitions round-trip through the wire format", func(t *testing.T) {
+		c := newSubscriptionMetadataTestGroup(staticUserData, V3_2_0_0)
+		owned := map[string][]int32{"my-topic": {0, 3}}
+		meta := c.subscriptionMetadata(NewBalanceStrategyRange(), topics, owned, 7)
+
+		encoded, err := encode(meta, nil)
+		assert.NoError(t, err)
+		decoded := &ConsumerGroupMemberMetadata{}
+		assert.NoError(t, decode(encoded, decoded, nil))
+
+		assert.Equal(t, meta.Version, decoded.Version)
+		assert.Equal(t, meta.Topics, decoded.Topics)
+		assert.Equal(t, meta.OwnedPartitions, decoded.OwnedPartitions)
+		assert.Equal(t, meta.GenerationID, decoded.GenerationID)
 	})
 }
 

--- a/rebalance_protocol.go
+++ b/rebalance_protocol.go
@@ -1,0 +1,84 @@
+package sarama
+
+import "fmt"
+
+// RebalanceProtocol identifies a rebalance protocol supported by a BalanceStrategy
+//
+// The zero value is RebalanceProtocolEager, so a strategy that does not declare
+// its supported protocols is treated as eager-only.
+type RebalanceProtocol int8
+
+const (
+	// RebalanceProtocolEager revokes every assignment before a group rejoins
+	RebalanceProtocolEager RebalanceProtocol = iota
+
+	// RebalanceProtocolCooperative retains partitions that do not move during a rebalance
+	RebalanceProtocolCooperative
+)
+
+func (p RebalanceProtocol) String() string {
+	switch p {
+	case RebalanceProtocolEager:
+		return "eager"
+	case RebalanceProtocolCooperative:
+		return "cooperative"
+	default:
+		return fmt.Sprintf("unknown(%d)", int8(p))
+	}
+}
+
+// RebalanceProtocolBalanceStrategy is an optional extension of BalanceStrategy
+// that declares which rebalance protocols the strategy can take part in. A
+// strategy that does not implement it is treated as eager-only.
+//
+// The consumer group uses the most preferred protocol common to every
+// configured strategy. This allows cooperative strategies to be introduced
+// alongside eager strategies during a rolling upgrade.
+type RebalanceProtocolBalanceStrategy interface {
+	BalanceStrategy
+
+	SupportedProtocols() []RebalanceProtocol
+}
+
+func supportedProtocols(strategy BalanceStrategy) []RebalanceProtocol {
+	if s, ok := strategy.(RebalanceProtocolBalanceStrategy); ok {
+		return s.SupportedProtocols()
+	}
+	return []RebalanceProtocol{RebalanceProtocolEager}
+}
+
+func selectRebalanceProtocol(strategies []BalanceStrategy) (RebalanceProtocol, error) {
+	if len(strategies) == 0 {
+		return RebalanceProtocolEager, ConfigurationError("no Consumer.Group.Rebalance balance strategies configured")
+	}
+
+	allEager := true
+	allCooperative := true
+	for _, strategy := range strategies {
+		supportsEager := false
+		supportsCooperative := false
+		for _, protocol := range supportedProtocols(strategy) {
+			switch protocol {
+			case RebalanceProtocolEager:
+				supportsEager = true
+			case RebalanceProtocolCooperative:
+				supportsCooperative = true
+			default:
+				return RebalanceProtocolEager, ConfigurationError(fmt.Sprintf(
+					"balance strategy %q declares unsupported rebalance protocol %s",
+					strategy.Name(), protocol,
+				))
+			}
+		}
+		allEager = allEager && supportsEager
+		allCooperative = allCooperative && supportsCooperative
+	}
+
+	if allCooperative {
+		return RebalanceProtocolCooperative, nil
+	}
+	if allEager {
+		return RebalanceProtocolEager, nil
+	}
+	return RebalanceProtocolEager, ConfigurationError("Consumer.Group.Rebalance.GroupStrategies do not have a commonly supported rebalance protocol")
+}

--- a/rebalance_protocol_test.go
+++ b/rebalance_protocol_test.go
@@ -1,0 +1,110 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type stubProtocolStrategy struct {
+	BalanceStrategy
+	protocols []RebalanceProtocol
+}
+
+func (s *stubProtocolStrategy) SupportedProtocols() []RebalanceProtocol {
+	return s.protocols
+}
+
+func TestSelectRebalanceProtocol(t *testing.T) {
+	eagerOnly := &stubProtocolStrategy{
+		BalanceStrategy: NewBalanceStrategyRange(),
+		protocols:       []RebalanceProtocol{RebalanceProtocolEager},
+	}
+	both := &stubProtocolStrategy{
+		BalanceStrategy: NewBalanceStrategyRange(),
+		protocols:       []RebalanceProtocol{RebalanceProtocolCooperative, RebalanceProtocolEager},
+	}
+	cooperativeOnly := &stubProtocolStrategy{
+		BalanceStrategy: NewBalanceStrategyRange(),
+		protocols:       []RebalanceProtocol{RebalanceProtocolCooperative},
+	}
+
+	tests := []struct {
+		name       string
+		strategies []BalanceStrategy
+		want       RebalanceProtocol
+		wantErr    bool
+	}{
+		{
+			name:       "no strategies has no common protocol",
+			strategies: nil,
+			wantErr:    true,
+		},
+		{
+			name:       "strategy without declared protocols defaults to eager",
+			strategies: []BalanceStrategy{NewBalanceStrategyRange()},
+			want:       RebalanceProtocolEager,
+		},
+		{
+			name:       "single cooperative-capable strategy selects cooperative",
+			strategies: []BalanceStrategy{both},
+			want:       RebalanceProtocolCooperative,
+		},
+		{
+			name:       "cooperative-capable alongside eager-only selects eager",
+			strategies: []BalanceStrategy{both, eagerOnly},
+			want:       RebalanceProtocolEager,
+		},
+		{
+			name:       "order does not affect selection",
+			strategies: []BalanceStrategy{eagerOnly, both},
+			want:       RebalanceProtocolEager,
+		},
+		{
+			name:       "highest common protocol wins",
+			strategies: []BalanceStrategy{both, cooperativeOnly},
+			want:       RebalanceProtocolCooperative,
+		},
+		{
+			name:       "disjoint protocols have no common protocol",
+			strategies: []BalanceStrategy{cooperativeOnly, eagerOnly},
+			wantErr:    true,
+		},
+		{
+			name: "duplicate protocols within one strategy are not double counted",
+			strategies: []BalanceStrategy{
+				&stubProtocolStrategy{
+					BalanceStrategy: NewBalanceStrategyRange(),
+					protocols: []RebalanceProtocol{
+						RebalanceProtocolCooperative,
+						RebalanceProtocolCooperative,
+					},
+				},
+				eagerOnly,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown protocol is rejected",
+			strategies: []BalanceStrategy{&stubProtocolStrategy{
+				BalanceStrategy: NewBalanceStrategyRange(),
+				protocols:       []RebalanceProtocol{42},
+			}},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectRebalanceProtocol(tt.strategies)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Select the most preferred protocol shared by all configured balance strategies. Strategies that do not declare protocol support remain eager-only.

Include owned partitions and the assignment generation in subscription metadata when supported by the configured Kafka version. Assignment behaviour remains unchanged.