### PR TITLE
fix(producer): keep partition muted during handleSuccess retries for non-idempotent producers

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -1404,12 +1404,11 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 				bp.parent.returnErrors(pSet.msgs, block.Err)
 			} else {
 				retryTopics = append(retryTopics, topic)
-				if bp.parent.conf.Producer.Idempotent {
-					if keepMuted[topic] == nil {
-						keepMuted[topic] = make(map[int32]struct{})
-					}
-					keepMuted[topic][partition] = struct{}{}
+				// keep partition muted during retry to preserve ordering
+				if keepMuted[topic] == nil {
+					keepMuted[topic] = make(map[int32]struct{})
 				}
+				keepMuted[topic][partition] = struct{}{}
 			}
 		// Other non-retriable errors
 		default:
@@ -1421,11 +1420,9 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 	})
 
 	if len(retryTopics) > 0 {
-		if bp.parent.conf.Producer.Idempotent {
-			err := bp.parent.client.RefreshMetadata(retryTopics...)
-			if err != nil {
-				Logger.Printf("Failed refreshing metadata because of %v\n", err)
-			}
+		err := bp.parent.client.RefreshMetadata(retryTopics...)
+		if err != nil {
+			Logger.Printf("Failed refreshing metadata because of %v\n", err)
 		}
 
 		sent.eachPartition(func(topic string, partition int32, pSet *partitionSet) {
@@ -1444,11 +1441,9 @@ func (bp *brokerProducer) handleSuccess(sent *produceSet, response *ProduceRespo
 					bp.currentRetries[topic] = make(map[int32]error)
 				}
 				bp.currentRetries[topic][partition] = block.Err
-				if bp.parent.conf.Producer.Idempotent {
-					go bp.parent.retryBatch(topic, partition, pSet, block.Err, true)
-				} else {
-					bp.parent.retryMessages(pSet.msgs, block.Err)
-				}
+
+				go bp.parent.retryBatch(topic, partition, pSet, block.Err, true)
+
 				// dropping the following messages has the side effect of incrementing their retry count
 				bp.parent.retryMessages(bp.accumulatingBatch.dropPartition(topic, partition), block.Err)
 			}

--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2135,6 +2135,61 @@ func TestRetryBatchReleasesMuteOnShutdown(t *testing.T) {
 	parent.muter.unmute(contender)
 }
 
+func TestBrokerProducerHandleSuccess(t *testing.T) {
+	t.Run("keeps non-idempotent retriable errors muted", func(t *testing.T) {
+		config := NewTestConfig()
+		config.Producer.Idempotent = false
+		config.Producer.Retry.Max = 1
+		config.Producer.Retry.Backoff = 0
+
+		parent := &asyncProducer{
+			conf:       config,
+			muter:      newPartitionMuter(),
+			brokers:    make(map[*Broker]*brokerProducer),
+			brokerRefs: make(map[*brokerProducer]int),
+			txnmgr:     &transactionManager{},
+		}
+		retryLeader := &Broker{id: 2}
+		parent.client = &stubLeaderClient{leader: retryLeader, cfg: config}
+
+		output := make(chan *produceSet, 1)
+		parent.brokers[retryLeader] = &brokerProducer{
+			parent: parent,
+			broker: retryLeader,
+			output: output,
+			input:  make(chan *ProducerMessage),
+		}
+
+		bp := &brokerProducer{
+			parent:            parent,
+			broker:            &Broker{id: 1},
+			input:             make(chan *ProducerMessage),
+			accumulatingBatch: newProduceSet(parent),
+			currentRetries:    make(map[string]map[int32]error),
+		}
+
+		sent := newProduceSet(parent)
+		safeAddMessage(t, sent, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("retry")})
+		retryPartitionSet := sent.msgs["topic"][0]
+		require.True(t, parent.muter.tryMute(sent), "sent batch should mute its partition")
+
+		response := &ProduceResponse{}
+		response.AddTopicPartition("topic", 0, ErrNotLeaderForPartition)
+
+		bp.handleSuccess(sent, response)
+
+		retrySet := assertDoneWithin(t, output, 2*time.Second)
+		defer parent.muter.unmute(retrySet)
+
+		require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
+		require.Equal(t, 1, retryPartitionSet.msgs[0].retries)
+
+		contender := newProduceSet(parent)
+		safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
+		assert.False(t, parent.muter.tryMute(contender), "partition should stay muted by the retrying batch")
+	})
+}
+
 func TestBrokerProducerHandleError(t *testing.T) {
 	t.Run("keeps non-idempotent connection retries muted", func(t *testing.T) {
 		config := NewTestConfig()
@@ -2178,12 +2233,13 @@ func TestBrokerProducerHandleError(t *testing.T) {
 
 		retrySet := assertDoneWithin(t, output, 2*time.Second)
 		defer parent.muter.unmute(retrySet)
+
 		require.Equal(t, retryPartitionSet, retrySet.msgs["topic"][0])
 		require.Equal(t, 1, retryPartitionSet.msgs[0].retries)
 
 		contender := newProduceSet(parent)
 		safeAddMessage(t, contender, &ProducerMessage{Topic: "topic", Partition: 0, Value: StringEncoder("next")})
-		require.False(t, parent.muter.tryMute(contender), "partition should stay muted by the retrying batch")
+		assert.False(t, parent.muter.tryMute(contender), "partition should stay muted by the retrying batch")
 	})
 }
 


### PR DESCRIPTION
PR #3644 changed `handleError()` to use `retryBatch()` for non-idempotent producers, keeping partitions muted during retries. However, `handleSuccess()` was not updated consistently: it called `retryBatch()` with `alreadyMuted=true`, but did not add the partition to `keepMuted`, causing the partition to be unmuted immediately after launching the retry goroutine.

This inconsistency could lead to message reordering, as a new batch for the same partition could be sent before the retry completes.

This commit aligns `handleSuccess()` with `handleError()` by:

- Always populating `keepMuted` for retriable errors (not just for idempotent)
- Always calling `RefreshMetadata()` before retries (not just for idempotent)