### PR TITLE
feat(consumer): support cooperative rebalancing

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -29,35 +29,46 @@ var ErrSessionConsumeClaimExited = errors.New("kafka: ConsumeClaim goroutine exi
 // unreachable after retries).
 var ErrSessionHeartbeatFailed = errors.New("kafka: heartbeat loop failed")
 
+// ErrRebalanceTimedOut is set as the cancellation cause of a consumer group session
+// context when a ConsumeClaim did not return within Consumer.Group.Rebalance.Timeout
+// of the partition being revoked from it.
+var ErrRebalanceTimedOut = errors.New("kafka: ConsumeClaim did not exit within Consumer.Group.Rebalance.Timeout of being revoked")
+
+// errPartitionRevoked is set as the cancellation cause of a single claim's context
+// when the partition has been revoked by a cooperative rebalance. It is internal:
+// the session survives, and the handler is told by its Messages() channel closing.
+var errPartitionRevoked = errors.New("kafka: partition revoked by rebalance")
+
 // ConsumerGroup is responsible for dividing up processing of topics and partitions
 // over a collection of processes (the members of the consumer group).
 type ConsumerGroup interface {
 	// Consume joins a cluster of consumers for a given list of topics and
 	// starts a blocking ConsumerGroupSession through the ConsumerGroupHandler.
 	//
-	// The life-cycle of a session is represented by the following steps:
+	// A call to Consume follows this lifecycle:
 	//
-	// 1. The consumers join the group (as explained in https://kafka.apache.org/documentation/#intro_consumers)
-	//    and is assigned their "fair share" of partitions, aka 'claims'.
-	// 2. Before processing starts, the handler's Setup() hook is called to notify the user
-	//    of the claims and allow any necessary preparation or alteration of state.
-	// 3. For each of the assigned claims the handler's ConsumeClaim() function is then called
-	//    in a separate goroutine which requires it to be thread-safe. Any state must be carefully protected
-	//    from concurrent reads/writes.
-	// 4. The session will persist until one of the ConsumeClaim() functions exits. This can be either when the
-	//    parent context is canceled or when a server-side rebalance cycle is initiated.
-	// 5. Once all the ConsumeClaim() loops have exited, the handler's Cleanup() hook is called
-	//    to allow the user to perform any final tasks before a rebalance.
-	// 6. Finally, marked offsets are committed one last time before claims are released.
+	// 1. The consumer joins the group and receives its assigned topic partitions,
+	//    also known as claims.
+	// 2. The handler's Setup method runs before claim processing starts.
+	// 3. The handler's ConsumeClaim method runs in a separate goroutine for each
+	//    claim, so the handler must be safe for concurrent use.
+	// 4. When the session ends, Consume waits for the claims to return, calls the
+	//    handler's Cleanup method, and commits marked offsets before releasing them.
 	//
-	// Please note, that once a rebalance is triggered, sessions must be completed within
-	// Config.Consumer.Group.Rebalance.Timeout. This means that ConsumeClaim() functions must exit
-	// as quickly as possible to allow time for Cleanup() and the final offset commit. If the timeout
-	// is exceeded, the consumer will be removed from the group by Kafka, which will cause offset
-	// commit failures.
-	// This method should be called inside an infinite loop, when a
-	// server-side rebalance happens, the consumer session will need to be
-	// recreated to get the new claims.
+	// With an eager strategy, a rebalance ends the current session and this
+	// Consume call. The caller should invoke Consume from a loop to create the
+	// next session and receive the new claims.
+	//
+	// With a cooperative strategy, a rebalance updates the existing session:
+	//
+	//   - Setup runs on the first join and Cleanup runs when the member leaves.
+	//   - Retained claims keep running.
+	//   - A revoked claim has its Messages channel closed.
+	//   - Consume and the session context remain active across rebalances.
+	//
+	// A revoked ConsumeClaim must return within
+	// Config.Consumer.Group.Rebalance.Timeout. If it does not, Kafka may remove
+	// the member from the group and subsequent offset commits may fail.
 	Consume(ctx context.Context, topics []string, handler ConsumerGroupHandler) error
 
 	// Errors returns a read channel of errors that occurred during the consumer life-cycle.
@@ -234,8 +245,13 @@ func (c *consumerGroup) Consume(ctx context.Context, topics []string, handler Co
 	sess, err := c.newSession(ctx, topics, handler, c.config.Consumer.Group.Rebalance.Retry.Max)
 	if errors.Is(err, ErrClosedClient) {
 		return ErrClosedConsumerGroup
-	} else if err != nil {
+	}
+	if err != nil {
 		return err
+	}
+
+	if c.protocol == RebalanceProtocolCooperative {
+		return c.consumeCooperative(ctx, topics, sess)
 	}
 
 	// Wait for session exit signal or Close() call
@@ -247,15 +263,18 @@ func (c *consumerGroup) Consume(ctx context.Context, topics []string, handler Co
 	// Gracefully release session claims
 	err = sess.release(true)
 
-	// store the session cancellation cause so it can be sent as the reason
-	// on the next JoinGroup or LeaveGroup request
+	c.recordSessionCause(sess)
+
+	return err
+}
+
+// recordSessionCause keeps the reason for the next JoinGroup or LeaveGroup request
+func (c *consumerGroup) recordSessionCause(sess *consumerGroupSession) {
 	if cause := context.Cause(sess.ctx); !errors.Is(cause, context.Canceled) {
 		c.lastSessionCause = cause
 	} else {
 		c.lastSessionCause = nil
 	}
-
-	return err
 }
 
 // Pause implements ConsumerGroup.
@@ -522,9 +541,7 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 	}
 
 	// only the leader needs to check whether there are newly-added partitions in order to trigger a rebalance
-	if res.isLeader {
-		go c.loopCheckPartitionNumbers(res.allSubscribedTopicPartitions, res.allSubscribedTopics, session)
-	}
+	session.watchPartitionNumbers(res)
 
 	return session, nil
 }
@@ -849,12 +866,11 @@ func (c *consumerGroup) handleError(err error, topic string, partition int32) {
 	}
 }
 
