### PR TITLE
fix(producer): prevent deadlock in non-idempotent producer retryBatch

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -1358,6 +1358,15 @@ func (bp *brokerProducer) handleResponse(response *brokerProducerResponse) {
 		bp.handleSuccess(response.set, response.res)
 	}
 
+	// Release the BP reference if this produceSet was holding one (from retryBatch).
+	// This must be done after handling the response to ensure the BP stays alive
+	// until all processing is complete.
+	if response.set.bpRefBP != nil {
+		bp.parent.unrefBrokerProducer(response.set.bpRefBroker, response.set.bpRefBP)
+		response.set.bpRefBroker = nil
+		response.set.bpRefBP = nil
+	}
+
 	if bp.accumulatingBatch.empty() {
 		bp.rollOver() // this can happen if the response invalidated our buffer
 	}
@@ -1506,14 +1515,22 @@ func (p *asyncProducer) retryBatch(topic string, partition int32, pSet *partitio
 		}
 	}
 	bp := p.getBrokerProducer(leader)
-	defer p.unrefBrokerProducer(leader, bp)
+
+	// Store the BP reference in the produceSet so it's released after the batch
+	// is fully handled (in handleResponse). This prevents the BP from shutting
+	// down prematurely while the batch is still in flight.
+	produceSet.bpRefBroker = leader
+	produceSet.bpRefBP = bp
+
 	select {
 	case bp.output <- produceSet:
+		// BP reference will be released by handleResponse after the batch is processed
 	case <-p.done:
 		for _, msg := range pSet.msgs {
 			p.returnError(msg, ErrShuttingDown)
 		}
 		p.muter.unmute(produceSet)
+		p.unrefBrokerProducer(leader, bp)
 	}
 }
 

--- a/async_producer.go
+++ b/async_producer.go
@@ -1404,12 +1404,11 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 				bp.parent.returnErrors(pSet.msgs, block.Err)
 			} else {
 				retryTopics = append(retryTopics, topic)
-				if bp.parent.conf.Producer.Idempotent {
-					if keepMuted[topic] == nil {
-						keepMuted[topic] = make(map[int32]struct{})
-					}
-					keepMuted[topic][partition] = struct{}{}
+				// keep partition muted during retry to preserve ordering
+				if keepMuted[topic] == nil {
+					keepMuted[topic] = make(map[int32]struct{})
 				}
+				keepMuted[topic][partition] = struct{}{}
 			}
 		// Other non-retriable errors
 		default:
@@ -1421,11 +1420,9 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 	})
 
 	if len(retryTopics) > 0 {
-		if bp.parent.conf.Producer.Idempotent {
-			err := bp.parent.client.RefreshMetadata(retryTopics...)
-			if err != nil {
-				Logger.Printf("Failed refreshing metadata because of %v\n", err)
-			}
+		err := bp.parent.client.RefreshMetadata(retryTopics...)
+		if err != nil {
+			Logger.Printf("Failed refreshing metadata because of %v\n", err)
 		}
 
 		sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
@@ -1444,11 +1441,9 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 					bp.currentRetries[topic] = make(map[int32]error)
 				}
 				bp.currentRetries[topic][partition] = block.Err
-				if bp.parent.conf.Producer.Idempotent {
-					go bp.parent.retryBatch(topic, partition, pSet, block.Err, true)
-				} else {
-					bp.parent.retryMessages(pSet.msgs, block.Err)
-				}
+
+				go bp.parent.retryBatch(topic, partition, pSet, block.Err, true)
+
 				// dropping the following messages has the side effect of incrementing their retry count
 				bp.parent.retryMessages(bp.accumulatingBatch.dropPartition(topic, partition), block.Err)
 			}

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2135,6 +2135,61 @@ func TestRetryBatchReleasesMuteOnShutdown(t *testing.T) {
 	parent.muter.unmute(contender)
 }
 
+func TestBrokerProducerHandleSuccess(t *testing.T) {
+	t.Run("keeps non-idempotent retriable errors muted", func(t *testing.T) {
+		config := NewTestConfig()
+		config.Producer.Idempotent = false
+		config.Producer.Retry.Max = 1
+		config.Producer.Retry.Backoff = 0
+
+		parent := &asyncProducer{
+			conf:       config,
+			muter:      newPartitionMuter(),
+			brokers:    make(map[*Broker]*brokerProducer),
+			brokerRefs: make(map[*brokerProducer]int),
+			txnmgr:     &transactionManager{},
+		}
+		retryLeader := &Broker{id: 2}
+		parent.client = &stubLeaderClient{leader: retryLeader, cfg: config}
+
+		output := make(chan *produceSet, 1)
+		parent.brokers[retryLeader] = &brokerProducer{
+			parent: parent,
+			broker: retryLeader,
+			output: output,
+			input:  make(chan *ProducerMessage),
+		}
+
+		bp := &brokerProducer{
+			parent:            parent,
+			broker:            &Broker{id: 1},
+			input:             make(chan *ProducerMessage),
+			accumulatingBatch: newProduceSet(parent),
+			currentRetries:    make(map[string]map[int32]error),
+		}
+
+		sent := newProduceSet(parent)
+		safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+		retryPartitionSet := sent.msgs["topic"][0]
+		require.True(t, parent.muter.tryMute(sent), "sent batch should mute its partition")
+
+		response := &ProduceResponse{}
+		response.AddTopicPartition("topic", 0, ErrNotLeaderForPartition)
+
+		bp.handleSuccess(sent, response)
+
+		retrySet := assertDoneWithin(t, output, 2*time.Second)
+		defer parent.muter.unmute(retrySet)
+
+		require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
+		require.Equal(t, 1, retryPartitionSet.msgs[0].retries)
+
+		contender := newProduceSet(parent)
+		safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+		assert.False(t, parent.muter.tryMute(contender), "partition should stay muted by the retrying batch")
+	})
+}
+
 func TestBrokerProducerHandleError(t *testing.T) {
 	t.Run("keeps non-idempotent connection retries muted", func(t *testing.T) {
 		config := NewTestConfig()
@@ -2178,12 +2233,13 @@ func TestBrokerProducerHandleError(t *testing.T) {
 
 		retrySet := assertDoneWithin(t, output, 2*time.Second)
 		defer parent.muter.unmute(retrySet)
+
 		require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
 		require.Equal(t, 1, retryPartitionSet.msgs[0].retries)
 
 		contender := newProduceSet(parent)
 		safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
-		require.False(t, parent.muter.tryMute(contender), "partition should stay muted by the retrying batch")
+		assert.False(t, parent.muter.tryMute(contender), "partition should stay muted by the retrying batch")
 	})
 }
 

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2243,6 +2243,73 @@ func TestBrokerProducerHandleError(t *testing.T) {
 	})
 }
 
