### PR TITLE
feat(consumer): add cooperative sticky assignor

### DIFF
--- a/balance_strategy.go
+++ b/balance_strategy.go
@@ -21,6 +21,9 @@ const (
 	// StickyBalanceStrategyName identifies strategies that use the sticky-partition assignment strategy
 	StickyBalanceStrategyName = "sticky"
 
+	// CooperativeStickyBalanceStrategyName matches Java's cooperative assignor name
+	CooperativeStickyBalanceStrategyName = "cooperative-sticky"
+
 	defaultGeneration = -1
 )
 
@@ -220,6 +223,8 @@ func (s *balanceStrategy) AssignmentData(memberID string, topics map[string][]in
 
 type stickyBalanceStrategy struct {
 	movements partitionMovements
+
+	cooperative bool
 }
 
 // Name implements BalanceStrategy.
@@ -234,7 +239,7 @@ func (s *stickyBalanceStrategy) Plan(members map[string]ConsumerGroupMemberMetad
 	}
 
 	// prepopulate the current assignment state from userdata on the consumer group members
-	currentAssignment, prevAssignment, err := prepopulateCurrentAssignments(members)
+	currentAssignment, prevAssignment, err := prepopulateCurrentAssignments(members, s.cooperative)
 	if err != nil {
 		return nil, err
 	}
@@ -323,6 +328,9 @@ func (s *stickyBalanceStrategy) Plan(members map[string]ConsumerGroupMemberMetad
 				plan.Add(memberID, assignment.Topic, assignment.Partition)
 			}
 		}
+	}
+	if s.cooperative {
+		adjustCooperativeAssignment(plan, members)
 	}
 	return plan, nil
 }
