### PR TITLE
refactor(consumer): separate join and sync round

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -278,7 +278,7 @@ func (c *consumerGroup) ResumeAll() {
 	c.consumer.ResumeAll()
 }
 
-func (c *consumerGroup) retryNewSession(ctx context.Context, topics []string, handler ConsumerGroupHandler, retries int, refreshCoordinator bool) (*consumerGroupSession, error) {
+func (c *consumerGroup) retryJoinSync(ctx context.Context, topics []string, held *heldAssignment, retries int, refreshCoordinator bool) (*rebalanceResult, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
@@ -293,14 +293,30 @@ func (c *consumerGroup) retryNewSession(ctx context.Context, topics []string, ha
 			if retries <= 0 {
 				return nil, err
 			}
-			return c.retryNewSession(ctx, topics, handler, retries-1, true)
+			return c.retryJoinSync(ctx, topics, held, retries-1, true)
 		}
 	}
 
-	return c.newSession(ctx, topics, handler, retries-1)
+	return c.joinSync(ctx, topics, held, retries-1)
 }
 
-func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler ConsumerGroupHandler, retries int) (*consumerGroupSession, error) {
+type heldAssignment struct {
+	claims       map[string][]int32
+	generationID int32
+}
+
+type rebalanceResult struct {
+	memberID     string
+	generationID int32
+	claims       map[string][]int32
+
+	isLeader                     bool
+	allSubscribedTopicPartitions map[string][]int32
+	allSubscribedTopics          []string
+}
+
+// joinSync separates group negotiation from session lifetime so a session can survive a rejoin
+func (c *consumerGroup) joinSync(ctx context.Context, topics []string, held *heldAssignment, retries int) (*rebalanceResult, error) {
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
@@ -310,7 +326,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 			return nil, err
 		}
 
-		return c.retryNewSession(ctx, topics, handler, retries, true)
+		return c.retryJoinSync(ctx, topics, held, retries, true)
 	}
 
 	var (
@@ -329,7 +345,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 	}
 
 	// Join consumer group
-	join, err := c.joinGroupRequest(coordinator, topics)
+	join, err := c.joinGroupRequest(coordinator, topics, held)
 	if consumerGroupJoinTotal != nil {
 		consumerGroupJoinTotal.Inc(1)
 	}
@@ -351,20 +367,23 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 	case ErrUnknownMemberId, ErrIllegalGeneration:
 		// reset member ID and retry immediately
 		c.memberID = ""
-		return c.newSession(ctx, topics, handler, retries)
+		if c.lostHeldAssignment(held, join.Err) {
+			return nil, join.Err
+		}
+		return c.joinSync(ctx, topics, held, retries)
 	case ErrNotCoordinatorForConsumer, ErrRebalanceInProgress, ErrOffsetsLoadInProgress:
 		// retry after backoff
 		if retries <= 0 {
 			return nil, join.Err
 		}
-		return c.retryNewSession(ctx, topics, handler, retries, true)
+		return c.retryJoinSync(ctx, topics, held, retries, true)
 	case ErrMemberIdRequired:
 		// from JoinGroupRequest v4 onwards (due to KIP-394) if the client starts
 		// with an empty member id, it needs to get the assigned id from the
 		// response and send another join request with that id to actually join the
 		// group
 		c.memberID = join.MemberId
-		return c.newSession(ctx, topics, handler, retries)
+		return c.joinSync(ctx, topics, held, retries)
 	case ErrFencedInstancedId:
 		if c.groupInstanceId != nil {
 			Logger.Printf("JoinGroup failed: group instance id %s has been fenced\n", *c.groupInstanceId)
@@ -425,13 +444,16 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 	case ErrUnknownMemberId, ErrIllegalGeneration:
 		// reset member ID and retry immediately
 		c.memberID = ""
-		return c.newSession(ctx, topics, handler, retries)
+		if c.lostHeldAssignment(held, syncGroupResponse.Err) {
+			return nil, syncGroupResponse.Err
+		}
+		return c.joinSync(ctx, topics, held, retries)
 	case ErrNotCoordinatorForConsumer, ErrRebalanceInProgress, ErrOffsetsLoadInProgress:
 		// retry after backoff
 		if retries <= 0 {
 			return nil, syncGroupResponse.Err
 		}
-		return c.retryNewSession(ctx, topics, handler, retries, true)
+		return c.retryJoinSync(ctx, topics, held, retries, true)
 	case ErrFencedInstancedId:
 		if c.groupInstanceId != nil {
 			Logger.Printf("JoinGroup failed: group instance id %s has been fenced\n", *c.groupInstanceId)
@@ -470,20 +492,44 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 		}
 	}
 
