### PR TITLE
fix(producer): drain pending responses immediately once channel closes

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -1072,7 +1072,15 @@ func (p *asyncProducer) newBrokerProducer(broker *Broker) *brokerProducer {
 			select {
 			case res, ok := <-pending:
 				if !ok {
-					continue
+					// pending is closed and never blocks again, so select could keep
+					// racing this case against responses<- instead of progressing.
+					// Once closed, just drain buf directly in order.
+					for buf.Length() > 0 {
+						responses <- buf.Peek()
+						buf.Remove()
+					}
+					close(responses)
+					return
 				}
 				buf.Add(res)
 				continue


### PR DESCRIPTION
In newBrokerProducer's response-ordering goroutine, once `pending` is closed, <-pending never blocks again (a closed channel is always ready). If `buf` still has buffered responses at that point, the select can keep racing the closed-channel case against `responses <- headRes` instead of making forward progress, since Go picks uniformly among ready cases.

Once closure is observed, there's nothing left to wait for, so drain the remaining buffer directly into `responses` in order instead of looping through select.