### PR TITLE
feat(offset): commit revoked partitions on cooperative rebalance

### DIFF
--- a/offset_manager.go
+++ b/offset_manager.go
@@ -35,13 +35,16 @@ type offsetManager struct {
 
 	memberID        string
 	groupInstanceId *string
-	generation      int32
 
-	broker     *Broker
+	// generationLock prevents a commit from crossing a generation boundary
+	generationLock sync.RWMutex
+	generation     int32
+
 	brokerLock sync.RWMutex
+	broker     *Broker
 
-	poms     map[string]map[int32]*partitionOffsetManager
 	pomsLock sync.RWMutex
+	poms     map[string]map[int32]*partitionOffsetManager
 
 	closeOnce sync.Once
 	closing   chan none
@@ -255,17 +258,42 @@ func (om *offsetManager) Commit() {
 	om.releasePOMs(false)
 }
 
+//lint:ignore U1000 // consumed by the cooperative rebalancing path added in a following PR; the only in-build caller here is the unit test (excluded by the integration build tag)
+func (om *offsetManager) setGeneration(generation int32) {
+	om.generationLock.Lock()
+	defer om.generationLock.Unlock()
+	om.generation = generation
+}
+
+// partitionTargets names a subset of managed partitions; a nil set means all of them
+type partitionTargets map[string]map[int32]none
+
+func (ps partitionTargets) covers(topic string, partition int32) bool {
+	if ps == nil {
+		return true
+	}
+	_, ok := ps[topic][partition]
+	return ok
+}
+
 func (om *offsetManager) flushToBroker() {
+	om.flushToBrokerFor(nil)
+}
+
+func (om *offsetManager) flushToBrokerFor(targets partitionTargets) {
+	om.generationLock.RLock()
+	defer om.generationLock.RUnlock()
+
 	broker, err := om.coordinator()
 	if err != nil {
-		om.handleError(err)
+		om.handleErrorFor(err, targets)
 		return
 	}
 
 	// Care needs to be taken to unlock this. Don't want to defer the unlock as this would
 	// cause the lock to be held while waiting for the broker to reply.
 	broker.lock.Lock()
-	req := om.constructRequest()
+	req := om.constructRequestFor(targets)
 	if req == nil {
 		broker.lock.Unlock()
 		return
@@ -274,7 +302,7 @@ func (om *offsetManager) flushToBroker() {
 	broker.lock.Unlock()
 
 	if err != nil {
-		om.handleError(err)
+		om.handleErrorFor(err, targets)
 		om.releaseCoordinator(broker)
 		_ = broker.Close()
 		return
@@ -282,7 +310,7 @@ func (om *offsetManager) flushToBroker() {
 
 	err = handleResponsePromise(req, resp, rp, nil)
 	if err != nil {
-		om.handleError(err)
+		om.handleErrorFor(err, targets)
 		om.releaseCoordinator(broker)
 		_ = broker.Close()
 		return
@@ -303,11 +331,12 @@ func sendOffsetCommit(coordinator *Broker, req *OffsetCommitRequest) (*OffsetCom
 	return resp, promise, nil
 }
 
-func (om *offsetManager) constructRequest() *OffsetCommitRequest {
+func (om *offsetManager) constructRequestFor(targets partitionTargets) *OffsetCommitRequest {
 	r := &OffsetCommitRequest{
-		Version:                 1,
-		ConsumerGroup:           om.group,
-		ConsumerID:              om.memberID,
+		Version:       1,
+		ConsumerGroup: om.group,
+		ConsumerID:    om.memberID,
+		// om.generation is read under generationLock, held by flushToBrokerFor
 		ConsumerGroupGeneration: om.generation,
 	}
 	// Version 1 adds timestamp and group membership information, as well as the commit timestamp.
@@ -361,8 +390,11 @@ func (om *offsetManager) constructRequest() *OffsetCommitRequest {
 	om.pomsLock.RLock()
 	defer om.pomsLock.RUnlock()
 
-	for _, topicManagers := range om.poms {
-		for _, pom := range topicManagers {
+	for topic, topicManagers := range om.poms {
+		for partition, pom := range topicManagers {
+			if !targets.covers(topic, partition) {
+				continue
+			}
 			pom.lock.Lock()
 			if pom.dirty {
 				r.AddBlockWithLeaderEpoch(pom.topic, pom.partition, pom.offset, pom.leaderEpoch, commitTimestamp, pom.metadata)
@@ -438,12 +470,15 @@ func (om *offsetManager) handleResponse(broker *Broker, req *OffsetCommitRequest
 	}
 }
 
-func (om *offsetManager) handleError(err error) {
+func (om *offsetManager) handleErrorFor(err error, targets partitionTargets) {
 	om.pomsLock.RLock()
 	defer om.pomsLock.RUnlock()
 
-	for _, topicManagers := range om.poms {
-		for _, pom := range topicManagers {
+	for topic, topicManagers := range om.poms {
+		for partition, pom := range topicManagers {
+			if !targets.covers(topic, partition) {
+				continue
+			}
 			pom.handleError(err)
 		}
 	}
@@ -460,13 +495,58 @@ func (om *offsetManager) asyncClosePOMs() {
 	}
 }
 
+// removePartitions closes partitions revoked during a rebalance, committing first when configured
+//
+//lint:ignore U1000 // consumed by the cooperative rebalancing path added in a following PR; the only in-build caller here is the unit test (excluded by the integration build tag)
+func (om *offsetManager) removePartitions(topicPartitions map[string][]int32) {
+	targets := make(partitionTargets, len(topicPartitions))
+	for topic, partitions := range topicPartitions {
+		targets[topic] = make(map[int32]none, len(partitions))
+		for _, partition := range partitions {
+			targets[topic][partition] = none{}
+		}
+	}
+
+	om.pomsLock.RLock()
+	for topic, partitions := range targets {
+		for partition := range partitions {
+			if pom := om.poms[topic][partition]; pom != nil {
+				pom.AsyncClose()
+			}
+		}
+	}
+	om.pomsLock.RUnlock()
+
+	if !om.conf.Consumer.Offsets.AutoCommit.Enable {
+		om.releaseSelectedPOMs(true, targets)
+		return
+	}
+
+	for attempt := 0; attempt <= om.conf.Consumer.Offsets.Retry.Max; attempt++ {
+		om.flushToBrokerFor(targets)
+		if om.releaseSelectedPOMs(false, targets) == 0 {
+			return
+		}
+	}
+	om.releaseSelectedPOMs(true, targets)
+}
+
 // Releases/removes closed POMs once they are clean (or when forced)
 func (om *offsetManager) releasePOMs(force bool) (remaining int) {
+	return om.releaseSelectedPOMs(force, nil)
+}
+
+// releaseSelectedPOMs holds the write lock while closing POM error channels
+func (om *offsetManager) releaseSelectedPOMs(force bool, targets partitionTargets) (remaining int) {
 	om.pomsLock.Lock()
 	defer om.pomsLock.Unlock()
 
 	for topic, topicManagers := range om.poms {
 		for partition, pom := range topicManagers {
+			if !targets.covers(topic, partition) {
+				continue
+			}
+
 			pom.lock.Lock()
 			releaseDue := pom.done && (force || !pom.dirty)
 			pom.lock.Unlock()
@@ -478,9 +558,10 @@ func (om *offsetManager) releasePOMs(force bool) (remaining int) {
 				if len(om.poms[topic]) == 0 {
 					delete(om.poms, topic)
 				}
+			} else {
+				remaining++
 			}
 		}
-		remaining += len(om.poms[topic])
 	}
 	return
 }

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -902,9 +903,9 @@ func TestConstructRequestRetentionTime(t *testing.T) {
 		for _, retention := range []time.Duration{0, time.Millisecond} {
 			name := fmt.Sprintf("version %s retention: %s", version, retention)
 			t.Run(name, func(t *testing.T) {
-				// Perform necessary setup for calling the constructRequest() method. This
-				// test-case only cares about the code path that sets the retention time
-				// field in the returned request struct.
+				// Perform necessary setup for calling the constructRequestFor() method.
+				// This test-case only cares about the code path that sets the retention
+				// time field in the returned request struct.
 				conf := NewTestConfig()
 				conf.Version = version
 				conf.Consumer.Offsets.Retention = retention
@@ -919,7 +920,7 @@ func TestConstructRequestRetentionTime(t *testing.T) {
 					},
 				}
 
-				req := om.constructRequest()
+				req := om.constructRequestFor(nil)
 
 				expectedRetention := expectedRetention(version, retention)
 				if req.RetentionTime != expectedRetention {
@@ -928,4 +929,252 @@ func TestConstructRequestRetentionTime(t *testing.T) {
 			})
 		}
 	}
+}
+
+// offsetCommitCapture records every OffsetCommitRequest it sees before
+// delegating to the wrapped response.
+type offsetCommitCapture struct {
+	inner MockResponse
+	mu    sync.Mutex
+	reqs  []*OffsetCommitRequest
+}
+
+func (c *offsetCommitCapture) For(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*OffsetCommitRequest)
+	c.mu.Lock()
+	c.reqs = append(c.reqs, req)
+	c.mu.Unlock()
+	return c.inner.For(reqBody)
+}
+
+func (c *offsetCommitCapture) requests() []*OffsetCommitRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return slices.Clone(c.reqs)
+}
+
+func initHandledOffsetManager(t *testing.T, config *Config, commit MockResponse) (*offsetManager, Client, *MockBroker) {
+	t.Helper()
+	config.Version = V2_0_0_0
+
+	broker := NewMockBroker(t, 1)
+	metadata := NewMockMetadataResponse(t).SetBroker(broker.Addr(), broker.BrokerID())
+	offsetFetch := NewMockOffsetFetchResponse(t).SetError(ErrNoError)
+	for p := int32(0); p < 4; p++ {
+		metadata = metadata.SetLeader("my_topic", p, broker.BrokerID())
+		offsetFetch = offsetFetch.SetOffset("group", "my_topic", p, 5, "", ErrNoError)
+	}
+	broker.SetHandlerByMap(map[string]MockResponse{
+		"MetadataRequest":        metadata,
+		"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).SetCoordinator(CoordinatorGroup, "group", broker),
+		"OffsetFetchRequest":     offsetFetch,
+		"OffsetCommitRequest":    commit,
+	})
+
+	client, err := NewClient([]string{broker.Addr()}, config)
+	require.NoError(t, err)
+
+	om, err := newOffsetManagerFromClient("group", "member", 1, client, nil)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		safeClose(t, om)
+		safeClose(t, client)
+		broker.Close()
+	})
+	return om, client, broker
+}
+
+// newCapturingOffsetManager builds an offset manager whose commit requests are
+// recorded in the returned capture.
+func newCapturingOffsetManager(t *testing.T, autoCommit bool) (*offsetManager, *offsetCommitCapture) {
+	t.Helper()
+	config := NewTestConfig()
+	config.Consumer.Offsets.AutoCommit.Enable = autoCommit
+	capture := &offsetCommitCapture{inner: NewMockOffsetCommitResponse(t)}
+	om, _, _ := initHandledOffsetManager(t, config, capture)
+	return om, capture
+}
+
+func TestOffsetManagerRemovePartitions(t *testing.T) {
+	t.Run("commits marked offsets and stops managing the partitions", func(t *testing.T) {
+		om, capture := newCapturingOffsetManager(t, true)
+
+		poms := map[int32]PartitionOffsetManager{}
+		for p := int32(0); p < 4; p++ {
+			pom, err := om.ManagePartition("my_topic", p)
+			require.NoError(t, err)
+			pom.MarkOffset(int64(100+p), "")
+			poms[p] = pom
+		}
+
+		om.removePartitions(map[string][]int32{"my_topic": {2, 3}})
+
+		var committed []int32
+		for _, req := range capture.requests() {
+			for p := range req.blocks["my_topic"] {
+				committed = append(committed, p)
+			}
+		}
+		require.Contains(t, committed, int32(2))
+		require.Contains(t, committed, int32(3))
+		require.NotContains(t, committed, int32(0))
+		require.NotContains(t, committed, int32(1))
+
+		require.Nil(t, om.findPOM("my_topic", 2))
+		require.Nil(t, om.findPOM("my_topic", 3))
+		require.NotNil(t, om.findPOM("my_topic", 0))
+		require.NotNil(t, om.findPOM("my_topic", 1))
+
+		_, open := <-poms[2].Errors()
+		require.False(t, open)
+	})
+
+	t.Run("does not commit marked offsets when auto-commit is disabled", func(t *testing.T) {
+		om, capture := newCapturingOffsetManager(t, false)
+
+		poms := map[int32]PartitionOffsetManager{}
+		for p := int32(0); p < 2; p++ {
+			pom, err := om.ManagePartition("my_topic", p)
+			require.NoError(t, err)
+			pom.MarkOffset(int64(100+p), "")
+			poms[p] = pom
+		}
+
+		om.removePartitions(map[string][]int32{"my_topic": {1}})
+
+		require.Empty(t, capture.requests())
+		require.Nil(t, om.findPOM("my_topic", 1))
+		require.NotNil(t, om.findPOM("my_topic", 0))
+		_, open := <-poms[1].Errors()
+		require.False(t, open)
+	})
+
+	t.Run("ignores partitions that are not managed", func(t *testing.T) {
+		om, _ := newCapturingOffsetManager(t, false)
+
+		_, err := om.ManagePartition("my_topic", 0)
+		require.NoError(t, err)
+
+		om.removePartitions(map[string][]int32{"my_topic": {3}, "other_topic": {0}})
+		require.NotNil(t, om.findPOM("my_topic", 0))
+	})
+
+	// send-on-closed-channel safety when a commit runs concurrently with removePartitions (#2608)
+	t.Run("is safe against a concurrent commit", func(t *testing.T) {
+		config := NewTestConfig()
+		config.Consumer.Offsets.AutoCommit.Enable = false
+		config.Consumer.Offsets.Retry.Max = 0
+		config.Consumer.Return.Errors = true
+
+		commit := NewMockOffsetCommitResponse(t)
+		for p := int32(0); p < 4; p++ {
+			commit = commit.SetError("group", "my_topic", p, ErrOffsetMetadataTooLarge)
+		}
+		om, _, _ := initHandledOffsetManager(t, config, commit)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < 300; i++ {
+				om.Commit()
+			}
+		}()
+
+		for i := 0; i < 120; i++ {
+			p := int32(i % 4)
+			pom, err := om.ManagePartition("my_topic", p)
+			require.NoError(t, err)
+			go func() {
+				for range pom.Errors() {
+				}
+			}()
+			pom.MarkOffset(int64(100+i), "")
+			om.removePartitions(map[string][]int32{"my_topic": {p}})
+		}
+		wg.Wait()
+	})
+}
+
+func TestOffsetManagerSetGeneration(t *testing.T) {
+	t.Run("commits carry the generation most recently set", func(t *testing.T) {
+		om, capture := newCapturingOffsetManager(t, false)
+
+		pom, err := om.ManagePartition("my_topic", 0)
+		require.NoError(t, err)
+
+		pom.MarkOffset(100, "")
+		om.Commit()
+		om.setGeneration(7)
+		pom.MarkOffset(101, "")
+		om.Commit()
+
+		reqs := capture.requests()
+		require.NotEmpty(t, reqs)
+		require.Equal(t, int32(1), reqs[0].ConsumerGroupGeneration)
+		require.Equal(t, int32(7), reqs[len(reqs)-1].ConsumerGroupGeneration)
+	})
+
+	t.Run("waits for an in-flight commit to finish", func(t *testing.T) {
+		config := NewTestConfig()
+		config.Consumer.Offsets.AutoCommit.Enable = false
+		capture := &offsetCommitCapture{inner: NewMockOffsetCommitResponse(t)}
+		gate := &gatedResponse{inner: capture, entered: make(chan none), release: make(chan none)}
+		om, _, _ := initHandledOffsetManager(t, config, gate)
+
+		pom, err := om.ManagePartition("my_topic", 0)
+		require.NoError(t, err)
+		pom.MarkOffset(100, "")
+
+		commitDone := make(chan none)
+		go func() {
+			om.Commit()
+			close(commitDone)
+		}()
+		<-gate.entered
+
+		genDone := make(chan none)
+		go func() {
+			om.setGeneration(7)
+			close(genDone)
+		}()
+		require.Never(t, func() bool {
+			select {
+			case <-genDone:
+				return true
+			default:
+				return false
+			}
+		}, 150*time.Millisecond, 20*time.Millisecond)
+
+		close(gate.release)
+		<-commitDone
+		<-genDone
+
+		pom.MarkOffset(101, "")
+		om.Commit()
+
+		reqs := capture.requests()
+		require.Equal(t, int32(1), reqs[0].ConsumerGroupGeneration)
+		require.Equal(t, int32(7), reqs[len(reqs)-1].ConsumerGroupGeneration)
+	})
+}
+
+// gatedResponse holds the first request in flight: it closes entered when that
+// request arrives, then blocks until release is closed. Later requests pass
+// straight through to the wrapped response.
+type gatedResponse struct {
+	inner   MockResponse
+	once    sync.Once
+	entered chan none
+	release chan none
+}
+
+func (g *gatedResponse) For(reqBody versionedDecoder) encoderWithHeader {
+	g.once.Do(func() {
+		close(g.entered)
+		<-g.release
+	})
+	return g.inner.For(reqBody)
 }

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -1016,10 +1016,7 @@ func TestOffsetManagerRemovePartitions(t *testing.T) {
 				committed = append(committed, p)
 			}
 		}
-		require.Contains(t, committed, int32(2))
-		require.Contains(t, committed, int32(3))
-		require.NotContains(t, committed, int32(0))
-		require.NotContains(t, committed, int32(1))
+		require.ElementsMatch(t, []int32{2,3}, committed)
 
 		require.Nil(t, om.findPOM("my_topic", 2))
 		require.Nil(t, om.findPOM("my_topic", 3))


### PR DESCRIPTION
Add removePartitions to commit and stop tracking the offsets for the partitions a cooperative rebalance moves away, without touching the retained ones. A generation lock stops a commit using a stale generation while the assignment is changing.