@@ -865,17 +873,53 @@ func areSubscriptionsIdentical(partition2AllPotentialConsumers map[topicPartitio
 	return true
 }
 
+// memberData reads cooperative ownership from the subscription metadata
+func memberData(meta ConsumerGroupMemberMetadata, cooperative bool) (StickyAssignorUserData, error) {
+	if !cooperative {
+		return deserializeTopicPartitionAssignment(meta.UserData)
+	}
+
+	data := &cooperativeStickyAssignorUserData{
+		Generation:      defaultGeneration,
+		topicPartitions: ownedTopicPartitions(meta.OwnedPartitions),
+	}
+
+	if meta.Version >= 2 {
+		data.Generation = meta.GenerationID
+		return data, nil
+	}
+	if len(meta.UserData) > 0 {
+		encoded := &cooperativeStickyAssignorUserData{}
+		if err := decode(meta.UserData, encoded, nil); err != nil {
+			Logger.Printf("consumer/cooperative-sticky: ignoring undecodable user data: %v\n", err)
+			return data, nil
+		}
+		data.Generation = encoded.Generation
+	}
+	return data, nil
+}
+
+func ownedTopicPartitions(owned []*OwnedPartition) []topicPartitionAssignment {
+	partitions := make([]topicPartitionAssignment, 0, len(owned))
+	for _, op := range owned {
+		for _, partition := range op.Partitions {
+			partitions = append(partitions, topicPartitionAssignment{Topic: op.Topic, Partition: partition})
+		}
+	}
+	return partitions
+}
+
 // We need to process subscriptions' user data with each consumer's reported generation in mind
 // higher generations overwrite lower generations in case of a conflict
 // note that a conflict could exist only if user data is for different generations
-func prepopulateCurrentAssignments(members map[string]ConsumerGroupMemberMetadata) (map[string][]topicPartitionAssignment, map[topicPartitionAssignment]consumerGenerationPair, error) {
+func prepopulateCurrentAssignments(members map[string]ConsumerGroupMemberMetadata, cooperative bool) (map[string][]topicPartitionAssignment, map[topicPartitionAssignment]consumerGenerationPair, error) {
 	currentAssignment := make(map[string][]topicPartitionAssignment)
 	prevAssignment := make(map[topicPartitionAssignment]consumerGenerationPair)
 
 	// for each partition we create a sorted map of its consumers by generation
 	sortedPartitionConsumersByGeneration := make(map[topicPartitionAssignment]map[int]string)
 	for memberID, meta := range members {
-		consumerUserData, err := deserializeTopicPartitionAssignment(meta.UserData)
+		consumerUserData, err := memberData(meta, cooperative)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/balance_strategy_cooperative_sticky.go
+++ b/balance_strategy_cooperative_sticky.go
@@ -89,11 +89,9 @@ func adjustCooperativeAssignment(plan BalanceStrategyPlan, members map[string]Co
 			continue
 		}
 		topics := plan[newOwner]
-		partitions := slices.DeleteFunc(topics[tp.Topic], func(p int32) bool { return p == tp.Partition })
-		if len(partitions) == 0 {
+		topics[tp.Topic] = slices.DeleteFunc(topics[tp.Topic], func(p int32) bool { return p == tp.Partition })
+		if len(topics[tp.Topic]) == 0 {
 			delete(topics, tp.Topic)
-			continue
 		}
-		topics[tp.Topic] = partitions
 	}
 }

--- a/balance_strategy_cooperative_sticky.go
+++ b/balance_strategy_cooperative_sticky.go
@@ -1,0 +1,99 @@
+package sarama
+
+import (
+	"slices"
+	"sync/atomic"
+)
+
+// NewBalanceStrategyCooperativeSticky returns a cooperative sticky balance strategy
+//
+// Existing groups should first deploy it alongside their current eager
+// strategy, then remove the eager strategy in a second rolling deployment:
+//
+//	[]BalanceStrategy{NewBalanceStrategyCooperativeSticky(), NewBalanceStrategyRange()}
+//	[]BalanceStrategy{NewBalanceStrategyCooperativeSticky()}
+//
+// The returned strategy is stateful and must not be shared between consumer
+// groups. It requires Version >= V2_4_0_0.
+func NewBalanceStrategyCooperativeSticky() BalanceStrategy {
+	s := &cooperativeStickyBalanceStrategy{
+		stickyBalanceStrategy: stickyBalanceStrategy{cooperative: true},
+	}
+	s.generation.Store(defaultGeneration)
+	return s
+}
+
+type cooperativeStickyBalanceStrategy struct {
+	stickyBalanceStrategy
+
+	// generation disambiguates current ownership from stale subscriptions
+	generation atomic.Int32
+}
+
+// Name implements BalanceStrategy.
+func (s *cooperativeStickyBalanceStrategy) Name() string {
+	return CooperativeStickyBalanceStrategyName
+}
+
+// SupportedProtocols implements RebalanceProtocolBalanceStrategy
+func (s *cooperativeStickyBalanceStrategy) SupportedProtocols() []RebalanceProtocol {
+	return []RebalanceProtocol{RebalanceProtocolCooperative, RebalanceProtocolEager}
+}
+
+// SubscriptionUserData implements SubscriptionUserDataBalanceStrategy
+func (s *cooperativeStickyBalanceStrategy) SubscriptionUserData(topics []string) ([]byte, error) {
+	return encode(&cooperativeStickyAssignorUserData{Generation: s.generation.Load()}, nil)
+}
+
+// OnAssignment implements OnAssignmentBalanceStrategy.
+func (s *cooperativeStickyBalanceStrategy) OnAssignment(assignment *ConsumerGroupMemberAssignment, generationID int32) {
+	s.generation.Store(generationID)
+}
+
+// AssignmentData implements BalanceStrategy
+func (s *cooperativeStickyBalanceStrategy) AssignmentData(memberID string, topics map[string][]int32, generationID int32) ([]byte, error) {
+	return nil, nil
+}
+
+// adjustCooperativeAssignment withholds partitions until their old owner revokes them
+func adjustCooperativeAssignment(plan BalanceStrategyPlan, members map[string]ConsumerGroupMemberMetadata) {
+	addedOwners := make(map[topicPartitionAssignment]string)
+	revoked := make(map[topicPartitionAssignment]none)
+
+	for memberID, meta := range members {
+		owned := make(map[topicPartitionAssignment]none, len(meta.OwnedPartitions))
+		for _, partition := range ownedTopicPartitions(meta.OwnedPartitions) {
+			owned[partition] = none{}
+		}
+
+		assigned := make(map[topicPartitionAssignment]none)
+		for topic, partitions := range plan[memberID] {
+			for _, partition := range partitions {
+				tp := topicPartitionAssignment{Topic: topic, Partition: partition}
+				assigned[tp] = none{}
+				if _, held := owned[tp]; !held {
+					addedOwners[tp] = memberID
+				}
+			}
+		}
+
+		for tp := range owned {
+			if _, keeps := assigned[tp]; !keeps {
+				revoked[tp] = none{}
+			}
+		}
+	}
+
+	for tp, newOwner := range addedOwners {
+		if _, transferring := revoked[tp]; !transferring {
+			continue
+		}
+		topics := plan[newOwner]
+		partitions := slices.DeleteFunc(topics[tp.Topic], func(p int32) bool { return p == tp.Partition })
+		if len(partitions) == 0 {
+			delete(topics, tp.Topic)
+			continue
+		}
+		topics[tp.Topic] = partitions
+	}
+}

--- a/balance_strategy_cooperative_sticky_test.go
+++ b/balance_strategy_cooperative_sticky_test.go
@@ -1,0 +1,164 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBalanceStrategyCooperativeSticky(t *testing.T) {
+	const topic = "t"
+
+	ownedMeta := func(generation int32, partitions ...int32) ConsumerGroupMemberMetadata {
+		meta := ConsumerGroupMemberMetadata{
+			Version:      2,
+			Topics:       []string{topic},
+			GenerationID: generation,
+		}
+		if len(partitions) > 0 {
+			meta.OwnedPartitions = []*OwnedPartition{{Topic: topic, Partitions: partitions}}
+		}
+		return meta
+	}
+
+	t.Run("advertises the protocol name java recognizes", func(t *testing.T) {
+		strategy := NewBalanceStrategyCooperativeSticky()
+		require.Equal(t, "cooperative-sticky", strategy.Name())
+	})
+
+	t.Run("supports cooperative and eager", func(t *testing.T) {
+		strategy := NewBalanceStrategyCooperativeSticky()
+		protocol, err := selectRebalanceProtocol([]BalanceStrategy{strategy})
+		require.NoError(t, err)
+		require.Equal(t, RebalanceProtocolCooperative, protocol)
+		protocol, err = selectRebalanceProtocol([]BalanceStrategy{strategy, NewBalanceStrategyRange()})
+		require.NoError(t, err)
+		require.Equal(t, RebalanceProtocolEager, protocol)
+	})
+
+	t.Run("the eager sticky strategy stays eager-only", func(t *testing.T) {
+		sticky := NewBalanceStrategySticky()
+		require.NotImplements(t, (*RebalanceProtocolBalanceStrategy)(nil), sticky, "sticky must not declare supported protocols")
+		require.NotImplements(t, (*SubscriptionUserDataBalanceStrategy)(nil), sticky, "sticky must not provide subscription user data")
+		require.NotImplements(t, (*OnAssignmentBalanceStrategy)(nil), sticky, "sticky must not observe assignments")
+	})
+
+	t.Run("attaches no assignment data", func(t *testing.T) {
+		strategy := NewBalanceStrategyCooperativeSticky()
+		data, err := strategy.AssignmentData("m1", map[string][]int32{topic: {0}}, 7)
+		require.NoError(t, err)
+		require.Nil(t, data)
+	})
+
+	t.Run("subscription user data is a bare int32 generation", func(t *testing.T) {
+		strategy := NewBalanceStrategyCooperativeSticky().(*cooperativeStickyBalanceStrategy)
+
+		data, err := strategy.SubscriptionUserData([]string{topic})
+		require.NoError(t, err)
+		require.Equal(t, []byte{0xff, 0xff, 0xff, 0xff}, data)
+
+		strategy.OnAssignment(&ConsumerGroupMemberAssignment{}, 7)
+		data, err = strategy.SubscriptionUserData([]string{topic})
+		require.NoError(t, err)
+		require.Equal(t, []byte{0x00, 0x00, 0x00, 0x07}, data)
+	})
+
+	t.Run("ownership is read from owned partitions not user data", func(t *testing.T) {
+		meta := ownedMeta(7, 0, 3)
+		data, err := memberData(meta, true)
+		require.NoError(t, err)
+		want := []topicPartitionAssignment{{Topic: topic, Partition: 0}, {Topic: topic, Partition: 3}}
+		require.Equal(t, want, data.partitions())
+		require.Equal(t, 7, data.generation())
+	})
+
+	t.Run("generation falls back to user data below subscription v2", func(t *testing.T) {
+		userData, err := encode(&cooperativeStickyAssignorUserData{Generation: 4}, nil)
+		require.NoError(t, err)
+		meta := ConsumerGroupMemberMetadata{
+			Version:         1, // no GenerationID field on the wire
+			Topics:          []string{topic},
+			UserData:        userData,
+			OwnedPartitions: []*OwnedPartition{{Topic: topic, Partitions: []int32{1}}},
+		}
+		data, err := memberData(meta, true)
+		require.NoError(t, err)
+		require.Equal(t, 4, data.generation())
+	})
+
+	t.Run("a member reporting nothing owns nothing", func(t *testing.T) {
+		data, err := memberData(ownedMeta(defaultGeneration), true)
+		require.NoError(t, err)
+		require.Empty(t, data.partitions())
+		require.Equal(t, defaultGeneration, data.generation())
+	})
+
+	t.Run("unreadable user data does not fail the rebalance", func(t *testing.T) {
+		meta := ownedMeta(defaultGeneration, 0)
+		meta.UserData = []byte("invalid")
+		plan, err := NewBalanceStrategyCooperativeSticky().Plan(
+			map[string]ConsumerGroupMemberMetadata{"m1": meta},
+			map[string][]int32{topic: {0}},
+		)
+		require.NoError(t, err)
+		require.Equal(t, []int32{0}, planPartitions(plan, "m1", topic))
+	})
+
+	t.Run("partitions changing hands are withheld then reassigned", func(t *testing.T) {
+		topics := map[string][]int32{topic: {0, 1, 2, 3}}
+
+		strategy := NewBalanceStrategyCooperativeSticky()
+		members := map[string]ConsumerGroupMemberMetadata{
+			"m1": ownedMeta(1, 0, 1, 2, 3),
+			"m2": ownedMeta(defaultGeneration),
+		}
+		plan, err := strategy.Plan(members, topics)
+		require.NoError(t, err)
+
+		require.Len(t, planPartitions(plan, "m1", topic), 2, "m1 should retain 2 partitions")
+		require.Empty(t, planPartitions(plan, "m2", topic), "m2 should get nothing until m1 has revoked")
+
+		retained := planPartitions(plan, "m1", topic)
+		members = map[string]ConsumerGroupMemberMetadata{
+			"m1": ownedMeta(2, retained...),
+			"m2": ownedMeta(2),
+		}
+		plan, err = strategy.Plan(members, topics)
+		require.NoError(t, err)
+		require.Equal(t, retained, planPartitions(plan, "m1", topic), "m1 should keep its partitions across the rebalance")
+		require.Len(t, planPartitions(plan, "m2", topic), 2, "m2 should get the 2 freed partitions")
+
+		assigned := append(planPartitions(plan, "m1", topic), planPartitions(plan, "m2", topic)...)
+		slices.Sort(assigned)
+		require.Equal(t, []int32{0, 1, 2, 3}, assigned)
+	})
+
+	t.Run("unowned partitions are assigned immediately", func(t *testing.T) {
+		strategy := NewBalanceStrategyCooperativeSticky()
+		members := map[string]ConsumerGroupMemberMetadata{"m1": ownedMeta(defaultGeneration)}
+		plan, err := strategy.Plan(members, map[string][]int32{topic: {0, 1}})
+		require.NoError(t, err)
+		require.Equal(t, []int32{0, 1}, planPartitions(plan, "m1", topic))
+	})
+
+	t.Run("an unchanged assignment is left alone", func(t *testing.T) {
+		strategy := NewBalanceStrategyCooperativeSticky()
+		members := map[string]ConsumerGroupMemberMetadata{
+			"m1": ownedMeta(3, 0),
+			"m2": ownedMeta(3, 1),
+		}
+		plan, err := strategy.Plan(members, map[string][]int32{topic: {0, 1}})
+		require.NoError(t, err)
+		require.Equal(t, []int32{0}, planPartitions(plan, "m1", topic))
+		require.Equal(t, []int32{1}, planPartitions(plan, "m2", topic))
+	})
+}
+
+func planPartitions(plan BalanceStrategyPlan, memberID, topic string) []int32 {
+	partitions := slices.Clone(plan[memberID][topic])
+	slices.Sort(partitions)
+	return partitions
+}

--- a/balance_strategy_test.go
+++ b/balance_strategy_test.go
@@ -444,7 +444,7 @@ func Test_prepopulateCurrentAssignments(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, gotPrevAssignments, err := prepopulateCurrentAssignments(tt.args.members)
+			_, gotPrevAssignments, err := prepopulateCurrentAssignments(tt.args.members, false)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("prepopulateCurrentAssignments() error = %v, wantErr %v", err, tt.wantErr)

--- a/sticky_assignor_user_data.go
+++ b/sticky_assignor_user_data.go
@@ -113,6 +113,29 @@ func (m *StickyAssignorUserDataV1) partitions() []topicPartitionAssignment { ret
 func (m *StickyAssignorUserDataV1) hasGeneration() bool                    { return true }
 func (m *StickyAssignorUserDataV1) generation() int                        { return int(m.Generation) }
 
+// cooperativeStickyAssignorUserData matches Java's bare int32 generation data
+type cooperativeStickyAssignorUserData struct {
+	Generation int32
+
+	topicPartitions []topicPartitionAssignment
+}
+
+func (m *cooperativeStickyAssignorUserData) encode(pe packetEncoder) error {
+	pe.putInt32(m.Generation)
+	return nil
+}
+
+func (m *cooperativeStickyAssignorUserData) decode(pd packetDecoder) (err error) {
+	m.Generation, err = pd.getInt32()
+	return err
+}
+
+func (m *cooperativeStickyAssignorUserData) partitions() []topicPartitionAssignment {
+	return m.topicPartitions
+}
+func (m *cooperativeStickyAssignorUserData) hasGeneration() bool { return true }
+func (m *cooperativeStickyAssignorUserData) generation() int     { return int(m.Generation) }
+
 func populateTopicPartitions(topics map[string][]int32) []topicPartitionAssignment {
 	topicPartitions := make([]topicPartitionAssignment, 0)
 	for topic, partitions := range topics {


### PR DESCRIPTION
Reuse the sticky planner with ownership from subscription metadata. Partitions moving between members are withheld until their previous owner has revoked them.

Advertise both eager and cooperative protocols so existing groups can migrate with two rolling deployments.