### PR TITLE
fix(consumer): preserve pauses across reassignment

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -106,6 +106,9 @@ type consumer struct {
 	client          Client
 	metricRegistry  metrics.Registry
 	lock            sync.Mutex
+
+	// paused retains pause state while a partition is reassigned, guarded by lock
+	paused map[string]map[int32]none
 }
 
 // NewConsumer creates a new consumer using the given broker addresses and configuration.
@@ -137,6 +140,7 @@ func newConsumer(client Client) (Consumer, error) {
 		conf:            client.Config(),
 		children:        make(map[string]map[int32]*partitionConsumer),
 		brokerConsumers: make(map[*Broker]*brokerConsumer),
+		paused:          make(map[string]map[int32]none),
 		metricRegistry:  newCleanupRegistry(client.Config().MetricRegistry),
 	}
 
@@ -234,6 +238,10 @@ func (c *consumer) addChild(child *partitionConsumer) error {
 		return ConfigurationError("That topic/partition is already being consumed")
 	}
 
+	if _, paused := c.paused[child.topic][child.partition]; paused {
+		child.Pause()
+	}
+
 	topicChildren[child.partition] = child
 	return nil
 }
@@ -290,6 +298,10 @@ func (c *consumer) Pause(topicPartitions map[string][]int32) {
 		for _, partition := range partitions {
 			if topicConsumers, ok := c.children[topic]; ok {
 				if partitionConsumer, ok := topicConsumers[partition]; ok {
+					if c.paused[topic] == nil {
+						c.paused[topic] = make(map[int32]none)
+					}
+					c.paused[topic][partition] = none{}
 					partitionConsumer.Pause()
 				}
 			}
@@ -304,6 +316,11 @@ func (c *consumer) Resume(topicPartitions map[string][]int32) {
 
 	for topic, partitions := range topicPartitions {
 		for _, partition := range partitions {
+			delete(c.paused[topic], partition)
+			if len(c.paused[topic]) == 0 {
+				delete(c.paused, topic)
+			}
+
 			if topicConsumers, ok := c.children[topic]; ok {
 				if partitionConsumer, ok := topicConsumers[partition]; ok {
 					partitionConsumer.Resume()
@@ -318,8 +335,13 @@ func (c *consumer) PauseAll() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	for _, partitions := range c.children {
-		for _, partitionConsumer := range partitions {
+	for topic, partitions := range c.children {
+		for partition, partitionConsumer := range partitions {
+			if c.paused[topic] == nil {
+				c.paused[topic] = make(map[int32]none)
+			}
+			c.paused[topic][partition] = none{}
+
 			partitionConsumer.Pause()
 		}
 	}
@@ -330,6 +352,7 @@ func (c *consumer) ResumeAll() {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	clear(c.paused)
 	for _, partitions := range c.children {
 		for _, partitionConsumer := range partitions {
 			partitionConsumer.Resume()

--- a/consumer.go
+++ b/consumer.go
@@ -100,14 +100,15 @@ type Consumer interface {
 const partitionConsumersBatchTimeout = 100 * time.Millisecond
 
 type consumer struct {
-	conf            *Config
+	conf           *Config
+	client         Client
+	metricRegistry metrics.Registry
+
+	// lock guards the fields below it
+	lock            sync.Mutex
 	children        map[string]map[int32]*partitionConsumer
 	brokerConsumers map[*Broker]*brokerConsumer
-	client          Client
-	metricRegistry  metrics.Registry
-	lock            sync.Mutex
-
-	// paused retains pause state while a partition is reassigned, guarded by lock
+	// paused retains pause state while a partition is reassigned
 	paused map[string]map[int32]none
 }
 

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/rcrowley/go-metrics"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 )
@@ -2579,5 +2580,96 @@ func TestConsumerAbortNoGoroutineLeak(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			require.FailNow(t, "abort() did not return")
 		}
+	})
+}
+
+func TestConsumerPause(t *testing.T) {
+	newConsumerWithChild := func() (*consumer, *partitionConsumer) {
+		c := &consumer{
+			children: make(map[string]map[int32]*partitionConsumer),
+			paused:   make(map[string]map[int32]none),
+		}
+		return c, &partitionConsumer{topic: "my_topic", partition: 0}
+	}
+
+	t.Run("a paused partition stays paused when reassigned", func(t *testing.T) {
+		c, child := newConsumerWithChild()
+		require.NoError(t, c.addChild(child))
+		c.Pause(map[string][]int32{"my_topic": {0}})
+		assert.True(t, child.IsPaused())
+		c.removeChild(child)
+
+		reassigned := &partitionConsumer{topic: child.topic, partition: child.partition}
+		require.NoError(t, c.addChild(reassigned))
+		assert.True(t, reassigned.IsPaused())
+	})
+
+	t.Run("a partition paused by PauseAll comes back paused when reassigned", func(t *testing.T) {
+		c, child := newConsumerWithChild()
+		require.NoError(t, c.addChild(child))
+		c.PauseAll()
+		assert.True(t, child.IsPaused())
+		c.removeChild(child)
+
+		reassigned := &partitionConsumer{topic: child.topic, partition: child.partition}
+		require.NoError(t, c.addChild(reassigned))
+		assert.True(t, reassigned.IsPaused())
+	})
+
+	t.Run("resuming after PauseAll keeps the partition resumed when reassigned", func(t *testing.T) {
+		c, child := newConsumerWithChild()
+		require.NoError(t, c.addChild(child))
+		c.PauseAll()
+		c.Resume(map[string][]int32{child.topic: {child.partition}})
+		assert.False(t, child.IsPaused())
+		c.removeChild(child)
+
+		reassigned := &partitionConsumer{topic: child.topic, partition: child.partition}
+		require.NoError(t, c.addChild(reassigned))
+		assert.False(t, reassigned.IsPaused())
+	})
+
+	t.Run("resuming one partition retains pauses for other partitions", func(t *testing.T) {
+		c, child := newConsumerWithChild()
+		otherChild := &partitionConsumer{topic: child.topic, partition: 1}
+		require.NoError(t, c.addChild(child))
+		require.NoError(t, c.addChild(otherChild))
+		c.PauseAll()
+		c.Resume(map[string][]int32{child.topic: {child.partition}})
+		c.removeChild(child)
+		c.removeChild(otherChild)
+
+		reassigned := &partitionConsumer{topic: child.topic, partition: child.partition}
+		otherReassigned := &partitionConsumer{topic: otherChild.topic, partition: otherChild.partition}
+		require.NoError(t, c.addChild(reassigned))
+		require.NoError(t, c.addChild(otherReassigned))
+		assert.False(t, reassigned.IsPaused())
+		assert.True(t, otherReassigned.IsPaused())
+	})
+
+	t.Run("an unpaused partition is not affected", func(t *testing.T) {
+		c, child := newConsumerWithChild()
+		c.Pause(map[string][]int32{"my_topic": {1}, "other_topic": {0}})
+		require.NoError(t, c.addChild(child))
+		assert.False(t, child.IsPaused())
+	})
+
+	t.Run("pausing an unassigned partition does not affect a later assignment", func(t *testing.T) {
+		c, child := newConsumerWithChild()
+		c.Pause(map[string][]int32{"my_topic": {0}})
+		require.NoError(t, c.addChild(child))
+		assert.False(t, child.IsPaused())
+	})
+
+	t.Run("ResumeAll clears retained pauses", func(t *testing.T) {
+		c, child := newConsumerWithChild()
+		require.NoError(t, c.addChild(child))
+		c.PauseAll()
+		c.removeChild(child)
+		c.ResumeAll()
+
+		reassigned := &partitionConsumer{topic: child.topic, partition: child.partition}
+		require.NoError(t, c.addChild(reassigned))
+		assert.False(t, reassigned.IsPaused())
 	})
 }


### PR DESCRIPTION
- prevent reassignment from silently resuming paused consumption
- retain pauses for active partitions and apply them to replacement consumers
- clear retained state through Resume and ResumeAll, with unit test coverage