-	session, err := newConsumerGroupSession(ctx, c, claims, join.MemberId, join.GenerationId, handler)
+	return &rebalanceResult{
+		memberID:                     join.MemberId,
+		generationID:                 join.GenerationId,
+		claims:                       claims,
+		isLeader:                     join.LeaderId == join.MemberId,
+		allSubscribedTopicPartitions: allSubscribedTopicPartitions,
+		allSubscribedTopics:          allSubscribedTopics,
+	}, nil
+}
+
+func (c *consumerGroup) lostHeldAssignment(held *heldAssignment, err error) bool {
+	if held == nil || len(held.claims) == 0 {
+		return false
+	}
+	Logger.Printf("consumergroup/%s: lost ownership of %v due to %v\n", c.groupID, held.claims, err)
+	return true
+}
+
+func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler ConsumerGroupHandler, retries int) (*consumerGroupSession, error) {
+	res, err := c.joinSync(ctx, topics, nil, retries)
+	if err != nil {
+		return nil, err
+	}
+
+	session, err := newConsumerGroupSession(ctx, c, res.claims, res.memberID, res.generationID, handler)
 	if err != nil {
 		return nil, err
 	}
 
 	// only the leader needs to check whether there are newly-added partitions in order to trigger a rebalance
-	if join.LeaderId == join.MemberId {
-		go c.loopCheckPartitionNumbers(allSubscribedTopicPartitions, allSubscribedTopics, session)
+	if res.isLeader {
+		go c.loopCheckPartitionNumbers(res.allSubscribedTopicPartitions, res.allSubscribedTopics, session)
 	}
 
-	return session, err
+	return session, nil
 }
 
-func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (*JoinGroupResponse, error) {
+func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string, held *heldAssignment) (*JoinGroupResponse, error) {
 	req := &JoinGroupRequest{
 		GroupId:        c.groupID,
 		MemberId:       c.memberID,
@@ -523,11 +569,15 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string) (
 		c.lastSessionCause = nil
 	}
 
-	// Under the eager protocol the previous session has already been torn down
-	// by the time we rejoin, so this member owns nothing and has no generation
-	// to report. The cooperative path supplies both.
+	var owned map[string][]int32
+	generationID := int32(defaultGeneration)
+	if held != nil {
+		owned = held.claims
+		generationID = held.generationID
+	}
+
 	for _, strategy := range c.config.groupStrategies() {
-		meta := c.subscriptionMetadata(strategy, topics, nil, defaultGeneration)
+		meta := c.subscriptionMetadata(strategy, topics, owned, generationID)
 		if err := req.AddGroupProtocolMetadata(strategy.Name(), meta); err != nil {
 			return nil, err
 		}

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -252,8 +252,142 @@ func TestConsumerShouldNotRetrySessionIfContextCancelled(t *testing.T) {
 	cancel()
 	_, err := c.newSession(ctx, nil, nil, 1024)
 	assert.Equal(t, context.Canceled, err)
-	_, err = c.retryNewSession(ctx, nil, nil, 1024, true)
+	_, err = c.retryJoinSync(ctx, nil, nil, 1024, true)
 	assert.Equal(t, context.Canceled, err)
+}
+
+func TestConsumerGroupJoinSync(t *testing.T) {
+	setup := func(t *testing.T, joinResponse, syncResponse MockResponse) (*consumerGroup, *MockBroker) {
+		t.Helper()
+
+		config := NewTestConfig()
+		config.ClientID = t.Name()
+		config.Version = V3_2_0_0
+		config.Consumer.Group.Rebalance.Retry.Backoff = 0
+
+		broker := NewMockBroker(t, 0)
+		t.Cleanup(broker.Close)
+		broker.SetHandlerByMap(map[string]MockResponse{
+			"MetadataRequest": NewMockMetadataResponse(t).
+				SetBroker(broker.Addr(), broker.BrokerID()),
+			"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).
+				SetCoordinator(CoordinatorGroup, "my-group", broker),
+			"JoinGroupRequest":  joinResponse,
+			"SyncGroupRequest":  syncResponse,
+			"LeaveGroupRequest": NewMockLeaveGroupResponse(t),
+		})
+
+		group, err := NewConsumerGroup([]string{broker.Addr()}, "my-group", config)
+		assert.NoError(t, err)
+		t.Cleanup(func() {
+			assert.NoError(t, group.Close())
+		})
+
+		return group.(*consumerGroup), broker
+	}
+
+	joinRequests := func(broker *MockBroker) []*JoinGroupRequest {
+		var requests []*JoinGroupRequest
+		for _, exchange := range broker.History() {
+			if request, ok := exchange.Request.(*JoinGroupRequest); ok {
+				requests = append(requests, request)
+			}
+		}
+		return requests
+	}
+
+	t.Run("returns the negotiated assignment and reports retained ownership", func(t *testing.T) {
+		c, broker := setup(
+			t,
+			NewMockJoinGroupResponse(t).
+				SetGroupProtocol(RangeBalanceStrategyName).
+				SetGenerationId(7).
+				SetLeaderId("other-member").
+				SetMemberId("member-1"),
+			NewMockSyncGroupResponse(t).SetMemberAssignment(
+				&ConsumerGroupMemberAssignment{
+					Topics: map[string][]int32{"my-topic": {2, 0}},
+				},
+			),
+		)
+		c.memberID = "member-1"
+		held := &heldAssignment{
+			claims:       map[string][]int32{"my-topic": {3, 1}},
+			generationID: 6,
+		}
+
+		result, err := c.joinSync(t.Context(), []string{"my-topic"}, held, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, "member-1", result.memberID)
+		assert.Equal(t, int32(7), result.generationID)
+		assert.Equal(t, map[string][]int32{"my-topic": {0, 2}}, result.claims)
+		assert.False(t, result.isLeader)
+
+		requests := joinRequests(broker)
+		assert.Len(t, requests, 1)
+		assert.Len(t, requests[0].OrderedGroupProtocols, 1)
+		metadata := &ConsumerGroupMemberMetadata{}
+		assert.NoError(t, decode(requests[0].OrderedGroupProtocols[0].Metadata, metadata, nil))
+		assert.Equal(t, []*OwnedPartition{
+			{Topic: "my-topic", Partitions: []int32{1, 3}},
+		}, metadata.OwnedPartitions)
+		assert.Equal(t, int32(6), metadata.GenerationID)
+	})
+
+	t.Run("retries unknown membership when no assignment is retained", func(t *testing.T) {
+		c, broker := setup(
+			t,
+			NewMockSequence(
+				NewMockJoinGroupResponse(t).SetError(ErrUnknownMemberId),
+				NewMockJoinGroupResponse(t).
+					SetGroupProtocol(RangeBalanceStrategyName).
+					SetMemberId("member-2"),
+			),
+			NewMockSyncGroupResponse(t),
+		)
+		c.memberID = "stale-member"
+
+		result, err := c.joinSync(t.Context(), []string{"my-topic"}, nil, 0)
+		assert.NoError(t, err)
+		assert.Equal(t, "member-2", result.memberID)
+		assert.Len(t, joinRequests(broker), 2)
+	})
+
+	t.Run("returns unknown membership when retained ownership is lost", func(t *testing.T) {
+		c, broker := setup(
+			t,
+			NewMockJoinGroupResponse(t).SetError(ErrUnknownMemberId),
+			NewMockSyncGroupResponse(t),
+		)
+		c.memberID = "stale-member"
+
+		result, err := c.joinSync(t.Context(), []string{"my-topic"}, &heldAssignment{
+			claims:       map[string][]int32{"my-topic": {0}},
+			generationID: 4,
+		}, 1)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrUnknownMemberId)
+		assert.Len(t, joinRequests(broker), 1)
+	})
+
+	t.Run("returns illegal generation when sync invalidates retained ownership", func(t *testing.T) {
+		c, broker := setup(
+			t,
+			NewMockJoinGroupResponse(t).
+				SetGroupProtocol(RangeBalanceStrategyName).
+				SetMemberId("member-3"),
+			NewMockSyncGroupResponse(t).SetError(ErrIllegalGeneration),
+		)
+		c.memberID = "member-3"
+
+		result, err := c.joinSync(t.Context(), []string{"my-topic"}, &heldAssignment{
+			claims:       map[string][]int32{"my-topic": {0}},
+			generationID: 4,
+		}, 1)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, ErrIllegalGeneration)
+		assert.Len(t, joinRequests(broker), 1)
+	})
 }
 
 // strategyWithSubscriptionUserData wraps a BalanceStrategy and adds a


### PR DESCRIPTION
- decouple group negotiation from session creation so cooperative members can rejoin without replacing their session
- return the negotiated assignment and leader metadata needed to create or retain a session
- carry retained ownership into JoinGroup and stop if the broker invalidates it