### PR TITLE
chore(ci): update linters for Go 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
   # Use the Go toolchain installed by setup-go
   GOTOOLCHAIN: local
   # renovate: datasource=github-releases depName=golangci/golangci-lint
-  GOLANGCI_LINT_VERSION: v2.12.2
+  GOLANGCI_LINT_VERSION: v2.13.1
   # renovate: datasource=github-releases depName=dominikh/go-tools
   STATICCHECK_VERSION: 2026.2.1
   # renovate: datasource=github-releases depName=mfridman/tparse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   # renovate: datasource=github-releases depName=golangci/golangci-lint
   GOLANGCI_LINT_VERSION: v2.12.2
   # renovate: datasource=github-releases depName=dominikh/go-tools
-  STATICCHECK_VERSION: 2026.1
+  STATICCHECK_VERSION: 2026.2.1
   # renovate: datasource=github-releases depName=mfridman/tparse
   TPARSE_VERSION: v0.18.0
 


### PR DESCRIPTION
The "Linting with Go stable" job broke when stable moved to Go 1.27:

- staticcheck 2026.1 cannot read Go 1.27 export data (`export data version 4 is greater than maximum supported version 2`); the [2026.2 release](https://github.com/dominikh/go-tools/releases/tag/2026.2) adds Go 1.27 support.
- golangci-lint v2.12.2 is built with go1.26 and panics with `file requires newer Go version go1.27 (application built with go1.26)`; v2.13.1 is built with go1.27.

Verified locally that staticcheck 2026.2.1 and golangci-lint v2.13.1 both run clean over the repo with the functional build tag.