### PR TITLE
fix(test): capture logs without replacing the global Logger

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"runtime"
 	"sync"
@@ -1366,9 +1365,7 @@ func TestClientBackgroundMetadataUpdater(t *testing.T) {
 		defer seedBroker.Close()
 
 		w := &matchWriter{substr: []byte("no specific topics to update metadata")}
-		orig := Logger
-		Logger = log.New(w, "", 0)
-		t.Cleanup(func() { Logger = orig })
+		redirectLogger(t, w)
 
 		conf := NewTestConfig()
 		conf.Metadata.Full = false

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -1860,9 +1860,7 @@ func TestPartitionConsumerComputeBackoff(t *testing.T) {
 	t.Run("emits stuck warning at threshold and each multiple", func(t *testing.T) {
 		child := newChild()
 		var buf bytes.Buffer
-		orig := Logger
-		Logger = log.New(&buf, "", 0)
-		t.Cleanup(func() { Logger = orig })
+		redirectLogger(t, &buf)
 
 		expectStuckWarning := func(want string) {
 			t.Helper()

--- a/sarama_test.go
+++ b/sarama_test.go
@@ -4,6 +4,7 @@ package sarama
 
 import (
 	"flag"
+	"io"
 	"log"
 	"os"
 	"testing"
@@ -15,4 +16,21 @@ func TestMain(m *testing.M) {
 		Logger = log.New(os.Stderr, "[DEBUG] ", log.Lmicroseconds|log.Ltime)
 	}
 	os.Exit(m.Run())
+}
+
+// redirectLogger sends Logger output to w for the rest of the test.
+// It prefers (*log.Logger).SetOutput so leftover goroutines from other tests
+// (for example safeAsyncClose) do not race on a write to the Logger variable.
+func redirectLogger(t *testing.T, w io.Writer) {
+	t.Helper()
+	std, ok := Logger.(*log.Logger)
+	if !ok {
+		orig := Logger
+		Logger = log.New(w, "", 0)
+		t.Cleanup(func() { Logger = orig })
+		return
+	}
+	prev := std.Writer()
+	std.SetOutput(w)
+	t.Cleanup(func() { std.SetOutput(prev) })
 }


### PR DESCRIPTION
Sorry this showed up as a `go test -race` failure after a close. `TestPartitionConsumerComputeBackoff` was replacing the package `Logger` while `TestConsumerExpiryTicker` still had a `safeAsyncClose` goroutine reading it through `DebugLogger`.

The stuck-warning subtest now uses `(*log.Logger).SetOutput`, which is documented as safe for concurrent use, so leftover close logs no longer race with the capture. `TestClientBackgroundMetadataUpdater` had the same assignment, so I pointed that at the same helper.

Fixes #3736.