### PR TITLE
fix: make broker throttle waits interruptible on close

### DIFF
--- a/broker.go
+++ b/broker.go
@@ -61,10 +61,10 @@ type Broker struct {
 	kerberosAuthenticator               GSSAPIKerberosAuth
 	clientSessionReauthenticationTimeMs int64
 
+	throttleLock     sync.Mutex
 	throttleDeadline time.Time
 	throttleNotify   chan struct{}
 	throttleCanceled bool
-	throttleLock     sync.Mutex
 }
 
 // SASLMechanism specifies the SASL mechanism the client uses to authenticate with the broker
@@ -2018,16 +2018,9 @@ func (b *Broker) waitIfThrottled() error {
 		b.throttleLock.Unlock()
 
 		DebugLogger.Printf("broker/%d waiting for throttle timer\n", b.ID())
-		timer := time.NewTimer(remaining)
 		select {
-		case <-timer.C:
+		case <-time.After(remaining):
 		case <-notify:
-			if !timer.Stop() {
-				select {
-				case <-timer.C:
-				default:
-				}
-			}
 		}
 	}
 }

--- a/broker.go
+++ b/broker.go
@@ -61,8 +61,10 @@ type Broker struct {
 	kerberosAuthenticator               GSSAPIKerberosAuth
 	clientSessionReauthenticationTimeMs int64
 
-	throttleTimer     *time.Timer
-	throttleTimerLock sync.Mutex
+	throttleDeadline time.Time
+	throttleNotify   chan struct{}
+	throttleCanceled bool
+	throttleLock     sync.Mutex
 }
 
 // SASLMechanism specifies the SASL mechanism the client uses to authenticate with the broker
@@ -201,6 +203,7 @@ func (b *Broker) Open(conf *Config) error {
 	}
 
 	b.lock.Lock()
