### PR TITLE
fix: correct JoinGroup v8 selection threshold to V3_2_0_0

### DIFF
--- a/consumer_group.go
+++ b/consumer_group.go
@@ -540,7 +540,7 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string, h
 	// send two JoinGroupRequests, once with the empty member id, and then again
 	// with the assigned id from the first response. This is handled via the
 	// ErrMemberIdRequired case.
-	if c.config.Version.IsAtLeast(V3_1_0_0) {
+	if c.config.Version.IsAtLeast(V3_2_0_0) {
 		req.Version = 8
 	} else if c.config.Version.IsAtLeast(V2_5_0_0) {
 		req.Version = 7

--- a/consumer_group.go
+++ b/consumer_group.go
@@ -364,6 +364,9 @@ func (c *consumerGroup) joinSync(ctx context.Context, topics []string, held *hel
 	switch join.Err {
 	case ErrNoError:
 		c.memberID = join.MemberId
+		// clear the session cause only once a join succeeds so the KIP-394
+		// second request repeats the reason
+		c.lastSessionCause = nil
 	case ErrUnknownMemberId, ErrIllegalGeneration:
 		// reset member ID and retry immediately
 		c.memberID = ""
@@ -530,33 +533,11 @@ func (c *consumerGroup) newSession(ctx context.Context, topics []string, handler
 }
 
 func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string, held *heldAssignment) (*JoinGroupResponse, error) {
-	req := &JoinGroupRequest{
-		GroupId:        c.groupID,
-		MemberId:       c.memberID,
-		SessionTimeout: int32(c.config.Consumer.Group.Session.Timeout / time.Millisecond),
-		ProtocolType:   "consumer",
-	}
-	// from JoinGroupRequest v4 onwards (due to KIP-394) the client will actually
-	// send two JoinGroupRequests, once with the empty member id, and then again
-	// with the assigned id from the first response. This is handled via the
-	// ErrMemberIdRequired case.
-	if c.config.Version.IsAtLeast(V3_2_0_0) {
-		req.Version = 8
-	} else if c.config.Version.IsAtLeast(V2_5_0_0) {
-		req.Version = 7
-	} else if c.config.Version.IsAtLeast(V2_4_0_0) {
-		req.Version = 6
-	} else if c.config.Version.IsAtLeast(V2_3_0_0) {
-		req.Version = 5
-	} else if c.config.Version.IsAtLeast(V2_2_0_0) {
-		req.Version = 4
-	} else if c.config.Version.IsAtLeast(V2_0_0_0) {
-		req.Version = 3
-	} else if c.config.Version.IsAtLeast(V0_11_0_0) {
-		req.Version = 2
-	} else if c.config.Version.IsAtLeast(V0_10_1_0) {
-		req.Version = 1
-	}
+	req := NewJoinGroupRequest(c.config.Version)
+	req.GroupId = c.groupID
+	req.MemberId = c.memberID
+	req.SessionTimeout = int32(c.config.Consumer.Group.Session.Timeout / time.Millisecond)
+	req.ProtocolType = "consumer"
 	if req.Version >= 1 {
 		req.RebalanceTimeout = int32(c.config.Consumer.Group.Rebalance.Timeout / time.Millisecond)
 	}
@@ -566,7 +547,6 @@ func (c *consumerGroup) joinGroupRequest(coordinator *Broker, topics []string, h
 	if req.Version >= 8 && c.lastSessionCause != nil {
 		reason := sessionCauseToReason(c.lastSessionCause)
 		req.Reason = &reason
-		c.lastSessionCause = nil
 	}
 
 	var owned map[string][]int32

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -256,49 +256,52 @@ func TestConsumerShouldNotRetrySessionIfContextCancelled(t *testing.T) {
 	assert.Equal(t, context.Canceled, err)
 }
 
-func TestConsumerGroupJoinSync(t *testing.T) {
-	setup := func(t *testing.T, joinResponse, syncResponse MockResponse) (*consumerGroup, *MockBroker) {
-		t.Helper()
+// newJoinSyncConsumerGroup starts a mock broker that answers the join/sync
+// flow with the given responses and returns the group wired to it.
+func newJoinSyncConsumerGroup(t *testing.T, version KafkaVersion, joinResponse, syncResponse MockResponse) (*consumerGroup, *MockBroker) {
+	t.Helper()
 
-		config := NewTestConfig()
-		config.ClientID = t.Name()
-		config.Version = V3_2_0_0
-		config.Consumer.Group.Rebalance.Retry.Backoff = 0
+	config := NewTestConfig()
+	config.ClientID = t.Name()
+	config.Version = version
+	config.Consumer.Group.Rebalance.Retry.Backoff = 0
 
-		broker := NewMockBroker(t, 0)
-		t.Cleanup(broker.Close)
-		broker.SetHandlerByMap(map[string]MockResponse{
-			"MetadataRequest": NewMockMetadataResponse(t).
-				SetBroker(broker.Addr(), broker.BrokerID()),
-			"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).
-				SetCoordinator(CoordinatorGroup, "my-group", broker),
-			"JoinGroupRequest":  joinResponse,
-			"SyncGroupRequest":  syncResponse,
-			"LeaveGroupRequest": NewMockLeaveGroupResponse(t),
-		})
+	broker := NewMockBroker(t, 0)
+	t.Cleanup(broker.Close)
+	broker.SetHandlerByMap(map[string]MockResponse{
+		"MetadataRequest": NewMockMetadataResponse(t).
+			SetBroker(broker.Addr(), broker.BrokerID()),
+		"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).
+			SetCoordinator(CoordinatorGroup, "my-group", broker),
+		"JoinGroupRequest":  joinResponse,
+		"SyncGroupRequest":  syncResponse,
+		"LeaveGroupRequest": NewMockLeaveGroupResponse(t),
+	})
 
-		group, err := NewConsumerGroup([]string{broker.Addr()}, "my-group", config)
-		assert.NoError(t, err)
-		t.Cleanup(func() {
-			assert.NoError(t, group.Close())
-		})
+	group, err := NewConsumerGroup([]string{broker.Addr()}, "my-group", config)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, group.Close())
+	})
 
-		return group.(*consumerGroup), broker
-	}
+	return group.(*consumerGroup), broker
+}
 
-	joinRequests := func(broker *MockBroker) []*JoinGroupRequest {
-		var requests []*JoinGroupRequest
-		for _, exchange := range broker.History() {
-			if request, ok := exchange.Request.(*JoinGroupRequest); ok {
-				requests = append(requests, request)
-			}
+// joinGroupRequests filters the broker history down to the JoinGroup requests.
+func joinGroupRequests(broker *MockBroker) []*JoinGroupRequest {
+	var requests []*JoinGroupRequest
+	for _, exchange := range broker.History() {
+		if request, ok := exchange.Request.(*JoinGroupRequest); ok {
+			requests = append(requests, request)
 		}
-		return requests
 	}
+	return requests
+}
 
+func TestConsumerGroupJoinSync(t *testing.T) {
 	t.Run("returns the negotiated assignment and reports retained ownership", func(t *testing.T) {
-		c, broker := setup(
-			t,
+		c, broker := newJoinSyncConsumerGroup(
+			t, V3_2_0_0,
 			NewMockJoinGroupResponse(t).
 				SetGroupProtocol(RangeBalanceStrategyName).
 				SetGenerationId(7).
@@ -323,7 +326,7 @@ func TestConsumerGroupJoinSync(t *testing.T) {
 		assert.Equal(t, map[string][]int32{"my-topic": {0, 2}}, result.claims)
 		assert.False(t, result.isLeader)
 
-		requests := joinRequests(broker)
+		requests := joinGroupRequests(broker)
 		assert.Len(t, requests, 1)
 		assert.Len(t, requests[0].OrderedGroupProtocols, 1)
 		metadata := &ConsumerGroupMemberMetadata{}
@@ -335,8 +338,8 @@ func TestConsumerGroupJoinSync(t *testing.T) {
 	})
 
 	t.Run("retries unknown membership when no assignment is retained", func(t *testing.T) {
-		c, broker := setup(
-			t,
+		c, broker := newJoinSyncConsumerGroup(
+			t, V3_2_0_0,
 			NewMockSequence(
 				NewMockJoinGroupResponse(t).SetError(ErrUnknownMemberId),
 				NewMockJoinGroupResponse(t).
@@ -350,12 +353,12 @@ func TestConsumerGroupJoinSync(t *testing.T) {
 		result, err := c.joinSync(t.Context(), []string{"my-topic"}, nil, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, "member-2", result.memberID)
-		assert.Len(t, joinRequests(broker), 2)
+		assert.Len(t, joinGroupRequests(broker), 2)
 	})
 
 	t.Run("returns unknown membership when retained ownership is lost", func(t *testing.T) {
-		c, broker := setup(
-			t,
+		c, broker := newJoinSyncConsumerGroup(
+			t, V3_2_0_0,
 			NewMockJoinGroupResponse(t).SetError(ErrUnknownMemberId),
 			NewMockSyncGroupResponse(t),
 		)
@@ -367,12 +370,12 @@ func TestConsumerGroupJoinSync(t *testing.T) {
 		}, 1)
 		assert.Nil(t, result)
 		assert.ErrorIs(t, err, ErrUnknownMemberId)
-		assert.Len(t, joinRequests(broker), 1)
+		assert.Len(t, joinGroupRequests(broker), 1)
 	})
 
 	t.Run("returns illegal generation when sync invalidates retained ownership", func(t *testing.T) {
-		c, broker := setup(
-			t,
+		c, broker := newJoinSyncConsumerGroup(
+			t, V3_2_0_0,
 			NewMockJoinGroupResponse(t).
 				SetGroupProtocol(RangeBalanceStrategyName).
 				SetMemberId("member-3"),
@@ -386,17 +389,30 @@ func TestConsumerGroupJoinSync(t *testing.T) {
 		}, 1)
 		assert.Nil(t, result)
 		assert.ErrorIs(t, err, ErrIllegalGeneration)
-		assert.Len(t, joinRequests(broker), 1)
+		assert.Len(t, joinGroupRequests(broker), 1)
 	})
 }
 
 // TestJoinGroupVersionSelection checks the JoinGroup version picked for each
-// Config.Version. 3.1.x should get v7, not v8 (v8 needs 3.2.0, see #3585).
+// Config.Version. 3.1.x should get v7, not v8 (v8 needs 3.2.0, #3585).
 func TestJoinGroupVersionSelection(t *testing.T) {
+	t.Run("every supported config version can send the version it selects", func(t *testing.T) {
+		for _, kv := range SupportedVersions {
+			if !kv.IsAtLeast(V0_10_2_0) {
+				continue // consumer groups require 0.10.2
+			}
+			req := NewJoinGroupRequest(kv)
+			assert.Truef(t, req.isValidVersion(), "JoinGroup v%d selected for %s is not a valid version", req.Version, kv)
+			assert.Truef(t, kv.IsAtLeast(req.requiredVersion()),
+				"JoinGroup v%d selected for %s requires %s", req.Version, kv, req.requiredVersion())
+		}
+	})
+
 	versions := []struct {
 		version     KafkaVersion
 		wantVersion int16
 	}{
+		{V2_5_0_0, 7},
 		{V3_1_0_0, 7},
 		{V3_1_1_0, 7},
 		{V3_1_2_0, 7},
@@ -405,43 +421,54 @@ func TestJoinGroupVersionSelection(t *testing.T) {
 
 	for _, tc := range versions {
 		t.Run(tc.version.String(), func(t *testing.T) {
-			config := NewTestConfig()
-			config.ClientID = t.Name()
-			config.Version = tc.version
-			config.Consumer.Group.Rebalance.Retry.Backoff = 0
+			// answer the initial join with ErrMemberIdRequired so both
+			// KIP-394 requests are captured
+			c, broker := newJoinSyncConsumerGroup(
+				t, tc.version,
+				NewMockSequence(
+					NewMockJoinGroupResponse(t).SetError(ErrMemberIdRequired).SetMemberId("member-1"),
+					NewMockJoinGroupResponse(t).
+						SetGroupProtocol(RangeBalanceStrategyName).
+						SetMemberId("member-1"),
+				),
+				NewMockSyncGroupResponse(t),
+			)
 
-			broker := NewMockBroker(t, 0)
-			t.Cleanup(broker.Close)
-			broker.SetHandlerByMap(map[string]MockResponse{
-				"MetadataRequest": NewMockMetadataResponse(t).
-					SetBroker(broker.Addr(), broker.BrokerID()),
-				"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).
-					SetCoordinator(CoordinatorGroup, "my-group", broker),
-				"JoinGroupRequest": NewMockJoinGroupResponse(t).
-					SetGroupProtocol(RangeBalanceStrategyName).
-					SetMemberId("member-1"),
-				"SyncGroupRequest":  NewMockSyncGroupResponse(t),
-				"LeaveGroupRequest": NewMockLeaveGroupResponse(t),
-			})
-
-			group, err := NewConsumerGroup([]string{broker.Addr()}, "my-group", config)
-			assert.NoError(t, err)
-			c := group.(*consumerGroup)
-			t.Cleanup(func() { assert.NoError(t, group.Close()) })
-
-			_, err = c.joinSync(t.Context(), []string{"my-topic"}, nil, 0)
+			_, err := c.joinSync(t.Context(), []string{"my-topic"}, nil, 0)
 			assert.NoError(t, err)
 
-			var requests []*JoinGroupRequest
-			for _, exchange := range broker.History() {
-				if request, ok := exchange.Request.(*JoinGroupRequest); ok {
-					requests = append(requests, request)
-				}
+			requests := joinGroupRequests(broker)
+			assert.Len(t, requests, 2)
+			for _, request := range requests {
+				assert.Equal(t, tc.wantVersion, request.Version)
 			}
-			assert.Len(t, requests, 1)
-			assert.Equal(t, tc.wantVersion, requests[0].Version)
 		})
 	}
+
+	t.Run("the rejoin for a member id repeats the reason", func(t *testing.T) {
+		c, broker := newJoinSyncConsumerGroup(
+			t, V3_2_0_0,
+			NewMockSequence(
+				NewMockJoinGroupResponse(t).SetError(ErrMemberIdRequired).SetMemberId("member-1"),
+				NewMockJoinGroupResponse(t).
+					SetGroupProtocol(RangeBalanceStrategyName).
+					SetMemberId("member-1"),
+			),
+			NewMockSyncGroupResponse(t),
+		)
+		c.lastSessionCause = ErrRebalanceInProgress
+
+		_, err := c.joinSync(t.Context(), []string{"my-topic"}, nil, 0)
+		assert.NoError(t, err)
+
+		requests := joinGroupRequests(broker)
+		assert.Len(t, requests, 2)
+		for _, request := range requests {
+			assert.NotNil(t, request.Reason)
+			assert.Equal(t, sessionCauseToReason(ErrRebalanceInProgress), *request.Reason)
+		}
+		assert.NoError(t, c.lastSessionCause)
+	})
 }
 
 // strategyWithSubscriptionUserData wraps a BalanceStrategy and adds a

--- a/consumer_group_test.go
+++ b/consumer_group_test.go
@@ -390,6 +390,60 @@ func TestConsumerGroupJoinSync(t *testing.T) {
 	})
 }
 
+// TestJoinGroupVersionSelection checks the JoinGroup version picked for each
+// Config.Version. 3.1.x should get v7, not v8 (v8 needs 3.2.0, see #3585).
+func TestJoinGroupVersionSelection(t *testing.T) {
+	versions := []struct {
+		version     KafkaVersion
+		wantVersion int16
+	}{
+		{V3_1_0_0, 7},
+		{V3_1_1_0, 7},
+		{V3_1_2_0, 7},
+		{V3_2_0_0, 8},
+	}
+
+	for _, tc := range versions {
+		t.Run(tc.version.String(), func(t *testing.T) {
+			config := NewTestConfig()
+			config.ClientID = t.Name()
+			config.Version = tc.version
+			config.Consumer.Group.Rebalance.Retry.Backoff = 0
+
+			broker := NewMockBroker(t, 0)
+			t.Cleanup(broker.Close)
+			broker.SetHandlerByMap(map[string]MockResponse{
+				"MetadataRequest": NewMockMetadataResponse(t).
+					SetBroker(broker.Addr(), broker.BrokerID()),
+				"FindCoordinatorRequest": NewMockFindCoordinatorResponse(t).
+					SetCoordinator(CoordinatorGroup, "my-group", broker),
+				"JoinGroupRequest": NewMockJoinGroupResponse(t).
+					SetGroupProtocol(RangeBalanceStrategyName).
+					SetMemberId("member-1"),
+				"SyncGroupRequest":  NewMockSyncGroupResponse(t),
+				"LeaveGroupRequest": NewMockLeaveGroupResponse(t),
+			})
+
+			group, err := NewConsumerGroup([]string{broker.Addr()}, "my-group", config)
+			assert.NoError(t, err)
+			c := group.(*consumerGroup)
+			t.Cleanup(func() { assert.NoError(t, group.Close()) })
+
+			_, err = c.joinSync(t.Context(), []string{"my-topic"}, nil, 0)
+			assert.NoError(t, err)
+
+			var requests []*JoinGroupRequest
+			for _, exchange := range broker.History() {
+				if request, ok := exchange.Request.(*JoinGroupRequest); ok {
+					requests = append(requests, request)
+				}
+			}
+			assert.Len(t, requests, 1)
+			assert.Equal(t, tc.wantVersion, requests[0].Version)
+		})
+	}
+}
+
 // strategyWithSubscriptionUserData wraps a BalanceStrategy and adds a
 // SubscriptionUserDataBalanceStrategy implementation that returns the
 // configured data/error. It also records the topics it was invoked with so

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -17,6 +17,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// noopConsumerGroupHandler just lets the client join the group; it doesn't
+// need to handle any claims.
+type noopConsumerGroupHandler struct{}
+
+func (noopConsumerGroupHandler) Setup(ConsumerGroupSession) error   { return nil }
+func (noopConsumerGroupHandler) Cleanup(ConsumerGroupSession) error { return nil }
+func (noopConsumerGroupHandler) ConsumeClaim(ConsumerGroupSession, ConsumerGroupClaim) error {
+	return nil
+}
+
+// TestFuncJoinGroupVersionSelection checks the JoinGroup version picked for
+// each Config.Version against a real broker. 3.1.x wrongly picks v8, which
+// needs 3.2.0 (see #3585).
+func TestFuncJoinGroupVersionSelection(t *testing.T) {
+	checkKafkaVersion(t, "3.2.0")
+	setupFunctionalTest(t)
+	defer teardownFunctionalTest(t)
+
+	// A consumer group join should succeed for any of these versions - they're
+	// all real Kafka releases the test broker supports. Before the fix, 3.1.0,
+	// 3.1.1 and 3.1.2 wrongly send a JoinGroup v8 request and fail.
+	versions := []KafkaVersion{V3_1_0_0, V3_1_1_0, V3_1_2_0, V3_2_0_0}
+
+	for _, version := range versions {
+		t.Run(version.String(), func(t *testing.T) {
+			config := NewConfig()
+			config.Version = version
+			config.ClientID = t.Name()
+			config.Consumer.Group.Rebalance.Timeout = 6 * time.Second
+			config.Consumer.Group.Session.Timeout = 6 * time.Second
+
+			group, err := NewConsumerGroup(FunctionalTestEnv.KafkaBrokerAddrs, testFuncConsumerGroupID(t), config)
+			require.NoError(t, err)
+			defer func() { _ = group.Close() }()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+
+			err = group.Consume(ctx, []string{"test.4"}, noopConsumerGroupHandler{})
+			t.Logf("Config.Version=%s: join err=%v", version, err)
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func TestFuncConsumerGroupPartitioning(t *testing.T) {
 	t.Parallel()
 	checkKafkaVersion(t, "0.10.2")

--- a/functional_consumer_group_test.go
+++ b/functional_consumer_group_test.go
@@ -27,26 +27,24 @@ func (noopConsumerGroupHandler) ConsumeClaim(ConsumerGroupSession, ConsumerGroup
 	return nil
 }
 
-// TestFuncJoinGroupVersionSelection checks the JoinGroup version picked for
-// each Config.Version against a real broker. 3.1.x wrongly picks v8, which
-// needs 3.2.0 (see #3585).
+// TestFuncJoinGroupVersionSelection joins a real broker with Config.Version
+// values either side of the v7/v8 JoinGroup boundary. A 3.1.x config must
+// select v7: v8 needs a 3.2.0 broker, and the client refuses to send it to
+// anything older (#3585).
 func TestFuncJoinGroupVersionSelection(t *testing.T) {
+	t.Parallel()
+	// a >= 3.2.0 broker is required: against older brokers restrictApiVersion
+	// clamps v8 to v7 and would mask a wrong version selection
 	checkKafkaVersion(t, "3.2.0")
 	setupFunctionalTest(t)
 	defer teardownFunctionalTest(t)
 
-	// A consumer group join should succeed for any of these versions - they're
-	// all real Kafka releases the test broker supports. Before the fix, 3.1.0,
-	// 3.1.1 and 3.1.2 wrongly send a JoinGroup v8 request and fail.
 	versions := []KafkaVersion{V3_1_0_0, V3_1_1_0, V3_1_2_0, V3_2_0_0}
 
 	for _, version := range versions {
 		t.Run(version.String(), func(t *testing.T) {
-			config := NewConfig()
+			config := defaultConfig(t.Name())
 			config.Version = version
-			config.ClientID = t.Name()
-			config.Consumer.Group.Rebalance.Timeout = 6 * time.Second
-			config.Consumer.Group.Session.Timeout = 6 * time.Second
 
 			group, err := NewConsumerGroup(FunctionalTestEnv.KafkaBrokerAddrs, testFuncConsumerGroupID(t), config)
 			require.NoError(t, err)
@@ -55,9 +53,7 @@ func TestFuncJoinGroupVersionSelection(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 			defer cancel()
 
-			err = group.Consume(ctx, []string{"test.4"}, noopConsumerGroupHandler{})
-			t.Logf("Config.Version=%s: join err=%v", version, err)
-			assert.NoError(t, err)
+			assert.NoError(t, group.Consume(ctx, []string{"test.4"}, noopConsumerGroupHandler{}))
 		})
 	}
 }

--- a/join_group_request.go
+++ b/join_group_request.go
@@ -65,6 +65,38 @@ func (r *JoinGroupRequest) setVersion(v int16) {
 	r.Version = v
 }
 
+func NewJoinGroupRequest(version KafkaVersion) *JoinGroupRequest {
+	request := &JoinGroupRequest{}
+	if version.IsAtLeast(V3_2_0_0) {
+		// Version 8 adds the Reason for the (re-)join (KIP-800).
+		request.Version = 8
+	} else if version.IsAtLeast(V2_5_0_0) {
+		// Version 7 makes the response ProtocolName nullable (KIP-559).
+		request.Version = 7
+	} else if version.IsAtLeast(V2_4_0_0) {
+		// Version 6 is the first flexible version.
+		request.Version = 6
+	} else if version.IsAtLeast(V2_3_0_0) {
+		// Version 5 adds the GroupInstanceId for static membership (KIP-345).
+		request.Version = 5
+	} else if version.IsAtLeast(V2_2_0_0) {
+		// From version 4 onwards a join with an empty member id is answered
+		// with ErrMemberIdRequired and an assigned id, and the client sends a
+		// second request with that id to actually join (KIP-394).
+		request.Version = 4
+	} else if version.IsAtLeast(V2_0_0_0) {
+		// Version 3 is the same as version 2.
+		request.Version = 3
+	} else if version.IsAtLeast(V0_11_0_0) {
+		// Version 2 is the same as version 1.
+		request.Version = 2
+	} else if version.IsAtLeast(V0_10_1_0) {
+		// Version 1 adds the RebalanceTimeout.
+		request.Version = 1
+	}
+	return request
+}
+
 func (r *JoinGroupRequest) encode(pe packetEncoder) error {
 	if err := pe.putString(r.GroupId); err != nil {
 		return err

--- a/offset_manager_test.go
+++ b/offset_manager_test.go
@@ -1016,7 +1016,7 @@ func TestOffsetManagerRemovePartitions(t *testing.T) {
 				committed = append(committed, p)
 			}
 		}
-		require.ElementsMatch(t, []int32{2,3}, committed)
+		require.ElementsMatch(t, []int32{2, 3}, committed)
 
 		require.Nil(t, om.findPOM("my_topic", 2))
 		require.Nil(t, om.findPOM("my_topic", 3))


### PR DESCRIPTION
Fixes #3721.

#3585 fixed requiredVersion() for JoinGroupRequest/Response v8: it now says V3_2_0_0, not V3_1_0_0. But the actual selection switch in joinGroupRequest() still checked V3_1_0_0. So Config.Version 3.1.0, 3.1.1 and 3.1.2 sent a v8 request paired with v1 subscription metadata (subscriptionVersion() is already gated at V3_2_0_0). Real brokers reject that with UNSUPPORTED_VERSION.

v8 adds the Reason field from KIP-800, shipped in Kafka 3.2.0. #3585 had the right version, it just didn't fix this switch too.

The first two commits reproduce and fix the issue:
- TestJoinGroupVersionSelection (mock broker) asserts the JoinGroup wire version sent for 3.1.0, 3.1.1, 3.1.2 and 3.2.0 - it fails before the fix because 3.1.x sends v8 instead of v7.
- TestFuncJoinGroupVersionSelection (functional, real broker) joins a consumer group for the same versions - it fails before the fix because the broker actually rejects the v8 request.
- The one-line fix; both tests then pass on all four versions.

A follow-up commit then reworks version selection so this kind of drift can't recur, and fixes an adjacent bug in the block it touches:
- JoinGroup version selection moves into a NewJoinGroupRequest(KafkaVersion) constructor in join_group_request.go, matching NewMetadataRequest and friends. A new subtest walks SupportedVersions and asserts the selected version satisfies requiredVersion(), so a future version bump that only updates one side fails CI.
- The KIP-800 Reason was consumed when the first JoinGroup request was built, so the second KIP-394 request (the one that actually joins) carried no reason. lastSessionCause is kept until a join succeeds, and the version-selection test exercises the two-request flow and asserts both requests repeat the reason.
- Test cleanup: the mock join/sync harness is shared with TestConsumerGroupJoinSync, and the functional test uses the shared defaultConfig() and runs in parallel.
