### PR TITLE
fix(producer): wake stranded brokerProducer when partition unmutes

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -225,18 +225,13 @@ func (m *partitionMuter) waitUntilMuted(set *produceSet) bool {
 	return true
 }
 
-func (m *partitionMuter) awaitUnmuteChan(set *produceSet) (<-chan struct{}, bool) {
-	if set == nil || set.empty() {
-		return nil, false
-	}
-
+// nextUnmuteSignal returns the channel that the next unmute (or close) will
+// close.
+func (m *partitionMuter) nextUnmuteSignal() <-chan struct{} {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if !m.isAnyMuted(set) {
-		return nil, false
-	}
-	return m.unmuteSignal, true
+	return m.unmuteSignal
 }
 
 // unmute decrements the in-flight counter for all partitions in the set.
@@ -1126,8 +1121,9 @@ func (bp *brokerProducer) run() {
 	Logger.Printf("producer/broker/%d starting up\n", bp.broker.ID())
 
 	for {
+		var unmuteSignal <-chan struct{}
 		if bp.flushingBatch == nil && (bp.timerFired || bp.accumulatingBatch.readyToFlush()) {
-			bp.tryBuildFlushingBatch()
+			unmuteSignal = bp.tryBuildFlushingBatch()
 		}
 
 		var timerChan <-chan time.Time
@@ -1213,6 +1209,7 @@ func (bp *brokerProducer) run() {
 			bp.timerFired = true
 		case output <- bp.flushingBatch:
 			bp.flushingBatch = nil
+		case <-unmuteSignal:
 		case response, ok := <-bp.responses:
 			if ok {
 				bp.handleResponse(response)
@@ -1221,27 +1218,36 @@ func (bp *brokerProducer) run() {
 	}
 }
 
-func (bp *brokerProducer) tryBuildFlushingBatch() bool {
+// tryBuildFlushingBatch tries to promote the accumulating batch (or whichever
+// of its partitions aren't muted) into the flushing batch. If nothing could be
+// taken because every partition is muted, it returns a channel that the next
+// unmute will close so the caller knows when to try again.
+func (bp *brokerProducer) tryBuildFlushingBatch() <-chan struct{} {
 	if bp.flushingBatch != nil || bp.accumulatingBatch.empty() {
-		return false
+		return nil
 	}
+
+	// taken before the mute attempts so a racing unmute can't be missed
+	unmuteSignal := bp.parent.muter.nextUnmuteSignal()
 	if bp.parent.muter.tryMute(bp.accumulatingBatch) {
 		bp.flushingBatch = bp.accumulatingBatch
 		bp.rollOver()
-		return true
+		return nil
 	}
 
 	partial := bp.accumulatingBatch.takePartitions(func(topic string, partition int32) bool {
 		return bp.parent.muter.tryMutePartition(topic, partition)
 	})
 	if partial == nil {
-		return false
+		// the mute can be owned by another brokerProducer, so only the shared
+		// unmute signal is guaranteed to wake this one (#3689)
+		return unmuteSignal
 	}
 	bp.flushingBatch = partial
 	if bp.accumulatingBatch.empty() {
 		bp.rollOver()
 	}
-	return true
+	return nil
 }
 
 func (bp *brokerProducer) shutdown() {
@@ -1256,15 +1262,13 @@ func (bp *brokerProducer) shutdown() {
 	}
 	// then flush the current buffer
 	for !bp.accumulatingBatch.empty() || bp.flushingBatch != nil {
+		var unmuteSignal <-chan struct{}
 		if bp.flushingBatch == nil {
-			bp.tryBuildFlushingBatch()
+			unmuteSignal = bp.tryBuildFlushingBatch()
 		}
-		var unmuteCh <-chan struct{}
 		var outputCh chan<- *produceSet
 		if bp.flushingBatch != nil {
 			outputCh = bp.output
-		} else if ch, blocked := bp.parent.muter.awaitUnmuteChan(bp.accumulatingBatch); blocked {
-			unmuteCh = ch
 		}
 		select {
 		case response, ok := <-bp.responses:
@@ -1273,7 +1277,7 @@ func (bp *brokerProducer) shutdown() {
 			}
 		case outputCh <- bp.flushingBatch:
 			bp.flushingBatch = nil
-		case <-unmuteCh:
+		case <-unmuteSignal:
 		}
 	}
 	close(bp.output)
@@ -1325,18 +1329,14 @@ func (bp *brokerProducer) waitForSpace(msg *ProducerMessage, forceRollover bool)
 			return nil
 		}
 
-		if bp.tryBuildFlushingBatch() {
-			continue
-		}
-
-		if unmuteCh, blocked := bp.parent.muter.awaitUnmuteChan(bp.accumulatingBatch); blocked {
+		if unmuteSignal := bp.tryBuildFlushingBatch(); unmuteSignal != nil {
 			select {
 			case response := <-bp.responses:
 				bp.handleResponse(response)
 				if reason := bp.needsRetry(msg); reason != nil {
 					return reason
 				}
-			case <-unmuteCh:
+			case <-unmuteSignal:
 			}
 		}
 	}

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -1776,16 +1776,11 @@ func TestBrokerProducerWaitForSpaceEmptyBufferRollover(t *testing.T) {
 
 func awaitMuterBlocked(t *testing.T, m *partitionMuter, set *produceSet) {
 	t.Helper()
-	deadline := time.Now().Add(500 * time.Millisecond)
-	for {
-		if _, blocked := m.awaitUnmuteChan(set); blocked {
-			return
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("timeout waiting for muter to block on set")
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+		assert.True(c, m.isAnyMuted(set), "muter is not blocked on set")
+	}, 500*time.Millisecond, 5*time.Millisecond)
 }
 
 func assertNotDone[T any](t *testing.T, ch <-chan T, wait time.Duration) {
@@ -1859,44 +1854,100 @@ func TestBrokerProducerWaitForSpaceRespectsExternalUnmute(t *testing.T) {
 	}
 }
 
-func TestBrokerProducerFlushSkipsMutedPartitions(t *testing.T) {
+func TestBrokerProducerTryBuildFlushingBatch(t *testing.T) {
+	newTestBrokerProducer := func() *brokerProducer {
+		parent := &asyncProducer{
+			conf:   NewTestConfig(),
+			muter:  newPartitionMuter(),
+			txnmgr: &transactionManager{},
+		}
+		return &brokerProducer{
+			parent:            parent,
+			accumulatingBatch: newProduceSet(parent),
+		}
+	}
+
+	t.Run("signals when a batch stranded behind a muted partition can be retried", func(t *testing.T) {
+		bp := newTestBrokerProducer()
+		safeAddMessage(t, bp.accumulatingBatch, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("stranded")})
+
+		inFlightBatch := newProduceSet(bp.parent)
+		safeAddMessage(t, inFlightBatch, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retrying")})
+		require.True(t, bp.parent.muter.tryMute(inFlightBatch), "expected to mute partition")
+
+		unmuteSignal := bp.tryBuildFlushingBatch()
+		require.Nil(t, bp.flushingBatch, "expected the muted partition to remain buffered")
+		require.NotNil(t, unmuteSignal, "expected to await the muted partition")
+		select {
+		case <-unmuteSignal:
+			assert.Fail(t, "unmute signaled before the partition was unmuted")
+		default:
+		}
+
+		bp.parent.muter.unmute(inFlightBatch)
+		select {
+		case <-unmuteSignal:
+		default:
+			require.FailNow(t, "unmute was not signaled")
+		}
+
+		require.Nil(t, bp.tryBuildFlushingBatch(), "expected no unmute wait after building the batch")
+		require.NotNil(t, bp.flushingBatch, "expected to build the flushing batch")
+	})
+
+	t.Run("builds a partial batch from unmuted partitions", func(t *testing.T) {
+		bp := newTestBrokerProducer()
+		safeAddMessage(t, bp.accumulatingBatch, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("p0")})
+		safeAddMessage(t, bp.accumulatingBatch, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("p1")})
+
+		mutedBatch := newProduceSet(bp.parent)
+		safeAddMessage(t, mutedBatch, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("held")})
+		require.True(t, bp.parent.muter.tryMute(mutedBatch), "expected to mute partition")
+
+		require.Nil(t, bp.tryBuildFlushingBatch(), "expected no unmute wait after building a partial batch")
+		require.NotNil(t, bp.flushingBatch, "expected to flush available partitions")
+		assert.Contains(t, bp.flushingBatch.msgs["topic"], int32(0), "expected unmuted partition to flush")
+		assert.NotContains(t, bp.flushingBatch.msgs["topic"], int32(1), "expected muted partition to stay buffered")
+		assert.Contains(t, bp.accumulatingBatch.msgs["topic"], int32(1), "expected muted partition to remain buffered")
+	})
+}
+
+// TestAsyncProducerUnblocksOnExternalUnmute verifies that a batch stranded
+// behind a partition muted by another brokerProducer flushes once the mute is
+// released (#3689).
+func TestAsyncProducerUnblocksOnExternalUnmute(t *testing.T) {
+	seedBroker := NewMockBroker(t, 1)
+	leader := NewMockBroker(t, 2)
+
+	metadataResponse := new(MetadataResponse)
+	metadataResponse.AddBroker(leader.Addr(), leader.BrokerID())
+	metadataResponse.AddTopicPartition("my_topic", 0, leader.BrokerID(), nil, nil, nil, ErrNoError)
+	seedBroker.Returns(metadataResponse)
+
+	prodSuccess := new(ProduceResponse)
+	prodSuccess.AddTopicPartition("my_topic", 0, ErrNoError)
+	leader.Returns(prodSuccess)
+
 	config := NewTestConfig()
-	parent := &asyncProducer{
-		conf:   config,
-		muter:  newPartitionMuter(),
-		txnmgr: &transactionManager{},
-	}
-	bp := &brokerProducer{
-		parent:            parent,
-		accumulatingBatch: newProduceSet(parent),
-		currentRetries:    make(map[string]map[int32]error),
-	}
+	config.Producer.Return.Successes = true
+	producer, err := NewAsyncProducer([]string{seedBroker.Addr()}, config)
+	require.NoError(t, err)
 
-	safeAddMessage(t, bp.accumulatingBatch, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("p0")})
-	safeAddMessage(t, bp.accumulatingBatch, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("p1")})
+	// mute the partition externally, as a retryBatch with a batch still in flight would
+	parent := producer.(*asyncProducer)
+	retryingBatch := newProduceSet(parent)
+	safeAddMessage(t, retryingBatch, &ProducerMessage{Topic: "my_topic", Partition: 0, Value: StringEncoder("in-flight")})
+	require.True(t, parent.muter.tryMute(retryingBatch), "expected to mute partition")
 
-	blocked := newProduceSet(parent)
-	safeAddMessage(t, blocked, &ProducerMessage{Topic: "topic", Partition: 1, Value: StringEncoder("held")})
-	if !parent.muter.tryMute(blocked) {
-		t.Fatal("expected to mute blocked partition")
-	}
-	defer parent.muter.unmute(blocked)
+	producer.Input() <- &ProducerMessage{Topic: "my_topic", Value: StringEncoder(TestMessage)}
+	assertNotDone(t, producer.Successes(), 100*time.Millisecond)
 
-	if !bp.tryBuildFlushingBatch() {
-		t.Fatal("expected to flush available partitions")
-	}
-	if bp.flushingBatch == nil {
-		t.Fatal("expected flushing batch to be set")
-	}
-	if _, ok := bp.flushingBatch.msgs["topic"][1]; ok {
-		t.Fatal("expected muted partition to stay buffered")
-	}
-	if _, ok := bp.accumulatingBatch.msgs["topic"][0]; ok {
-		t.Fatal("expected unmuted partition to flush")
-	}
-	if _, ok := bp.accumulatingBatch.msgs["topic"][1]; !ok {
-		t.Fatal("expected muted partition to remain in accumulating batch")
-	}
+	parent.muter.unmute(retryingBatch)
+	expectResultsWithTimeout(t, producer, 1, 0, 5*time.Second)
+
+	closeProducerWithTimeout(t, producer, 5*time.Second)
+	leader.Close()
+	seedBroker.Close()
 }
 
 // TestBrokerProducerWaitForSpaceAllPartitionsMuted verifies that waitForSpace unblocks


### PR DESCRIPTION
A brokerProducer whose accumulated batch was blocked behind a partition muted elsewhere (e.g. by an in-flight retryBatch handled on another brokerProducer) never woke up, as its run() loop did not select on the unmute signal, deadlocking non-idempotent producers after connection errors.

- select on the muter unmute signal in run() when the batch cannot be built
- snapshot the signal before any mute attempt so a racing unmute is not missed
- fold awaitUnmuteChan into tryBuildFlushingBatch, returning the signal to wait on
- add an end-to-end regression test for the stranded batch scenario

Fixes #3689