-func (c *consumerGroup) loopCheckPartitionNumbers(allSubscribedTopicPartitions map[string][]int32, topics []string, session *consumerGroupSession) {
+// loopCheckPartitionNumbers triggers a rebalance when a subscribed topic grows
+func (c *consumerGroup) loopCheckPartitionNumbers(ctx context.Context, allSubscribedTopicPartitions map[string][]int32, topics []string, session *consumerGroupSession) {
 	if c.config.Metadata.RefreshFrequency == time.Duration(0) {
 		return
 	}
-
-	defer session.cancel(ErrSessionPartitionCountChanged)
 
 	oldTopicToPartitionNum := make(map[string]int, len(allSubscribedTopicPartitions))
 	for topic, partitions := range allSubscribedTopicPartitions {
@@ -865,6 +881,7 @@ func (c *consumerGroup) loopCheckPartitionNumbers(allSubscribedTopicPartitions m
 	defer pause.Stop()
 	for {
 		if newTopicToPartitionNum, err := c.topicToPartitionNumbers(topics); err != nil {
+			session.triggerRebalance(ErrSessionPartitionCountChanged)
 			return
 		} else {
 			for topic, num := range oldTopicToPartitionNum {
@@ -872,17 +889,17 @@ func (c *consumerGroup) loopCheckPartitionNumbers(allSubscribedTopicPartitions m
 					Logger.Printf(
 						"consumergroup/%s loop check partition number goroutine find partitions in topics %s changed from %d to %d\n",
 						c.groupID, topics, num, newTopicToPartitionNum[topic])
-					return // trigger the end of the session on exit
+					session.triggerRebalance(ErrSessionPartitionCountChanged)
+					return
 				}
 			}
 		}
 		select {
 		case <-pause.C:
-		case <-session.ctx.Done():
+		case <-ctx.Done():
 			Logger.Printf(
 				"consumergroup/%s loop check partition number goroutine will exit, topics %s\n",
 				c.groupID, topics)
-			// if session closed by other, should be exited
 			return
 		case <-c.closed:
 			return

--- a/consumer_group_cooperative.go
+++ b/consumer_group_cooperative.go
@@ -1,0 +1,157 @@
+package sarama
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"time"
+)
+
+// consumeCooperative keeps one session while its assignment changes
+func (c *consumerGroup) consumeCooperative(ctx context.Context, topics []string, sess *consumerGroupSession) (err error) {
+	defer func() {
+		if releaseErr := sess.release(true); releaseErr != nil && err == nil {
+			err = releaseErr
+		}
+		c.recordSessionCause(sess)
+	}()
+
+	for {
+		select {
+		case <-c.closed:
+			return nil
+		case <-ctx.Done():
+			return nil
+		case <-sess.ctx.Done():
+			return nil
+		case cause := <-sess.rejoin:
+			c.lastSessionCause = cause
+		}
+
+		for {
+			res, err := c.rejoinCooperative(ctx, topics, sess)
+			if errors.Is(err, ErrClosedClient) {
+				return ErrClosedConsumerGroup
+			}
+			if err != nil {
+				return err
+			}
+
+			followUp, err := sess.reconcileAssignment(res)
+			if err != nil {
+				return err
+			}
+			if !followUp {
+				break
+			}
+		}
+	}
+}
+
+func (c *consumerGroup) rejoinCooperative(ctx context.Context, topics []string, sess *consumerGroupSession) (*rebalanceResult, error) {
+	held := &heldAssignment{
+		claims:       sess.Claims(),
+		generationID: sess.GenerationID(),
+	}
+
+	sess.generationMu.Lock()
+	defer sess.generationMu.Unlock()
+
+	var res *rebalanceResult
+	err := sess.offsets.transitionGeneration(func() (int32, error) {
+		result, err := c.joinSync(ctx, topics, held, c.config.Consumer.Group.Rebalance.Retry.Max)
+		if err != nil {
+			return 0, err
+		}
+
+		res = result
+		sess.generationID.Store(res.generationID)
+		return res.generationID, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+// reconcileAssignment reports whether released claims require a follow-up join
+func (s *consumerGroupSession) reconcileAssignment(res *rebalanceResult) (bool, error) {
+	owned := s.Claims()
+	revoked := diffClaims(owned, res.claims)
+	added := diffClaims(res.claims, owned)
+
+	if len(revoked) > 0 {
+		if err := s.revokeClaims(revoked); err != nil {
+			return false, err
+		}
+		s.offsets.removePartitions(revoked)
+	}
+
+	for topic := range added {
+		if err := s.parent.client.RefreshMetadata(topic); err != nil {
+			return false, err
+		}
+	}
+	if err := s.manageClaims(added); err != nil {
+		return false, err
+	}
+
+	s.claims.Store(&res.claims)
+	s.startClaims(added)
+	s.watchPartitionNumbers(res)
+	return len(revoked) > 0, nil
+}
+
+// revokeClaims waits up to the rebalance timeout for handlers to return
+func (s *consumerGroupSession) revokeClaims(revoked map[string][]int32) error {
+	var stopping []*runningClaim
+	for topic, partitions := range revoked {
+		for _, partition := range partitions {
+			tp := topicPartitionAssignment{Topic: topic, Partition: partition}
+			if claim := s.running[tp]; claim != nil {
+				claim.cancel(errPartitionRevoked)
+				stopping = append(stopping, claim)
+				delete(s.running, tp)
+			}
+		}
+	}
+
+	timer := time.NewTimer(s.parent.config.Consumer.Group.Rebalance.Timeout)
+	defer timer.Stop()
+
+	for _, claim := range stopping {
+		select {
+		case <-claim.done:
+		case <-timer.C:
+			s.parent.handleError(ErrRebalanceTimedOut, "", -1)
+			s.cancel(ErrRebalanceTimedOut)
+			return ErrRebalanceTimedOut
+		}
+	}
+	return nil
+}
+
+// diffClaims returns the claims in a that are absent from b.
+func diffClaims(a, b map[string][]int32) map[string][]int32 {
+	diff := make(map[string][]int32)
+	for topic, partitions := range a {
+		for _, partition := range partitions {
+			if !slices.Contains(b[topic], partition) {
+				diff[topic] = append(diff[topic], partition)
+			}
+		}
+	}
+	return diff
+}
+
+func (s *consumerGroupSession) triggerRebalance(cause error) {
+	if s.parent.protocol == RebalanceProtocolEager {
+		s.cancel(cause)
+		return
+	}
+
+	select {
+	case s.rejoin <- cause:
+	default:
+	}
+}

--- a/consumer_group_cooperative_test.go
+++ b/consumer_group_cooperative_test.go
@@ -1,0 +1,583 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockCooperativeCoordinator returns one scripted assignment per generation
+type mockCooperativeCoordinator struct {
+	t TestReporter
+
+	mu          sync.Mutex
+	script      []map[string][]int32
+	gen         int32
+	owned       []map[string][]int32
+	rebalancing bool
+	fenced      bool
+	protocol    string
+	syncStarted chan none
+	syncRelease chan none
+	leaderID    string
+}
+
+// rebalanceNow makes the coordinator announce a rebalance on the next heartbeat.
+func (m *mockCooperativeCoordinator) rebalanceNow() {
+	m.mu.Lock()
+	m.rebalancing = true
+	m.mu.Unlock()
+}
+
+// fenceNow makes the coordinator forget the member.
+func (m *mockCooperativeCoordinator) fenceNow() {
+	m.mu.Lock()
+	m.fenced = true
+	m.mu.Unlock()
+}
+
+func (m *mockCooperativeCoordinator) heartbeat(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*HeartbeatRequest)
+	m.mu.Lock()
+	err := ErrNoError
+	switch {
+	case m.fenced:
+		err = ErrUnknownMemberId
+	case m.rebalancing:
+		err = ErrRebalanceInProgress
+	case req.GenerationId != m.gen:
+		err = ErrIllegalGeneration
+	}
+	m.mu.Unlock()
+	return &HeartbeatResponse{Version: req.Version, Err: err}
+}
+
+func newMockCooperativeCoordinator(t TestReporter, protocol string, script ...map[string][]int32) *mockCooperativeCoordinator {
+	return &mockCooperativeCoordinator{t: t, script: script, protocol: protocol, leaderID: "m1"}
+}
+
+func (m *mockCooperativeCoordinator) join(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*JoinGroupRequest)
+
+	m.mu.Lock()
+	owned := map[string][]int32{}
+	var metadata []byte
+	for _, p := range req.OrderedGroupProtocols {
+		if p.Name != m.protocol {
+			continue
+		}
+		metadata = p.Metadata
+		meta := &ConsumerGroupMemberMetadata{}
+		err := decode(p.Metadata, meta, nil)
+		assert.NoError(m.t, err) //nolint:testifylint // callbacks cannot call require through TestReporter
+		for _, op := range meta.OwnedPartitions {
+			owned[op.Topic] = slices.Clone(op.Partitions)
+		}
+	}
+	m.owned = append(m.owned, owned)
+	m.gen++
+	m.rebalancing = false
+	gen := m.gen
+	m.mu.Unlock()
+
+	return &JoinGroupResponse{
+		Version:       req.Version,
+		Err:           ErrNoError,
+		GenerationId:  gen,
+		GroupProtocol: m.protocol,
+		LeaderId:      m.leaderID,
+		MemberId:      "m1",
+		Members:       []GroupMember{{MemberId: "m1", Metadata: metadata}},
+	}
+}
+
+func (m *mockCooperativeCoordinator) sync(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*SyncGroupRequest)
+
+	m.mu.Lock()
+	idx := int(m.gen) - 1
+	if idx >= len(m.script) {
+		idx = len(m.script) - 1
+	}
+	assignment := m.script[idx]
+	started := m.syncStarted
+	release := m.syncRelease
+	m.syncStarted = nil
+	m.syncRelease = nil
+	m.mu.Unlock()
+	if started != nil {
+		close(started)
+		<-release
+	}
+
+	body, err := encode(&ConsumerGroupMemberAssignment{Topics: assignment}, nil)
+	assert.NoError(m.t, err)
+	return &SyncGroupResponse{
+		Version:          req.Version,
+		Err:              ErrNoError,
+		MemberAssignment: body,
+	}
+}
+
+func (m *mockCooperativeCoordinator) blockNextSync() (<-chan none, chan<- none) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.syncStarted = make(chan none)
+	m.syncRelease = make(chan none)
+	return m.syncStarted, m.syncRelease
+}
+
+func (m *mockCooperativeCoordinator) ownedAt(n int) map[string][]int32 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if n >= len(m.owned) {
+		return nil
+	}
+	return m.owned[n]
+}
+
+func (m *mockCooperativeCoordinator) joinCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.owned)
+}
+
+type mockCooperativeFn func(versionedDecoder) encoderWithHeader
+
+func (f mockCooperativeFn) For(reqBody versionedDecoder) encoderWithHeader { return f(reqBody) }
+
+type trackingHandler struct {
+	mu       sync.Mutex
+	setups   int
+	cleanups int
+	entries  map[string]int
+	exits    map[string]int
+}
+
+type trackingSnapshot struct {
+	setups   int
+	cleanups int
+	entries  map[string]int
+	exits    map[string]int
+}
+
+func newTrackingHandler() *trackingHandler {
+	return &trackingHandler{entries: map[string]int{}, exits: map[string]int{}}
+}
+
+func (h *trackingHandler) Setup(ConsumerGroupSession) error {
+	h.mu.Lock()
+	h.setups++
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *trackingHandler) Cleanup(ConsumerGroupSession) error {
+	h.mu.Lock()
+	h.cleanups++
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *trackingHandler) ConsumeClaim(_ ConsumerGroupSession, claim ConsumerGroupClaim) error {
+	key := fmt.Sprintf("%s/%d", claim.Topic(), claim.Partition())
+	h.mu.Lock()
+	h.entries[key]++
+	h.mu.Unlock()
+
+	for range claim.Messages() {
+	}
+
+	h.mu.Lock()
+	h.exits[key]++
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *trackingHandler) snapshot() trackingSnapshot {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return trackingSnapshot{
+		setups:   h.setups,
+		cleanups: h.cleanups,
+		entries:  maps.Clone(h.entries),
+		exits:    maps.Clone(h.exits),
+	}
+}
+
+type returningHandler struct{}
+
+func (*returningHandler) Setup(ConsumerGroupSession) error   { return nil }
+func (*returningHandler) Cleanup(ConsumerGroupSession) error { return nil }
+func (*returningHandler) ConsumeClaim(ConsumerGroupSession, ConsumerGroupClaim) error {
+	return nil
+}
+
+type revocationIgnoringHandler struct {
+	entered chan none
+}
+
+func (*revocationIgnoringHandler) Setup(ConsumerGroupSession) error   { return nil }
+func (*revocationIgnoringHandler) Cleanup(ConsumerGroupSession) error { return nil }
+func (h *revocationIgnoringHandler) ConsumeClaim(sess ConsumerGroupSession, _ ConsumerGroupClaim) error {
+	h.entered <- none{}
+	<-sess.Context().Done()
+	return nil
+}
+
+const cooperativeTestTopic = "my-topic"
+
+func cooperativeBrokerHandlers(t *testing.T, broker *MockBroker, coord *mockCooperativeCoordinator, partitions int32) map[string]MockResponse {
+	offsets := NewMockOffsetResponse(t)
+	for p := range partitions {
+		offsets = offsets.SetOffset(cooperativeTestTopic, p, OffsetOldest, 0).SetOffset(cooperativeTestTopic, p, OffsetNewest, 0)
+	}
+	return groupBrokerHandlers(t, broker, partitions, map[string]MockResponse{
+		"OffsetRequest":    offsets,
+		"FetchRequest":     NewMockFetchResponse(t, 1),
+		"HeartbeatRequest": mockCooperativeFn(coord.heartbeat),
+		"JoinGroupRequest": mockCooperativeFn(coord.join),
+		"SyncGroupRequest": mockCooperativeFn(coord.sync),
+	})
+}
+
+func newCooperativeBroker(t *testing.T, coord *mockCooperativeCoordinator, partitions int32) *MockBroker {
+	broker := NewMockBroker(t, 0)
+	broker.SetHandlerByMap(cooperativeBrokerHandlers(t, broker, coord, partitions))
+	return broker
+}
+
+func newCooperativeConfig(t *testing.T) *Config {
+	config := NewTestConfig()
+	config.ClientID = t.Name()
+	config.Version = V3_2_0_0
+	config.Consumer.Offsets.AutoCommit.Enable = false
+	config.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{NewBalanceStrategyCooperativeSticky()}
+	config.Consumer.Group.Heartbeat.Interval = 20 * time.Millisecond
+	config.Consumer.Group.Session.Timeout = 200 * time.Millisecond
+	config.Metadata.RefreshFrequency = 0
+	return config
+}
+
+func startCooperativeGroup(t *testing.T, coord *mockCooperativeCoordinator, config *Config, h ConsumerGroupHandler) (ConsumerGroup, <-chan error) {
+	t.Helper()
+	_, group, consumeDone := startCooperativeGroupWithPartitions(t, coord, 4, config, h)
+	return group, consumeDone
+}
+
+func startCooperativeGroupWithPartitions(t *testing.T, coord *mockCooperativeCoordinator, partitions int32, config *Config, h ConsumerGroupHandler) (*MockBroker, ConsumerGroup, <-chan error) {
+	t.Helper()
+	broker := newCooperativeBroker(t, coord, partitions)
+	t.Cleanup(broker.Close)
+
+	if config == nil {
+		config = newCooperativeConfig(t)
+	}
+	group, err := NewConsumerGroup([]string{broker.Addr()}, "my-group", config)
+	require.NoError(t, err)
+
+	consumeDone := make(chan error, 1)
+	go func() { consumeDone <- group.Consume(t.Context(), []string{cooperativeTestTopic}, h) }()
+	return broker, group, consumeDone
+}
+
+func waitForClaims(t *testing.T, h *trackingHandler, n int) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(c, h.snapshot().entries, n)
+	}, 20*time.Second, 20*time.Millisecond)
+}
+
+func waitForJoins(t *testing.T, coord *mockCooperativeCoordinator, n int) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, coord.joinCount(), n)
+	}, 20*time.Second, 20*time.Millisecond)
+}
+
+func waitForConsume(t *testing.T, consumeDone <-chan error) error {
+	t.Helper()
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+
+	select {
+	case err := <-consumeDone:
+		return err
+	case <-timer.C:
+		require.FailNow(t, "Consume did not return")
+		return nil
+	}
+}
+
+func closeCooperativeGroup(t *testing.T, group ConsumerGroup, consumeDone <-chan error) {
+	t.Helper()
+	require.NoError(t, group.Close())
+	require.NoError(t, waitForConsume(t, consumeDone))
+}
+
+func TestConsumerGroupCooperativeRebalance(t *testing.T) {
+	const topic = cooperativeTestTopic
+
+	t.Run("a rejoining member reports the partitions it still owns", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1, 2, 3}},
+			map[string][]int32{topic: {0, 1}},
+		)
+		h := newTrackingHandler()
+		group, consumeDone := startCooperativeGroup(t, coord, nil, h)
+
+		waitForClaims(t, h, 4)
+		coord.rebalanceNow()
+		waitForJoins(t, coord, 2)
+
+		require.Empty(t, coord.ownedAt(0), "first join should own nothing")
+		owned := coord.ownedAt(1)
+		require.NotNil(t, owned)
+		got := slices.Clone(owned[topic])
+		slices.Sort(got)
+		require.Equal(t, []int32{0, 1, 2, 3}, got)
+
+		closeCooperativeGroup(t, group, consumeDone)
+	})
+
+	t.Run("an eager member never reports owned partitions", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, RangeBalanceStrategyName,
+			map[string][]int32{topic: {0, 1, 2, 3}},
+			map[string][]int32{topic: {0, 1}},
+		)
+		broker := newCooperativeBroker(t, coord, 4)
+		t.Cleanup(broker.Close)
+
+		config := newCooperativeConfig(t)
+		config.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{NewBalanceStrategyRange()}
+		group, err := NewConsumerGroup([]string{broker.Addr()}, "my-group", config)
+		require.NoError(t, err)
+
+		h := newTrackingHandler()
+		consumeDone := make(chan error, 1)
+		go func() {
+			for t.Context().Err() == nil {
+				if err := group.Consume(t.Context(), []string{topic}, h); err != nil {
+					consumeDone <- err
+					return
+				}
+			}
+			consumeDone <- nil
+		}()
+
+		waitForClaims(t, h, 4)
+		coord.rebalanceNow()
+		waitForJoins(t, coord, 2)
+
+		for i := range coord.joinCount() {
+			require.Empty(t, coord.ownedAt(i), "eager join %d must not report owned partitions", i)
+		}
+
+		require.NoError(t, group.Close())
+		require.ErrorIs(t, waitForConsume(t, consumeDone), ErrClosedConsumerGroup)
+	})
+
+	t.Run("retained partitions keep running across a rebalance", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1, 2, 3}}, // generation 1
+			map[string][]int32{topic: {0, 1}},       // generation 2: 2 and 3 taken away
+		)
+		h := newTrackingHandler()
+		group, consumeDone := startCooperativeGroup(t, coord, nil, h)
+
+		waitForClaims(t, h, 4)
+
+		coord.rebalanceNow()
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			state := h.snapshot()
+			assert.Equal(c, 1, state.exits[topic+"/2"], "partition 2 should have been revoked")
+			assert.Equal(c, 1, state.exits[topic+"/3"], "partition 3 should have been revoked")
+		}, 20*time.Second, 20*time.Millisecond)
+
+		state := h.snapshot()
+		require.Equal(t, 1, state.entries[topic+"/0"], "partition 0 should have been claimed exactly once")
+		require.Equal(t, 1, state.entries[topic+"/1"], "partition 1 should have been claimed exactly once")
+		require.Zero(t, state.exits[topic+"/0"], "partition 0 should not have been revoked")
+		require.Zero(t, state.exits[topic+"/1"], "partition 1 should not have been revoked")
+		require.Equal(t, 1, state.setups, "Setup should run once per member, not per generation")
+		require.Zero(t, state.cleanups, "Cleanup should not run on a rebalance")
+
+		closeCooperativeGroup(t, group, consumeDone)
+
+		state = h.snapshot()
+		require.Equal(t, 1, state.setups)
+		require.Equal(t, 1, state.cleanups, "Cleanup should run once, on exit")
+	})
+
+	t.Run("a revocation makes the member rejoin without being told to", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1, 2, 3}},
+			map[string][]int32{topic: {0, 1}},
+		)
+		h := newTrackingHandler()
+		group, consumeDone := startCooperativeGroup(t, coord, nil, h)
+
+		waitForClaims(t, h, 4)
+		coord.rebalanceNow()
+
+		waitForJoins(t, coord, 3)
+
+		closeCooperativeGroup(t, group, consumeDone)
+	})
+
+	t.Run("gaining partitions does not make the member rejoin", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1}},
+			map[string][]int32{topic: {0, 1, 2, 3}},
+		)
+		h := newTrackingHandler()
+		group, consumeDone := startCooperativeGroup(t, coord, nil, h)
+
+		waitForClaims(t, h, 2)
+		coord.rebalanceNow()
+		waitForClaims(t, h, 4)
+
+		require.Never(t, func() bool { return coord.joinCount() > 2 }, 400*time.Millisecond, 25*time.Millisecond)
+		require.Empty(t, h.snapshot().exits)
+
+		closeCooperativeGroup(t, group, consumeDone)
+	})
+
+	t.Run("heartbeats wait for an in-flight rejoin to publish its generation", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1}},
+			map[string][]int32{topic: {0, 1}},
+		)
+		config := newCooperativeConfig(t)
+		config.Consumer.Group.Heartbeat.Interval = 10 * time.Millisecond
+		h := newTrackingHandler()
+		group, consumeDone := startCooperativeGroup(t, coord, config, h)
+
+		waitForClaims(t, h, 2)
+		syncStarted, syncRelease := coord.blockNextSync()
+		coord.rebalanceNow()
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			select {
+			case <-syncStarted:
+			default:
+				assert.Fail(c, "SyncGroup did not start")
+			}
+		}, 20*time.Second, 5*time.Millisecond)
+
+		timer := time.NewTimer(5 * config.Consumer.Group.Heartbeat.Interval)
+		<-timer.C
+		close(syncRelease)
+
+		waitForJoins(t, coord, 2)
+		require.Never(t, func() bool {
+			select {
+			case <-consumeDone:
+				return true
+			default:
+				return false
+			}
+		}, 100*time.Millisecond, 5*time.Millisecond)
+
+		closeCooperativeGroup(t, group, consumeDone)
+	})
+
+	t.Run("a ConsumeClaim returning of its own accord still ends the session", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1}},
+		)
+		h := &returningHandler{}
+		group, consumeDone := startCooperativeGroup(t, coord, nil, h)
+		defer func() { require.NoError(t, group.Close()) }()
+
+		require.NoError(t, waitForConsume(t, consumeDone))
+	})
+
+	t.Run("a handler that ignores revocation is cut off at the rebalance timeout", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1}},
+			map[string][]int32{topic: {0}},
+		)
+		config := newCooperativeConfig(t)
+		config.Consumer.Group.Rebalance.Timeout = 200 * time.Millisecond
+
+		h := &revocationIgnoringHandler{entered: make(chan none, 4)}
+		group, consumeDone := startCooperativeGroup(t, coord, config, h)
+		defer func() { require.NoError(t, group.Close()) }()
+
+		<-h.entered
+		<-h.entered
+		coord.rebalanceNow()
+
+		require.ErrorIs(t, waitForConsume(t, consumeDone), ErrRebalanceTimedOut)
+	})
+
+	t.Run("a member fenced by the coordinator ends the session", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1}},
+		)
+		h := newTrackingHandler()
+		group, consumeDone := startCooperativeGroup(t, coord, nil, h)
+		defer func() { require.NoError(t, group.Close()) }()
+
+		waitForClaims(t, h, 2)
+		coord.fenceNow()
+
+		require.NoError(t, waitForConsume(t, consumeDone))
+	})
+
+	t.Run("a partition count change makes the leader rejoin in place", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1}},
+			map[string][]int32{topic: {0, 1, 2}},
+		)
+		config := newCooperativeConfig(t)
+		config.Metadata.RefreshFrequency = 50 * time.Millisecond
+		h := newTrackingHandler()
+		broker, group, consumeDone := startCooperativeGroupWithPartitions(t, coord, 2, config, h)
+
+		waitForClaims(t, h, 2)
+
+		broker.SetHandlerByMap(cooperativeBrokerHandlers(t, broker, coord, 3))
+		waitForClaims(t, h, 3)
+
+		state := h.snapshot()
+		require.Equal(t, 1, state.setups, "the session should have survived the rebalance")
+		require.Zero(t, state.cleanups)
+		require.Equal(t, 1, state.entries[topic+"/0"])
+		require.Equal(t, 1, state.entries[topic+"/1"])
+
+		joins := coord.joinCount()
+		require.Never(t, func() bool { return coord.joinCount() > joins }, 400*time.Millisecond, 25*time.Millisecond)
+
+		closeCooperativeGroup(t, group, consumeDone)
+	})
+
+	t.Run("a follower refreshes metadata before claiming a new partition", func(t *testing.T) {
+		coord := newMockCooperativeCoordinator(t, CooperativeStickyBalanceStrategyName,
+			map[string][]int32{topic: {0, 1}},
+			map[string][]int32{topic: {0, 1, 2}},
+		)
+		coord.leaderID = "m2"
+
+		h := newTrackingHandler()
+		broker, group, consumeDone := startCooperativeGroupWithPartitions(t, coord, 2, nil, h)
+
+		waitForClaims(t, h, 2)
+
+		broker.SetHandlerByMap(cooperativeBrokerHandlers(t, broker, coord, 3))
+		coord.rebalanceNow()
+		waitForClaims(t, h, 3)
+
+		closeCooperativeGroup(t, group, consumeDone)
+	})
+}

