### PR TITLE
fix: prevent race in asyncProducer retryHandler

### DIFF
--- a/async_producer.go
+++ b/async_producer.go
@@ -1580,6 +1580,15 @@ func (bp *brokerProducer) handleError(sent *produceSet, err error) {
 	}
 }
 
+// Message in the retry buffer, paired with the size it contributed to currentByteSize.
+// The size is measured on insert: measuring it again on removal would read a message we have already sent to p.input,
+// which the dispatcher goroutine owns and could modifiy by then:
+// Potential data race through custom headerInterceptor.
+type retryBufEntry struct {
+	msg  *ProducerMessage
+	size int64
+}
+
 // singleton
 // effectively a "bridge" between the flushers and the dispatcher in order to avoid deadlock
 // based on https://godoc.org/github.com/eapache/channels#InfiniteChannel
@@ -1601,11 +1610,7 @@ func (p *asyncProducer) retryHandler() {
 
 	var currentByteSize int64
 	var msg *ProducerMessage
-	var buf queue.Queue[*ProducerMessage]
-	// Each message's size, remembered on insert. Measuring it on removal
-	// instead would read a message we have already sent to p.input, which the
-	// dispatcher goroutine owns and modifies by then (data race).
-	var sizes queue.Queue[int64]
+	var buf queue.Queue[retryBufEntry]
 
 	for {
 		if buf.Length() == 0 {
@@ -1613,9 +1618,8 @@ func (p *asyncProducer) retryHandler() {
 		} else {
 			select {
 			case msg = <-p.retries:
-			case p.input <- buf.Peek():
-				buf.Remove()
-				currentByteSize -= sizes.Remove()
+			case p.input <- buf.Peek().msg:
+				currentByteSize -= buf.Remove().size
 				continue
 			}
 		}
@@ -1625,23 +1629,20 @@ func (p *asyncProducer) retryHandler() {
 		}
 
 		size := int64(msg.ByteSize(version))
-		buf.Add(msg)
-		sizes.Add(size)
+		buf.Add(retryBufEntry{msg: msg, size: size})
 		currentByteSize += size
 
 		if (maxBufferLength <= 0 || buf.Length() < maxBufferLength) && (maxBufferBytes <= 0 || currentByteSize < maxBufferBytes) {
 			continue
 		}
 
-		msgToHandle := buf.Peek()
+		msgToHandle := buf.Peek().msg
 		if msgToHandle.flags == 0 {
 			select {
 			case p.input <- msgToHandle:
-				buf.Remove()
-				currentByteSize -= sizes.Remove()
+				currentByteSize -= buf.Remove().size
 			default:
-				buf.Remove()
-				currentByteSize -= sizes.Remove()
+				currentByteSize -= buf.Remove().size
 				p.returnError(msgToHandle, ErrProducerRetryBufferOverflow)
 			}
 		}

--- a/async_producer.go
+++ b/async_producer.go
@@ -1602,6 +1602,10 @@ func (p *asyncProducer) retryHandler() {
 	var currentByteSize int64
 	var msg *ProducerMessage
 	var buf queue.Queue[*ProducerMessage]
+	// Each message's size, remembered on insert. Measuring it on removal
+	// instead would read a message we have already sent to p.input, which the
+	// dispatcher goroutine owns and modifies by then (data race).
+	var sizes queue.Queue[int64]
 
 	for {
 		if buf.Length() == 0 {
@@ -1610,8 +1614,8 @@ func (p *asyncProducer) retryHandler() {
 			select {
 			case msg = <-p.retries:
 			case p.input <- buf.Peek():
-				msgToRemove := buf.Remove()
-				currentByteSize -= int64(msgToRemove.ByteSize(version))
+				buf.Remove()
+				currentByteSize -= sizes.Remove()
 				continue
 			}
 		}
@@ -1620,8 +1624,10 @@ func (p *asyncProducer) retryHandler() {
 			return
 		}
 
+		size := int64(msg.ByteSize(version))
 		buf.Add(msg)
-		currentByteSize += int64(msg.ByteSize(version))
+		sizes.Add(size)
+		currentByteSize += size
 
 		if (maxBufferLength <= 0 || buf.Length() < maxBufferLength) && (maxBufferBytes <= 0 || currentByteSize < maxBufferBytes) {
 			continue
@@ -1632,10 +1638,10 @@ func (p *asyncProducer) retryHandler() {
 			select {
 			case p.input <- msgToHandle:
 				buf.Remove()
-				currentByteSize -= int64(msgToHandle.ByteSize(version))
+				currentByteSize -= sizes.Remove()
 			default:
 				buf.Remove()
-				currentByteSize -= int64(msgToHandle.ByteSize(version))
+				currentByteSize -= sizes.Remove()
 				p.returnError(msgToHandle, ErrProducerRetryBufferOverflow)
 			}
 		}

--- a/async_producer_race_test.go
+++ b/async_producer_race_test.go
@@ -1,0 +1,35 @@
+package sarama
+
+import "testing"
+
+// retryHandler reads a message (via ByteSize) after publishing it to p.input,
+// by which point the receiving goroutine owns and mutates it.
+func TestRetryHandlerHeadersRace(t *testing.T) {
+	conf := NewTestConfig()
+	conf.Version = V0_11_0_0 // -> version 2, so ByteSize reads msg.Headers
+
+	p := &asyncProducer{
+		conf:    conf,
+		retries: make(chan *ProducerMessage),
+		input:   make(chan *ProducerMessage),
+	}
+
+	done := make(chan struct{})
+	go func() { defer close(done); p.retryHandler() }()
+
+	// Stands in for dispatcher(), which applies Producer.Interceptors to every
+	// message it receives from p.input, retries included. A tracing interceptor
+	// appends to msg.Headers.
+	go func() {
+		for msg := range p.input {
+			msg.Headers = append(msg.Headers, RecordHeader{Key: []byte("traceparent")})
+		}
+	}()
+
+	for range 10 {
+		p.retries <- &ProducerMessage{Topic: "t", Value: StringEncoder("x")}
+	}
+	close(p.retries)
+	<-done
+	close(p.input)
+}


### PR DESCRIPTION
There is a potential race in the `asyncProducer` `retryHandler` which is occasionally causing `nil` pointer dereferences on our side:

```
WARNING: DATA RACE
Write at 0x00c0001cd4d0 by goroutine 10:
  github.com/IBM/sarama.TestRetryHandlerHeadersRace.func2()
      /Users/dbl/src/github.com/IBM/sarama/async_producer_race_test.go:25 +0x18c

Previous read at 0x00c0001cd4d0 by goroutine 9:
  github.com/IBM/sarama.(*ProducerMessage).ByteSize()
      /Users/dbl/src/github.com/IBM/sarama/async_producer.go:400 +0x40
  github.com/IBM/sarama.(*asyncProducer).retryHandler()
      /Users/dbl/src/github.com/IBM/sarama/async_producer.go:1614 +0x488
  github.com/IBM/sarama.TestRetryHandlerHeadersRace.func1()
      /Users/dbl/src/github.com/IBM/sarama/async_producer_race_test.go:18 +0x68
```

`retryHandler` publishes a message to `p.input` and then reads it again to update its `ByteSize`:

```go
case p.input <- buf.Peek():
    msgToRemove := buf.Remove()
    currentByteSize -= int64(msgToRemove.ByteSize(version))
```

Once that send completes the message belongs to `dispatcher`, which can write to `Headers` through a `headerInterceptor`.

Only reachable with `Version >= V0_11_0_0` (`version == 2`): below that `ByteSize` skips the `Headers` loop entirely.

**I've added a test to reproduce:**
```
go test -race -run TestRetryHandlerHeadersRace
```

**Output without the fix:**
```
[..]
--- FAIL: TestRetryHandlerHeadersRace (0.00s)
    testing.go:1617: race detected during execution of test
FAIL
exit status 1
FAIL	github.com/IBM/sarama	0.072s
```

**Output with the fix applied:**
```
PASS
ok  	github.com/IBM/sarama	1.082s
```