+	b.resetThrottle()
 
 	if b.metricRegistry == nil {
 		b.metricRegistry = newCleanupRegistry(conf.MetricRegistry)
@@ -372,6 +375,11 @@ func (b *Broker) TLSConnectionState() (state tls.ConnectionState, ok bool) {
 
 // Close closes the broker resources
 func (b *Broker) Close() error {
+	// Wake a send waiting on a broker-provided throttle before acquiring
+	// b.lock. The send owns b.lock while waiting, so acquiring it first would
+	// make Close wait for the complete throttle duration.
+	b.cancelThrottle()
+
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
@@ -394,6 +402,8 @@ func (b *Broker) maybeCloseLocked(err error) bool {
 // closeLocked closes the broker connection and resets state.
 // NOTE: caller must hold b.lock.
 func (b *Broker) closeLocked() error {
+	b.cancelThrottle()
+
 	if b.conn == nil {
 		return ErrNotConnected
 	}
@@ -1182,7 +1192,9 @@ func (b *Broker) sendInternal(rb protocolBody, promise *responsePromise) error {
 	}
 
 	// check and wait if throttled
-	b.waitIfThrottled()
+	if err := b.waitIfThrottled(); err != nil {
+		return err
+	}
 
 	requestTime := time.Now()
 	// Will be decremented in responseReceiver (except error or request with NoResponse)
@@ -1974,25 +1986,78 @@ func (b *Broker) handleThrottledResponse(resp protocolBody) {
 }
 
 func (b *Broker) setThrottle(throttleTime time.Duration) {
-	b.throttleTimerLock.Lock()
-	defer b.throttleTimerLock.Unlock()
-	if b.throttleTimer != nil {
-		// if there is an existing timer stop/clear it
-		if !b.throttleTimer.Stop() {
-			<-b.throttleTimer.C
-		}
+	b.throttleLock.Lock()
+	defer b.throttleLock.Unlock()
+
+	// Ignore responses racing with connection shutdown. A subsequent Open
+	// resets the throttle state for the new connection.
+	if b.throttleCanceled {
+		return
 	}
-	b.throttleTimer = time.NewTimer(throttleTime)
+
+	b.throttleDeadline = time.Now().Add(throttleTime)
+	b.notifyThrottleWaitersLocked()
 }
 
-func (b *Broker) waitIfThrottled() {
-	b.throttleTimerLock.Lock()
-	defer b.throttleTimerLock.Unlock()
-	if b.throttleTimer != nil {
+func (b *Broker) waitIfThrottled() error {
+	for {
+		b.throttleLock.Lock()
+		if b.throttleCanceled {
+			b.throttleLock.Unlock()
+			return ErrNotConnected
+		}
+		remaining := time.Until(b.throttleDeadline)
+		if remaining <= 0 {
+			b.throttleLock.Unlock()
+			return nil
+		}
+		if b.throttleNotify == nil {
+			b.throttleNotify = make(chan struct{})
+		}
+		notify := b.throttleNotify
+		b.throttleLock.Unlock()
+
 		DebugLogger.Printf("broker/%d waiting for throttle timer\n", b.ID())
-		<-b.throttleTimer.C
-		b.throttleTimer = nil
+		timer := time.NewTimer(remaining)
+		select {
+		case <-timer.C:
+		case <-notify:
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		}
 	}
+}
+
+// cancelThrottle interrupts active throttle waits for the current connection.
+// It must be called before Close attempts to acquire b.lock.
+func (b *Broker) cancelThrottle() {
+	b.throttleLock.Lock()
+	defer b.throttleLock.Unlock()
+
+	b.throttleCanceled = true
+	b.throttleDeadline = time.Time{}
+	b.notifyThrottleWaitersLocked()
+}
+
+// resetThrottle initializes the throttle state for a newly opened connection.
+func (b *Broker) resetThrottle() {
+	b.throttleLock.Lock()
+	defer b.throttleLock.Unlock()
+
+	b.throttleCanceled = false
+	b.throttleDeadline = time.Time{}
+	b.notifyThrottleWaitersLocked()
+}
+
+func (b *Broker) notifyThrottleWaitersLocked() {
+	if b.throttleNotify != nil {
+		close(b.throttleNotify)
+	}
+	b.throttleNotify = make(chan struct{})
 }
 
 func (b *Broker) updateThrottleMetric(throttleTime time.Duration) {

--- a/broker_test.go
+++ b/broker_test.go
@@ -242,6 +242,55 @@ func TestBrokerClose(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, connected)
 	})
+
+	t.Run("interrupts broker throttle waits", func(t *testing.T) {
+		mockBroker := NewMockBroker(t, 0)
+		defer mockBroker.Close()
+
+		broker := NewBroker(mockBroker.Addr())
+		conf := NewTestConfig()
+		conf.ApiVersionsRequest = false
+
+		require.NoError(t, broker.Open(conf))
+		connected, err := broker.Connected()
+		require.NoError(t, err)
+		require.True(t, connected)
+
+		broker.setThrottle(time.Hour)
+
+		request := ProduceRequest{RequiredAcks: NoResponse}
+		sendErrs := make(chan error, 1)
+		go func() {
+			sendErrs <- broker.AsyncProduce(&request, nil)
+		}()
+
+		require.Eventually(t, func() bool {
+			if broker.lock.TryLock() {
+				broker.lock.Unlock()
+				return false
+			}
+			return true
+		}, time.Second, time.Millisecond, "send did not enter the throttle wait")
+
+		closeErrs := make(chan error, 1)
+		go func() {
+			closeErrs <- broker.Close()
+		}()
+
+		select {
+		case err := <-sendErrs:
+			require.ErrorIs(t, err, ErrNotConnected)
+		case <-time.After(time.Second):
+			require.FailNow(t, "throttled send was not interrupted by Close")
+		}
+
+		select {
+		case err := <-closeErrs:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			require.FailNow(t, "Close blocked on the broker throttle wait")
+		}
+	})
 }
 
 // closeImmediatelyDialer is a test dialer that returns a net.Conn whose peer is
@@ -1656,7 +1705,7 @@ func Test_handleThrottledResponse(t *testing.T) {
 			broker.brokerThrottleTime = broker.registerHistogram("throttle-time-in-ms")
 			startTime := time.Now()
 			broker.handleThrottledResponse(tt.response)
-			broker.waitIfThrottled()
+			require.NoError(t, broker.waitIfThrottled())
 			if tt.expectDelay {
 				if time.Since(startTime) < throttleTime {
 					t.Fatal("expected throttling to cause delay")
@@ -1680,17 +1729,24 @@ func Test_handleThrottledResponse(t *testing.T) {
 		broker.handleThrottledResponse(&MetadataResponse{
 			ThrottleTimeMs: int32(throttleTimeMs),
 		})
-		firstTimer := broker.throttleTimer
+		waitErrs := make(chan error, 1)
+		go func() {
+			waitErrs <- broker.waitIfThrottled()
+		}()
+		time.Sleep(throttleTime / 4)
 		broker.handleThrottledResponse(&MetadataResponse{
 			ThrottleTimeMs: int32(throttleTimeMs * 2),
 		})
-		if firstTimer.Stop() {
-			t.Fatal("expected first timer to be stopped")
+		select {
+		case err := <-waitErrs:
+			t.Fatalf("throttle wait returned before the replacement timer: %v", err)
+		case <-time.After(throttleTime):
 		}
-		startTime := time.Now()
-		broker.waitIfThrottled()
-		if time.Since(startTime) < throttleTime*2 {
-			t.Fatal("expected throttling to use second delay")
+		select {
+		case err := <-waitErrs:
+			require.NoError(t, err)
+		case <-time.After(throttleTime * 2):
+			t.Fatal("throttle wait did not use the replacement delay")
 		}
 		if broker.brokerThrottleTime.Min() != int64(throttleTimeMs) {
 			t.Fatal("expected throttling to update metrics")

--- a/broker_test.go
+++ b/broker_test.go
@@ -1731,22 +1731,30 @@ func Test_handleThrottledResponse(t *testing.T) {
 		})
 		waitErrs := make(chan error, 1)
 		go func() {
+			broker.lock.Lock()
+			defer broker.lock.Unlock()
 			waitErrs <- broker.waitIfThrottled()
 		}()
-		time.Sleep(throttleTime / 4)
+		require.Eventually(t, func() bool {
+			if broker.lock.TryLock() {
+				broker.lock.Unlock()
+				return false
+			}
+			return true
+		}, time.Second, time.Millisecond, "waitIfThrottled did not start waiting")
+
+		startTime := time.Now()
 		broker.handleThrottledResponse(&MetadataResponse{
 			ThrottleTimeMs: int32(throttleTimeMs * 2),
 		})
 		select {
 		case err := <-waitErrs:
-			t.Fatalf("throttle wait returned before the replacement timer: %v", err)
-		case <-time.After(throttleTime):
-		}
-		select {
-		case err := <-waitErrs:
 			require.NoError(t, err)
-		case <-time.After(throttleTime * 2):
+		case <-time.After(5 * time.Second):
 			t.Fatal("throttle wait did not use the replacement delay")
+		}
+		if elapsed := time.Since(startTime); elapsed < throttleTime*2 {
+			t.Fatalf("expected replacement throttle delay of at least %v, got %v", throttleTime*2, elapsed)
 		}
 		if broker.brokerThrottleTime.Min() != int64(throttleTimeMs) {
 			t.Fatal("expected throttling to update metrics")


### PR DESCRIPTION
Fixes #3710.

## What changed

- Replace the shared throttle timer with a deadline and a broadcast notification channel.
- Let `Broker.Close` cancel an active throttle wait before it tries to acquire `Broker.lock`.
- Return `ErrNotConnected` from a send interrupted by broker shutdown so the existing producer retry and reconnect paths can proceed.
- Reset throttle state when a new broker connection is opened and ignore throttled responses racing with shutdown.
- Add regression coverage for closing a broker while a send is blocked by a long throttle, and preserve replacement-throttle behavior.

## Why

`sendInternal` waits for a broker-provided throttle while its caller owns `Broker.lock`. Before this change, a long throttle therefore prevented `Broker.Close` from acquiring that lock. If another in-flight request failed during the wait, broker close, reconnect, retries, and delivery-result propagation could all remain blocked for the complete throttle duration.

The throttle wait also held `throttleTimerLock` while receiving from the timer channel. Moving to a deadline plus per-wait timer avoids sharing a timer channel between `setThrottle` and active waiters, while the notification channel lets replacement throttles and shutdown wake all waiters safely.

This change does not cap or ignore broker quota throttles. A healthy active connection continues to honor the complete broker-provided duration.

## Validation

- `GOTOOLCHAIN=auto go test ./...`
- `GOTOOLCHAIN=auto go test ./... -run 'TestBrokerClose|Test_handleThrottledResponse' -count=20`
- `GOTOOLCHAIN=auto go test -race ./... -run 'TestBrokerClose|Test_handleThrottledResponse' -count=10`
- `GOTOOLCHAIN=auto go vet ./...`

A full `GOTOOLCHAIN=auto go test -race ./...` run reaches existing races involving the global `DebugLogger` in `TestClientBackgroundMetadataUpdater` and `TestPartitionConsumerComputeBackoff`. The same races reproduce on an unmodified `origin/main` worktree. No race was reported in the changed throttle and close tests.
