### PR TITLE
feat: raise default Kafka version to 2.8.0

### DIFF
--- a/config.go
+++ b/config.go
@@ -529,7 +529,8 @@ type Config struct {
 	// and most 3rdparty ones.
 	ApiVersionsRequest bool
 	// The version of Kafka that Sarama will assume it is running against.
-	// Defaults to the oldest supported stable version. Since Kafka provides
+	// Defaults to 2.8 as Sarama has full protocol coverage for that
+	// version. Since Kafka provides
 	// backwards-compatibility, setting it to a version older than you have
 	// will not break anything, although it may prevent you from using the
 	// latest features. Setting it to a version greater than you are actually

--- a/utils.go
+++ b/utils.go
@@ -309,9 +309,10 @@ var (
 		V4_3_0_0,
 		V4_3_1_0,
 	}
-	MinVersion     = V0_8_2_0
-	MaxVersion     = V4_3_1_0
-	DefaultVersion = V2_6_0_0
+	MinVersion = V0_8_2_0
+	MaxVersion = V4_3_1_0
+	// DefaultVersion is 2.8 as Sarama has full protocol coverage for that version
+	DefaultVersion = V2_8_0_0
 )
 
 var (


### PR DESCRIPTION
Sarama has full protocol coverage up to and including 2.8, so assume that as the baseline rather than 2.6.0 when Version is unset.