--- a/consumer_group_session.go
+++ b/consumer_group_session.go
@@ -4,18 +4,21 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // ConsumerGroupSession represents a consumer group member session.
 type ConsumerGroupSession interface {
-	// Claims returns information about the claimed partitions by topic.
+	// Claims returns the currently claimed partitions by topic. The claims may
+	// change across cooperative rebalances.
 	Claims() map[string][]int32
 
 	// MemberID returns the cluster member ID.
 	MemberID() string
 
-	// GenerationID returns the current generation ID.
+	// GenerationID returns the current generation ID. The generation changes
+	// across cooperative rebalances.
 	GenerationID() int32
 
 	// MarkOffset marks the provided offset, alongside a metadata string
@@ -52,16 +55,33 @@ type ConsumerGroupSession interface {
 	Context() context.Context
 }
 
-type consumerGroupSession struct {
-	parent       *consumerGroup
-	memberID     string
-	generationID int32
-	handler      ConsumerGroupHandler
+type runningClaim struct {
+	cancel context.CancelCauseFunc
+	done   chan none
+}
 
-	claims  map[string][]int32
+type consumerGroupSession struct {
+	parent   *consumerGroup
+	memberID string
+	handler  ConsumerGroupHandler
+
+	// cooperative sessions replace these values on each generation
+	generationID atomic.Int32
+	claims       atomic.Pointer[map[string][]int32]
+
 	offsets *offsetManager
 	ctx     context.Context
 	cancel  context.CancelCauseFunc
+
+	// only the Consume goroutine accesses running and partitionWatchCancel
+	running              map[topicPartitionAssignment]*runningClaim
+	partitionWatchCancel context.CancelFunc
+
+	// the buffered channel coalesces concurrent rebalance notifications
+	rejoin chan error
+
+	// serializes joining a new generation with heartbeat requests
+	generationMu sync.Mutex
 
 	waitGroup       sync.WaitGroup
 	releaseOnce     sync.Once
@@ -80,37 +100,27 @@ func newConsumerGroupSession(ctx context.Context, parent *consumerGroup, claims 
 
 	// init session
 	sess := &consumerGroupSession{
-		parent:       parent,
-		memberID:     memberID,
-		generationID: generationID,
-		handler:      handler,
-		offsets:      offsets,
-		claims:       claims,
-		ctx:          ctx,
-		cancel:       cancel,
-		hbDying:      make(chan none),
-		hbDead:       make(chan none),
+		parent:   parent,
+		memberID: memberID,
+		handler:  handler,
+		offsets:  offsets,
+		ctx:      ctx,
+		cancel:   cancel,
+		running:  make(map[topicPartitionAssignment]*runningClaim),
+		rejoin:   make(chan error, 1),
+		hbDying:  make(chan none),
+		hbDead:   make(chan none),
 	}
+	sess.generationID.Store(generationID)
+	sess.claims.Store(&claims)
 
 	// start heartbeat loop
 	go sess.heartbeatLoop()
 
 	// create a POM for each claim
-	for topic, partitions := range claims {
-		for _, partition := range partitions {
-			pom, err := offsets.ManagePartition(topic, partition)
-			if err != nil {
-				_ = sess.release(false)
-				return nil, err
-			}
-
-			// handle POM errors
-			go func(topic string, partition int32) {
-				for err := range pom.Errors() {
-					sess.parent.handleError(err, topic, partition)
-				}
-			}(topic, partition)
-		}
+	if err := sess.manageClaims(claims); err != nil {
+		_ = sess.release(false)
+		return nil, err
 	}
 
 	// perform setup
@@ -120,42 +130,103 @@ func newConsumerGroupSession(ctx context.Context, parent *consumerGroup, claims 
 	}
 
 	// start consuming each topic partition in its own goroutine
-	for topic, partitions := range claims {
-		for _, partition := range partitions {
-			sess.waitGroup.Add(1) // increment wait group before spawning goroutine
-			go func(topic string, partition int32) {
-				defer sess.waitGroup.Done()
-				// cancel the group session as soon as any of the consume calls return
-				defer sess.cancel(ErrSessionConsumeClaimExited)
-
-				// if partition not currently readable, wait for it to become readable
-				if sess.parent.client.PartitionNotReadable(topic, partition) {
-					timer := time.NewTimer(5 * time.Second)
-					defer timer.Stop()
-
-					for sess.parent.client.PartitionNotReadable(topic, partition) {
-						select {
-						case <-ctx.Done():
-							return
-						case <-parent.closed:
-							return
-						case <-timer.C:
-							timer.Reset(5 * time.Second)
-						}
-					}
-				}
-
-				// consume a single topic/partition, blocking
-				sess.consume(topic, partition)
-			}(topic, partition)
-		}
-	}
+	sess.startClaims(claims)
 	return sess, nil
 }
 
-func (s *consumerGroupSession) Claims() map[string][]int32 { return s.claims }
+// watchPartitionNumbers replaces the leader-only watcher for each generation
+func (s *consumerGroupSession) watchPartitionNumbers(res *rebalanceResult) {
+	if s.partitionWatchCancel != nil {
+		s.partitionWatchCancel()
+		s.partitionWatchCancel = nil
+	}
+	if !res.isLeader {
+		return
+	}
+
+	var ctx context.Context
+	ctx, s.partitionWatchCancel = context.WithCancel(s.ctx)
+	go s.parent.loopCheckPartitionNumbers(ctx, res.allSubscribedTopicPartitions, res.allSubscribedTopics, s)
+}
+
+func (s *consumerGroupSession) managePartition(topic string, partition int32) error {
+	pom, err := s.offsets.ManagePartition(topic, partition)
+	if err != nil {
+		return err
+	}
+
+	// handle POM errors
+	go func() {
+		for err := range pom.Errors() {
+			s.parent.handleError(err, topic, partition)
+		}
+	}()
+	return nil
+}
+
+func (s *consumerGroupSession) manageClaims(claims map[string][]int32) error {
+	for topic, partitions := range claims {
+		for _, partition := range partitions {
+			if err := s.managePartition(topic, partition); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (s *consumerGroupSession) startClaims(claims map[string][]int32) {
+	for topic, partitions := range claims {
+		for _, partition := range partitions {
+			s.startClaim(topic, partition)
+		}
+	}
+}
+
+// startClaim gives each partition a context that can be canceled independently
+func (s *consumerGroupSession) startClaim(topic string, partition int32) {
+	claimCtx, cancel := context.WithCancelCause(s.ctx)
+	claim := &runningClaim{
+		cancel: cancel,
+		done:   make(chan none),
+	}
+
+	s.running[topicPartitionAssignment{Topic: topic, Partition: partition}] = claim
+
+	s.waitGroup.Go(func() {
+		defer close(claim.done)
+		// a handler returning without revocation still ends the session
+		defer func() {
+			if !errors.Is(context.Cause(claimCtx), errPartitionRevoked) {
+				s.cancel(ErrSessionConsumeClaimExited)
+			}
+		}()
+
+		// if partition not currently readable, wait for it to become readable
+		if s.parent.client.PartitionNotReadable(topic, partition) {
+			timer := time.NewTimer(5 * time.Second)
+			defer timer.Stop()
+
+			for s.parent.client.PartitionNotReadable(topic, partition) {
+				select {
+				case <-claimCtx.Done():
+					return
+				case <-s.parent.closed:
+					return
+				case <-timer.C:
+					timer.Reset(5 * time.Second)
+				}
+			}
+		}
+
+		// consume a single topic/partition, blocking
+		s.consume(claimCtx, topic, partition)
+	})
+}
+
+func (s *consumerGroupSession) Claims() map[string][]int32 { return *s.claims.Load() }
 func (s *consumerGroupSession) MemberID() string           { return s.memberID }
-func (s *consumerGroupSession) GenerationID() int32        { return s.generationID }
+func (s *consumerGroupSession) GenerationID() int32        { return s.generationID.Load() }
 
 func (s *consumerGroupSession) MarkOffset(topic string, partition int32, offset int64, metadata string) {
 	if pom := s.offsets.findPOM(topic, partition); pom != nil {
@@ -184,7 +255,7 @@ func (s *consumerGroupSession) Context() context.Context {
 // newClaimWithRetry calls newConsumerGroupClaim, retrying transient errors so
 // that brief leader/metadata desync around a rebalance doesn't leave a
 // partition permanently unclaimed for the lifetime of this session
-func (s *consumerGroupSession) newClaimWithRetry(topic string, partition int32, offset int64) (*consumerGroupClaim, error) {
+func (s *consumerGroupSession) newClaimWithRetry(ctx context.Context, topic string, partition int32, offset int64) (*consumerGroupClaim, error) {
 	retries := s.parent.config.Metadata.Retry.Max
 	for {
 		claim, err := newConsumerGroupClaim(s, topic, partition, offset)
@@ -202,8 +273,8 @@ func (s *consumerGroupSession) newClaimWithRetry(topic string, partition int32, 
 			topic, partition, backoff/time.Millisecond, retries, err)
 
 		select {
-		case <-s.ctx.Done():
-			return nil, err
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		case <-s.parent.closed:
 			return nil, err
 		case <-time.After(backoff):
@@ -225,10 +296,10 @@ func isRetriableClaimError(err error) bool {
 		errors.Is(err, ErrReplicaNotAvailable)
 }
 
-func (s *consumerGroupSession) consume(topic string, partition int32) {
+func (s *consumerGroupSession) consume(ctx context.Context, topic string, partition int32) {
 	// quick exit if rebalance is due
 	select {
-	case <-s.ctx.Done():
+	case <-ctx.Done():
 		return
 	case <-s.parent.closed:
 		return
@@ -242,16 +313,19 @@ func (s *consumerGroupSession) consume(topic string, partition int32) {
 	}
 
 	// create new claim
-	claim, err := s.newClaimWithRetry(topic, partition, offset)
+	claim, err := s.newClaimWithRetry(ctx, topic, partition, offset)
 	if err != nil {
-		s.parent.handleError(err, topic, partition)
+		if ctx.Err() == nil {
+			s.parent.handleError(err, topic, partition)
+		}
 		return
 	}
 
-	// trigger close when session is done
+	// trigger close when the claim is revoked or the session is done; closing
+	// Messages() is how a handler is told to let the partition go
 	go func() {
 		select {
-		case <-s.ctx.Done():
+		case <-ctx.Done():
 		case <-s.parent.closed:
 		}
 		claim.AsyncClose()
@@ -300,6 +374,12 @@ func (s *consumerGroupSession) release(withCleanup bool) (err error) {
 	return
 }
 
+func (s *consumerGroupSession) sendHeartbeat(coordinator *Broker) (*HeartbeatResponse, error) {
+	s.generationMu.Lock()
+	defer s.generationMu.Unlock()
+	return s.parent.heartbeatRequest(coordinator, s.memberID, s.GenerationID())
+}
+
 func (s *consumerGroupSession) heartbeatLoop() {
 	defer close(s.hbDead)
 	defer s.cancel(ErrSessionHeartbeatFailed) // trigger the end of the session on exit
@@ -334,7 +414,7 @@ func (s *consumerGroupSession) heartbeatLoop() {
 			continue
 		}
 
-		resp, err := s.parent.heartbeatRequest(coordinator, s.memberID, s.generationID)
+		resp, err := s.sendHeartbeat(coordinator)
 		if err != nil {
 			_ = coordinator.Close()
 
@@ -353,7 +433,7 @@ func (s *consumerGroupSession) heartbeatLoop() {
 			retries = s.parent.config.Metadata.Retry.Max
 		case ErrRebalanceInProgress:
 			retries = s.parent.config.Metadata.Retry.Max
-			s.cancel(err)
+			s.triggerRebalance(err)
 		case ErrUnknownMemberId, ErrIllegalGeneration:
 			s.cancel(err)
 			return
@@ -439,11 +519,9 @@ type ConsumerGroupClaim interface {
 	// You can use this to determine how far behind the processing is.
 	HighWaterMarkOffset() int64
 
-	// Messages returns the read channel for the messages that are returned by
-	// the broker. The messages channel will be closed when a new rebalance cycle
-	// is due. You must finish processing and mark offsets within
-	// Config.Consumer.Group.Session.Timeout before the topic/partition is eventually
-	// re-assigned to another group member.
+	// Messages returns messages from the broker. The channel closes when the
+	// claim is released. You must finish processing and mark offsets within
+	// Config.Consumer.Group.Rebalance.Timeout after a claim is revoked.
 	Messages() <-chan *ConsumerMessage
 }
 

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -629,6 +629,45 @@ func (m *mockHeartbeatRebalanceResponse) For(reqBody versionedDecoder) encoderWi
 	return resp
 }
 
+// groupBrokerHandlers returns the full handler map a single-broker consumer
+// group needs to form and consume "my-topic" as "my-group": partitions
+// [0,partitions) led by the broker, one message on partition 0, and a plain
+// range join/sync giving the member every partition. overrides replace
+// individual entries.
+func groupBrokerHandlers(t *testing.T, broker *MockBroker, partitions int32, overrides map[string]MockResponse) map[string]MockResponse {
+	allPartitions := make([]int32, partitions)
+	metadata := NewMockMetadataResponse(t).SetBroker(broker.Addr(), broker.BrokerID())
+	offsets := NewMockOffsetResponse(t)
+	offsetFetch := NewMockOffsetFetchResponse(t).SetError(ErrNoError)
+	for p := range partitions {
+		allPartitions[p] = p
+		metadata = metadata.SetLeader("my-topic", p, broker.BrokerID())
+		offsets = offsets.SetOffset("my-topic", p, OffsetOldest, 0).SetOffset("my-topic", p, OffsetNewest, 1)
+		offsetFetch = offsetFetch.SetOffset("my-group", "my-topic", p, 0, "", ErrNoError)
+	}
+	handlers := map[string]MockResponse{
+		"MetadataRequest":        metadata,
+		"OffsetRequest":          offsets,
+		"OffsetFetchRequest":     offsetFetch,
+		"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).SetCoordinator(CoordinatorGroup, "my-group", broker),
+		"HeartbeatRequest":       NewMockHeartbeatResponse(t),
+		"JoinGroupRequest": NewMockJoinGroupResponse(t).
+			SetGroupProtocol(RangeBalanceStrategyName).
+			SetMemberId("test-member"),
+		"SyncGroupRequest": NewMockSyncGroupResponse(t).SetMemberAssignment(
+			&ConsumerGroupMemberAssignment{
+				Version: 0,
+				Topics:  map[string][]int32{"my-topic": allPartitions},
+			}),
+		"LeaveGroupRequest":   NewMockLeaveGroupResponse(t),
+		"OffsetCommitRequest": NewMockOffsetCommitResponse(t),
+		"FetchRequest": NewMockFetchResponse(t, 1).
+			SetMessage("my-topic", 0, 0, StringEncoder("foo")),
+	}
+	maps.Copy(handlers, overrides)
+	return handlers
+}
+
 func TestConsumerGroupSessionCancelCause_Rebalance(t *testing.T) {
 	config := NewTestConfig()
 	config.ClientID = t.Name()
@@ -642,30 +681,9 @@ func TestConsumerGroupSessionCancelCause_Rebalance(t *testing.T) {
 	broker0 := NewMockBroker(t, 0)
 	defer broker0.Close()
 
-	broker0.SetHandlerByMap(map[string]MockResponse{
-		"MetadataRequest": NewMockMetadataResponse(t).
-			SetBroker(broker0.Addr(), broker0.BrokerID()).
-			SetLeader("my-topic", 0, broker0.BrokerID()),
-		"OffsetRequest": NewMockOffsetResponse(t).
-			SetOffset("my-topic", 0, OffsetOldest, 0).
-			SetOffset("my-topic", 0, OffsetNewest, 1),
-		"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).
-			SetCoordinator(CoordinatorGroup, "my-group", broker0),
+	broker0.SetHandlerByMap(groupBrokerHandlers(t, broker0, 1, map[string]MockResponse{
 		"HeartbeatRequest": &mockHeartbeatRebalanceResponse{t: t, successLeft: 1},
-		"JoinGroupRequest": NewMockJoinGroupResponse(t).SetGroupProtocol(RangeBalanceStrategyName),
-		"SyncGroupRequest": NewMockSyncGroupResponse(t).SetMemberAssignment(
-			&ConsumerGroupMemberAssignment{
-				Version: 0,
-				Topics: map[string][]int32{
-					"my-topic": {0},
-				},
-			}),
-		"OffsetFetchRequest": NewMockOffsetFetchResponse(t).SetOffset(
-			"my-group", "my-topic", 0, 0, "", ErrNoError,
-		).SetError(ErrNoError),
-		"FetchRequest": NewMockFetchResponse(t, 1).
-			SetMessage("my-topic", 0, 0, StringEncoder("foo")),
-	})
+	}))
 
 	group, err := NewConsumerGroup([]string{broker0.Addr()}, "my-group", config)
 	if err != nil {
@@ -703,32 +721,10 @@ func TestConsumerGroupReason(t *testing.T) {
 
 		broker0 := NewMockBroker(t, 0)
 		handlers := map[string]MockResponse{
-			"MetadataRequest": NewMockMetadataResponse(t).
-				SetBroker(broker0.Addr(), broker0.BrokerID()).
-				SetLeader("my-topic", 0, broker0.BrokerID()),
-			"OffsetRequest": NewMockOffsetResponse(t).
-				SetOffset("my-topic", 0, OffsetOldest, 0).
-				SetOffset("my-topic", 0, OffsetNewest, 1),
-			"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).
-				SetCoordinator(CoordinatorGroup, "my-group", broker0),
 			"HeartbeatRequest": &mockHeartbeatRebalanceResponse{t: t, successLeft: 1},
-			"JoinGroupRequest": NewMockJoinGroupResponse(t).
-				SetGroupProtocol(RangeBalanceStrategyName).
-				SetMemberId("test-member"),
-			"SyncGroupRequest": NewMockSyncGroupResponse(t).SetMemberAssignment(
-				&ConsumerGroupMemberAssignment{
-					Version: 0,
-					Topics:  map[string][]int32{"my-topic": {0}},
-				}),
-			"LeaveGroupRequest": NewMockLeaveGroupResponse(t),
-			"OffsetFetchRequest": NewMockOffsetFetchResponse(t).SetOffset(
-				"my-group", "my-topic", 0, 0, "", ErrNoError,
-			).SetError(ErrNoError),
-			"FetchRequest": NewMockFetchResponse(t, 1).
-				SetMessage("my-topic", 0, 0, StringEncoder("foo")),
 		}
 		maps.Copy(handlers, overrides)
-		broker0.SetHandlerByMap(handlers)
+		broker0.SetHandlerByMap(groupBrokerHandlers(t, broker0, 1, handlers))
 
 		group, err := NewConsumerGroup([]string{broker0.Addr()}, "my-group", config)
 		assert.NoError(t, err)

--- a/functional_consumer_group_cooperative_test.go
+++ b/functional_consumer_group_cooperative_test.go
@@ -1,0 +1,140 @@
+//go:build functional
+
+package sarama
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const functionalCooperativeTopic = "test.4"
+
+func TestFuncConsumerGroupCooperative(t *testing.T) {
+	checkKafkaVersion(t, "2.4.0")
+
+	t.Run("round trips messages while scaling the group", func(t *testing.T) {
+		setupFunctionalTest(t)
+		t.Cleanup(func() { teardownFunctionalTest(t) })
+
+		groupID := testFuncConsumerGroupID(t)
+		prefix := groupID + "-scale"
+		sink := newFunctionalCooperativeSink(prefix)
+
+		member1 := startFunctionalRoundTripMember(
+			t, groupID, "cooperative-1", NewBalanceStrategyCooperativeSticky(), sink,
+		)
+
+		waitForFunctionalCooperativeMessages(t, sink,
+			produceFunctionalCooperativeMessages(t, prefix, 0, 5))
+
+		member2 := startFunctionalRoundTripMember(
+			t, groupID, "cooperative-2", NewBalanceStrategyCooperativeSticky(), sink,
+		)
+
+		waitForFunctionalCooperativeMessages(t, sink,
+			produceFunctionalCooperativeMessages(t, prefix, 5, 5))
+
+		member1.AssertCleanShutdown()
+		member2.AssertCleanShutdown()
+	})
+
+	t.Run("upgrades an eager group to cooperative", func(t *testing.T) {
+		setupFunctionalTest(t)
+		t.Cleanup(func() { teardownFunctionalTest(t) })
+
+		groupID := testFuncConsumerGroupID(t)
+		prefix := groupID + "-upgrade"
+		sink := newFunctionalCooperativeSink(prefix)
+
+		eager := startFunctionalRoundTripMember(
+			t, groupID, "eager", NewBalanceStrategyRange(), sink,
+		)
+
+		waitForFunctionalCooperativeMessages(t, sink,
+			produceFunctionalCooperativeMessages(t, prefix, 0, 5))
+		eager.AssertCleanShutdown()
+
+		cooperative := startFunctionalRoundTripMember(
+			t, groupID, "cooperative", NewBalanceStrategyCooperativeSticky(), sink,
+		)
+
+		waitForFunctionalCooperativeMessages(t, sink,
+			produceFunctionalCooperativeMessages(t, prefix, 5, 5))
+		cooperative.AssertCleanShutdown()
+	})
+}
+
+func startFunctionalRoundTripMember(
+	t *testing.T,
+	groupID string,
+	clientID string,
+	strategy BalanceStrategy,
+	sink *testFuncConsumerGroupSink,
+) *testFuncConsumerGroupMember {
+	t.Helper()
+	config := defaultConfig(clientID)
+	config.Consumer.Offsets.Initial = OffsetOldest
+	config.Consumer.Group.Heartbeat.Interval = 500 * time.Millisecond
+	config.Consumer.Group.Rebalance.GroupStrategies = []BalanceStrategy{strategy}
+	member := runTestFuncConsumerGroupMemberWithConfig(
+		t, config, groupID, 0, sink, functionalCooperativeTopic,
+	)
+	t.Cleanup(member.Stop)
+	member.WaitForState(2)
+	return member
+}
+
+func newFunctionalCooperativeSink(prefix string) *testFuncConsumerGroupSink {
+	return &testFuncConsumerGroupSink{
+		msgs: make(chan testFuncConsumerGroupMessage, 100),
+		filter: func(message *ConsumerMessage) bool {
+			return strings.HasPrefix(string(message.Value), prefix)
+		},
+	}
+}
+
+func produceFunctionalCooperativeMessages(t *testing.T, prefix string, start, count int) []string {
+	t.Helper()
+	config := NewFunctionalTestConfig()
+	config.ClientID = t.Name()
+	config.Producer.Return.Successes = true
+	producer, err := NewSyncProducer(FunctionalTestEnv.KafkaBrokerAddrs, config)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, producer.Close()) }()
+
+	messages := make([]string, 0, count)
+	for i := start; i < start+count; i++ {
+		value := fmt.Sprintf("%s-%02d", prefix, i)
+		_, _, err := producer.SendMessage(&ProducerMessage{
+			Topic: functionalCooperativeTopic,
+			Value: StringEncoder(value),
+		})
+		require.NoError(t, err)
+		messages = append(messages, value)
+	}
+	return messages
+}
+
+func waitForFunctionalCooperativeMessages(t *testing.T, sink *testFuncConsumerGroupSink, expected []string) {
+	t.Helper()
+	pending := make(map[string]none, len(expected))
+	for _, message := range expected {
+		pending[message] = none{}
+	}
+
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	for len(pending) > 0 {
+		select {
+		case message := <-sink.msgs:
+			delete(pending, string(message.Value))
+		case <-timer.C:
+			require.Empty(t, pending, "consumer group did not receive every message")
+			return
+		}
+	}
+}

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -352,8 +352,9 @@ type testFuncConsumerGroupMessage struct {
 }
 
 type testFuncConsumerGroupSink struct {
-	msgs  chan testFuncConsumerGroupMessage
-	count atomic.Int32
+	msgs   chan testFuncConsumerGroupMessage
+	filter func(*ConsumerMessage) bool
+	count  atomic.Int32
 }
 
 func (s *testFuncConsumerGroupSink) Len() int {
@@ -364,7 +365,7 @@ func (s *testFuncConsumerGroupSink) Len() int {
 }
 
 func (s *testFuncConsumerGroupSink) Push(clientID string, m *ConsumerMessage) {
-	if s != nil {
+	if s != nil && (s.filter == nil || s.filter(m)) {
 		s.msgs <- testFuncConsumerGroupMessage{ClientID: clientID, ConsumerMessage: m}
 		s.count.Add(1)
 	}

--- a/offset_manager.go
+++ b/offset_manager.go
@@ -258,11 +258,18 @@ func (om *offsetManager) Commit() {
 	om.releasePOMs(false)
 }
 
-//lint:ignore U1000 // consumed by the cooperative rebalancing path added in a following PR; the only in-build caller here is the unit test (excluded by the integration build tag)
-func (om *offsetManager) setGeneration(generation int32) {
+// transitionGeneration keeps commits out while the coordinator establishes
+// the next generation
+func (om *offsetManager) transitionGeneration(next func() (int32, error)) error {
 	om.generationLock.Lock()
 	defer om.generationLock.Unlock()
+
+	generation, err := next()
+	if err != nil {
+		return err
+	}
 	om.generation = generation
+	return nil
 }
 
 // partitionTargets names a subset of managed partitions; a nil set means all of them
@@ -496,8 +503,6 @@ func (om *offsetManager) asyncClosePOMs() {
 }
 
 // removePartitions closes partitions revoked during a rebalance, committing first when configured
-//
-//lint:ignore U1000 // consumed by the cooperative rebalancing path added in a following PR; the only in-build caller here is the unit test (excluded by the integration build tag)
 func (om *offsetManager) removePartitions(topicPartitions map[string][]int32) {
 	targets := make(partitionTargets, len(topicPartitions))
 	for topic, partitions := range topicPartitions {

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -1016,7 +1016,7 @@ func TestOffsetManagerRemovePartitions(t *testing.T) {
 				committed = append(committed, p)
 			}
 		}
-		require.ElementsMatch(t, []int32{2,3}, committed)
+		require.ElementsMatch(t, []int32{2, 3}, committed)
 
 		require.Nil(t, om.findPOM("my_topic", 2))
 		require.Nil(t, om.findPOM("my_topic", 3))
@@ -1094,7 +1094,7 @@ func TestOffsetManagerRemovePartitions(t *testing.T) {
 	})
 }
 
-func TestOffsetManagerSetGeneration(t *testing.T) {
+func TestOffsetManagerTransitionGeneration(t *testing.T) {
 	t.Run("commits carry the generation most recently set", func(t *testing.T) {
 		om, capture := newCapturingOffsetManager(t, false)
 
@@ -1103,7 +1103,9 @@ func TestOffsetManagerSetGeneration(t *testing.T) {
 
 		pom.MarkOffset(100, "")
 		om.Commit()
-		om.setGeneration(7)
+		require.NoError(t, om.transitionGeneration(func() (int32, error) {
+			return 7, nil
+		}))
 		pom.MarkOffset(101, "")
 		om.Commit()
 
@@ -1131,10 +1133,11 @@ func TestOffsetManagerSetGeneration(t *testing.T) {
 		}()
 		<-gate.entered
 
-		genDone := make(chan none)
+		genDone := make(chan error, 1)
 		go func() {
-			om.setGeneration(7)
-			close(genDone)
+			genDone <- om.transitionGeneration(func() (int32, error) {
+				return 7, nil
+			})
 		}()
 		require.Never(t, func() bool {
 			select {
@@ -1147,7 +1150,7 @@ func TestOffsetManagerSetGeneration(t *testing.T) {
 
 		close(gate.release)
 		<-commitDone
-		<-genDone
+		require.NoError(t, <-genDone)
 
 		pom.MarkOffset(101, "")
 		om.Commit()
@@ -1155,6 +1158,49 @@ func TestOffsetManagerSetGeneration(t *testing.T) {
 		reqs := capture.requests()
 		require.Equal(t, int32(1), reqs[0].ConsumerGroupGeneration)
 		require.Equal(t, int32(7), reqs[len(reqs)-1].ConsumerGroupGeneration)
+	})
+
+	t.Run("holds commits until the next generation is established", func(t *testing.T) {
+		om, capture := newCapturingOffsetManager(t, false)
+
+		pom, err := om.ManagePartition("my_topic", 0)
+		require.NoError(t, err)
+		pom.MarkOffset(100, "")
+
+		started := make(chan none)
+		release := make(chan none)
+		transitionDone := make(chan error, 1)
+		go func() {
+			transitionDone <- om.transitionGeneration(func() (int32, error) {
+				close(started)
+				<-release
+				return 7, nil
+			})
+		}()
+		<-started
+
+		commitDone := make(chan none)
+		go func() {
+			om.Commit()
+			close(commitDone)
+		}()
+
+		require.Never(t, func() bool {
+			select {
+			case <-commitDone:
+				return true
+			default:
+				return false
+			}
+		}, 150*time.Millisecond, 20*time.Millisecond)
+
+		close(release)
+		require.NoError(t, <-transitionDone)
+		<-commitDone
+
+		reqs := capture.requests()
+		require.Len(t, reqs, 1)
+		require.Equal(t, int32(7), reqs[0].ConsumerGroupGeneration)
 	})
 }
 


### PR DESCRIPTION
Sarama can now take part in incremental cooperative rebalances as described in KIP-429. Instead of stopping every partition claim when membership changes, it stops only the claims the broker has revoked and continues consuming from the rest while it rejoins the group.

The consumer group session stays alive throughout that process. Offset commits and partition watches remain tied to the active generation.

KIP-429: https://cwiki.apache.org/confluence/display/KAFKA/KIP-429%3A%2BKafka%2BConsumer%2BIncremental%2BRebalance%2BProtocol

Fixes https://github.com/IBM/sarama/issues/1858