+// TestRetryBatchStoresBPRef verifies that retryBatch() stores the brokerProducer
+// reference in the produceSet so that handleResponse releases it, not retryBatch
+// itself.
+//
+// This keeps the brokerProducer alive for the entire batch lifecycle:
+// if the reference were released as soon as `bp.output <- produceSet` returns,
+// the refcount could drop to 0, close bp.input, and cause the run loop to exit
+// before the in-flight response is processed (leaving SyncProducer.SendMessages()
+// blocked forever on ProducerMessage.expectation).
+func TestRetryBatchStoresBPRef(t *testing.T) {
+	config := NewTestConfig()
+	config.Producer.Idempotent = false
+	config.Producer.Retry.Max = 1
+	config.Producer.Retry.Backoff = 0
+
+	parent := &asyncProducer{
+		conf:       config,
+		muter:      newPartitionMuter(),
+		brokers:    make(map[*Broker]*brokerProducer),
+		brokerRefs: make(map[*brokerProducer]int),
+		done:       make(chan struct{}),
+		txnmgr:     &transactionManager{},
+	}
+	leader := &Broker{id: 1}
+	parent.client = &stubLeaderClient{leader: leader, cfg: config}
+
+	// Use a buffered output so retryBatch can send without blocking.
+	bpOutput := make(chan *produceSet, 1)
+	bp := &brokerProducer{
+		parent: parent,
+		broker: leader,
+		output: bpOutput,
+		input:  make(chan *ProducerMessage),
+	}
+	parent.brokers[leader] = bp
+	parent.brokerRefs[bp] = 0
+
+	// Build the partition set, pre-muted as handleError leaves it.
+	sent := newProduceSet(parent)
+	safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+	retryPSet := sent.msgs["topic"][0]
+	require.True(t, parent.muter.tryMute(sent))
+
+	parent.retryBatch("topic", 0, retryPSet, ErrOutOfBrokers, true)
+
+	// retryBatch must have returned by now. Read the dispatched set.
+	select {
+	case dispatched := <-bpOutput:
+		// The BP reference must be stored in the set, not yet released.
+		require.NotNil(t, dispatched.bpRefBP,
+			"retryBatch must store the BP reference in the produceSet so handleResponse releases it")
+		require.Equal(t, bp, dispatched.bpRefBP)
+		require.Equal(t, leader, dispatched.bpRefBroker)
+
+		// The refcount must still be 1 (not yet released).
+		parent.brokerLock.Lock()
+		refs := parent.brokerRefs[bp]
+		parent.brokerLock.Unlock()
+		require.Equal(t, 1, refs, "BP refcount must remain 1 until handleResponse runs")
+
+		// Simulate handleResponse releasing the reference.
+		parent.unrefBrokerProducer(dispatched.bpRefBroker, dispatched.bpRefBP)
+	default:
+		t.Fatal("retryBatch did not dispatch the set")
+	}
+}
+
 type stubLeaderClient struct {
 	cfg    *Config
 	leader *Broker

--- a/produce_set.go
+++ b/produce_set.go
@@ -20,6 +20,12 @@ type produceSet struct {
 
 	bufferBytes int
 	bufferCount int
+
+	// bpRefBroker and bpRefBP hold a reference to the brokerProducer that should
+	// be released after this produceSet is fully handled (success or retry exhausted).
+	// Used by retryBatch to keep the BP alive until the batch is processed.
+	bpRefBroker *Broker
+	bpRefBP     *brokerProducer
 }
 
 func newProduceSet(parent *asyncProducer) *produceSet {


### PR DESCRIPTION
PR #3644 introduced a regression that can cause a `SyncProducer` to block
indefinitely when using non-idempotent mode with connection retries.
    
The deadlock scenario:
    
1. A connection error triggers `handleError()`, which launches a goroutine
   calling `retryBatch()` for the failed batch.
2. `retryBatch()` creates a new `brokerProducer` via `getBrokerProducer()` (refcount=1).
3. `retryBatch()` sends the batch on `bp.output`, then immediately releases its
   reference via defer `unrefBrokerProducer()` (refcount=0).
4. With `refcount=0`, the `brokerProducer` shuts down while the batch is still
   in flight waiting for a response from the broker.
5. The response is lost, `returnSuccesses()` / `returnErrors()` is never called.
6. `SendMessages()` blocks forever waiting on `ProducerMessage.expectation`.
    
The fix stores the `brokerProducer` reference in the `produceSet` itself, so it
is only released after `handleResponse()` has fully processed the batch (success
or retry exhausted). This ensures the `brokerProducer` stays alive until the
batch lifecycle is complete.

Fixes #3689