### PR TITLE
fix(producer): wake blocked flush when a muted partition is unmuted

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -1126,8 +1126,20 @@ func (bp *brokerProducer) run() {
 	Logger.Printf("producer/broker/%d starting up\n", bp.broker.ID())
 
 	for {
+		// if the accumulating batch is ready to flush but every partition is
+		// blocked behind a mute (an in-flight retryBatch), watch for the
+		// unmute signal: no other event may ever arrive to wake us up again (#3689)
+		var unmuteChan <-chan struct{}
 		if bp.flushingBatch == nil && (bp.timerFired || bp.accumulatingBatch.readyToFlush()) {
-			bp.tryBuildFlushingBatch()
+			for !bp.tryBuildFlushingBatch() && !bp.accumulatingBatch.empty() {
+				ch, blocked := bp.parent.muter.awaitUnmuteChan(bp.accumulatingBatch)
+				if blocked {
+					unmuteChan = ch
+					break
+				}
+				// raced with an unmute between the failed build and
+				// awaitUnmuteChan; retry the build immediately
+			}
 		}
 
 		var timerChan <-chan time.Time
@@ -1213,6 +1225,9 @@ func (bp *brokerProducer) run() {
 			bp.timerFired = true
 		case output <- bp.flushingBatch:
 			bp.flushingBatch = nil
+		case <-unmuteChan:
+			// a partition was unmuted; loop around to retry building the
+			// flushing batch
 		case response, ok := <-bp.responses:
 			if ok {
 				bp.handleResponse(response)

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1859,6 +1859,56 @@ func TestBrokerProducerWaitForSpaceRespectsExternalUnmute(t *testing.T) {
 	}
 }
 
+// TestBrokerProducerRunFlushesAfterExternalUnmute ensures the run loop retries
+// a flush that was blocked behind a muted partition once the mute is released
+// by an in-flight retryBatch completing elsewhere (#3689).
+func TestBrokerProducerRunFlushesAfterExternalUnmute(t *testing.T) {
+	config := NewTestConfig()
+	parent := &asyncProducer{
+		conf:   config,
+		muter:  newPartitionMuter(),
+		txnmgr: &transactionManager{},
+	}
+
+	// simulate an in-flight retryBatch holding the partition mute
+	retrying := newProduceSet(parent)
+	safeAddMessage(t, retrying, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retrying")})
+	if !parent.muter.tryMute(retrying) {
+		t.Fatal("expected to mute partition")
+	}
+
+	output := make(chan *produceSet, 1)
+	responses := make(chan *brokerProducerResponse)
+	bp := &brokerProducer{
+		parent:            parent,
+		broker:            &Broker{id: 1},
+		input:             make(chan *ProducerMessage),
+		output:            output,
+		responses:         responses,
+		accumulatingBatch: newProduceSet(parent),
+		currentRetries:    make(map[string]map[int32]error),
+	}
+	safeAddMessage(t, bp.accumulatingBatch, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("stranded")})
+
+	go withRecover(bp.run)
+	defer func() {
+		close(bp.input)
+		close(responses)
+	}()
+
+	// the run loop must hold the batch back while the partition is muted
+	assertNotDone(t, output, 50*time.Millisecond)
+	awaitMuterBlocked(t, parent.muter, bp.accumulatingBatch)
+
+	// and must wake up and flush it once the retry completes and unmutes
+	parent.muter.unmute(retrying)
+	flushed := assertDoneWithin(t, output, 2*time.Second)
+	defer parent.muter.unmute(flushed)
+	if _, ok := flushed.msgs["topic"][0]; !ok {
+		t.Fatal("expected stranded batch to flush after unmute")
+	}
+}
+
 func TestBrokerProducerFlushSkipsMutedPartitions(t *testing.T) {
 	config := NewTestConfig()
 	parent := &asyncProducer{


### PR DESCRIPTION
Fixes #3689

`brokerProducer.run()` never wakes up when a muted partition is unmuted. If `tryBuildFlushingBatch` fails because the partition is muted by an in-flight `retryBatch`, the select blocks until the next input/timer/response event. With a sync producer blocked in `SendMessages` and no flush timer, that event never comes and the batch is stranded forever.

`waitForSpace` and `shutdown` already guard this with `muter.awaitUnmuteChan` (#3645); `run()` was the third flush site and was missed. The hazard dates to the muter (v1.48.0, idempotent producers only); #3644 made it reachable for non-idempotent producers in v1.60.0. Full analysis in https://github.com/IBM/sarama/issues/3689#issuecomment-5092089657.

The fix selects on `awaitUnmuteChan(bp.accumulatingBatch)` when the build fails on a non-empty batch, retrying the build immediately if the unmute races in between. The inner loop can't spin: a build only fails on a non-empty batch when every partition is muted, and "not blocked" means none are, so the next build succeeds.

Testing:
- the new regression test fails on main (`timed out waiting for channel`) and passes with the fix, `-race` clean
- the issue's snippet against a live Kafka 3.7.2 with `connections.max.idle.ms=1000` runs indefinitely; on main it stalls on the second batch every run
- `go test -race .` matches main (TestClientBackgroundMetadataUpdater and TestPartitionConsumerComputeBackoff fail identically on clean main under the full suite, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
