### PR TITLE
feat(client): expose ClusterID via Client interface

### DIFF
--- a/async_producer_test.go
+++ b/async_producer_test.go
@@ -2217,6 +2217,7 @@ func (c *stubLeaderClient) RefreshCoordinator(string) error                  { r
 func (c *stubLeaderClient) TransactionCoordinator(string) (*Broker, error)   { return nil, nil }
 func (c *stubLeaderClient) RefreshTransactionCoordinator(string) error       { return nil }
 func (c *stubLeaderClient) InitProducerID() (*InitProducerIDResponse, error) { return nil, nil }
+func (c *stubLeaderClient) ClusterID() string                                { return "" }
 func (c *stubLeaderClient) LeastLoadedBroker() *Broker                       { return c.leader }
 func (c *stubLeaderClient) PartitionNotReadable(string, int32) bool          { return false }
 func (c *stubLeaderClient) Close() error                                     { return nil }

--- a/client.go
+++ b/client.go
@@ -35,6 +35,11 @@ type Client interface {
 	// and stores it in the local cache. Requires Kafka 0.10 or higher.
 	RefreshController() (*Broker, error)
 
+	// ClusterID returns the cluster ID reported by the broker in the most recent
+	// metadata response. It returns an empty string if the broker has not yet
+	// responded or if the Kafka version predates 0.10.1 (MetadataResponse v2).
+	ClusterID() string
+
 	// Brokers returns the current set of active brokers as retrieved from cluster metadata.
 	Brokers() []*Broker
 
@@ -156,6 +161,7 @@ type client struct {
 	deadSeeds   []*Broker
 
 	controllerID            int32                                   // cluster controller broker id
+	clusterID               string                                  // cluster ID from metadata response (Kafka ≥ 0.10.1)
 	brokers                 map[int32]*Broker                       // maps broker ids to brokers
 	metadata                map[string]map[int32]*PartitionMetadata // maps topics to partition ids to metadata
 	metadataTopics          map[string]none                         // topics that need to collect metadata
@@ -595,6 +601,12 @@ func (client *client) RefreshController() (*Broker, error) {
 
 	_ = controller.Open(client.conf)
 	return controller, nil
+}
+
+func (client *client) ClusterID() string {
+	client.lock.RLock()
+	defer client.lock.RUnlock()
+	return client.clusterID
 }
 
 func (client *client) Coordinator(consumerGroup string) (*Broker, error) {
@@ -1101,6 +1113,9 @@ func (client *client) updateMetadata(data *MetadataResponse, allKnownMetaData bo
 	client.updateBroker(data.Brokers)
 
 	client.controllerID = data.ControllerID
+	if data.ClusterID != nil && *data.ClusterID != "" {
+		client.clusterID = *data.ClusterID
+	}
 
 	if allKnownMetaData {
 		client.metadata = make(map[string]map[int32]*PartitionMetadata)

--- a/client_test.go
+++ b/client_test.go
@@ -929,6 +929,54 @@ func TestClientController(t *testing.T) {
 	})
 }
 
+func TestClientClusterID(t *testing.T) {
+	seedBroker := NewMockBroker(t, 1)
+	defer seedBroker.Close()
+
+	// V0_10_1_0 is the first version where MetadataResponse includes ClusterID.
+	t.Run("V0_10_1_0_returns_cluster_id", func(t *testing.T) {
+		seedBroker.SetHandlerByMap(map[string]MockResponse{
+			"MetadataRequest": NewMockMetadataResponse(t).
+				SetController(seedBroker.BrokerID()).
+				SetBroker(seedBroker.Addr(), seedBroker.BrokerID()).
+				SetClusterID("test-cluster-id"),
+		})
+
+		cfg := NewTestConfig()
+		cfg.Version = V0_10_1_0
+		client, err := NewClient([]string{seedBroker.Addr()}, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer safeClose(t, client)
+
+		if got := client.ClusterID(); got != "test-cluster-id" {
+			t.Errorf("expected ClusterID %q, got %q", "test-cluster-id", got)
+		}
+	})
+
+	// Pre-0.10.1 brokers do not return a ClusterID in metadata responses.
+	t.Run("V0_10_0_0_returns_empty", func(t *testing.T) {
+		seedBroker.SetHandlerByMap(map[string]MockResponse{
+			"MetadataRequest": NewMockMetadataResponse(t).
+				SetController(seedBroker.BrokerID()).
+				SetBroker(seedBroker.Addr(), seedBroker.BrokerID()),
+		})
+
+		cfg := NewTestConfig()
+		cfg.Version = V0_10_0_0
+		client, err := NewClient([]string{seedBroker.Addr()}, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer safeClose(t, client)
+
+		if got := client.ClusterID(); got != "" {
+			t.Errorf("expected empty ClusterID for old broker, got %q", got)
+		}
+	})
+}
+
 func TestClientMetadataTimeout(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -135,6 +135,7 @@ func (m *MockDescribeGroupsResponse) For(reqBody versionedDecoder) encoderWithHe
 // MockMetadataResponse is a `MetadataResponse` builder.
 type MockMetadataResponse struct {
 	controllerID int32
+	clusterID    string
 	errors       map[string]KError
 	leaders      map[string]map[int32]int32
 	brokers      map[string]int32
@@ -175,11 +176,19 @@ func (mmr *MockMetadataResponse) SetController(brokerID int32) *MockMetadataResp
 	return mmr
 }
 
+func (mmr *MockMetadataResponse) SetClusterID(clusterID string) *MockMetadataResponse {
+	mmr.clusterID = clusterID
+	return mmr
+}
+
 func (mmr *MockMetadataResponse) For(reqBody versionedDecoder) encoderWithHeader {
 	metadataRequest := reqBody.(*MetadataRequest)
 	metadataResponse := &MetadataResponse{
 		Version:      metadataRequest.version(),
 		ControllerID: mmr.controllerID,
+	}
+	if mmr.clusterID != "" {
+		metadataResponse.ClusterID = &mmr.clusterID
 	}
 	for addr, brokerID := range mmr.brokers {
 		metadataResponse.AddBroker(addr, brokerID)


### PR DESCRIPTION
## Summary

Adds `ClusterID() string` to the `Client` interface, surfacing the cluster ID that brokers already return in `MetadataResponse` (protocol version ≥ 2, Kafka ≥ 0.10.1.0) but that was never stored or accessible to callers.

### Changes

- **`client.go`** — adds `clusterID string` field to the `client` struct; stores the value in `updateMetadata()` under the existing `client.lock` RWMutex (same pattern as `controllerID`); adds `ClusterID() string` to the `Client` interface; implements `(*client).ClusterID()` with `RLock`.
- **`mockresponses.go`** — adds `clusterID` field and `SetClusterID()` builder to `MockMetadataResponse` so tests can configure the mock; populates `MetadataResponse.ClusterID` in `For()`.
- **`client_test.go`** — adds `TestClientClusterID` with two subtests: one at `V0_10_1_0` that asserts the value round-trips correctly, and one at `V0_10_0_0` that asserts an empty string is returned when the broker does not include a cluster ID.
- **`async_producer_test.go`** — adds the `ClusterID() string` stub to `stubLeaderClient` to satisfy the updated interface.

### Design notes

- Returns `string` (not `(string, error)`): the cluster ID is either present or not; returning empty string for pre-0.10.1 brokers is consistent with how `controllerID` behaves before any metadata has been received.
- `nopCloserClient` requires no changes — it embeds the `Client` interface by value and inherits the new method automatically.
- Nil-pointer guard: `MetadataResponse.ClusterID` is `*string`; the store path checks `!= nil && != ""` before overwriting, so a nil pointer from an old-version response never clears a previously cached value.