### PR TITLE
feat: support KIP-848 ConsumerGroupDescribe API

### DIFF
--- a/api_versions.go
+++ b/api_versions.go
@@ -86,4 +86,5 @@ const (
 	apiKeyDescribeProducers            = 61
 	apiKeyDescribeTransactions         = 65
 	apiKeyListTransactions             = 66
+	apiKeyConsumerGroupDescribe        = 69
 )

--- a/broker.go
+++ b/broker.go
@@ -1021,6 +1021,15 @@ func (b *Broker) UpdateFeatures(req *UpdateFeaturesRequest) (*UpdateFeaturesResp
 	return res, nil
 }
 
+// ConsumerGroupDescribe describes KIP-848 consumer groups coordinated by this broker.
+func (b *Broker) ConsumerGroupDescribe(req *ConsumerGroupDescribeRequest) (*ConsumerGroupDescribeResponse, error) {
+	res := new(ConsumerGroupDescribeResponse)
+	if err := b.sendAndReceive(req, res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 // DescribeProducers sends a request to list the active producer state for
 // topic partitions led by this broker
 func (b *Broker) DescribeProducers(req *DescribeProducersRequest) (*DescribeProducersResponse, error) {

--- a/consumer_group_describe_broker_test.go
+++ b/consumer_group_describe_broker_test.go
@@ -1,0 +1,102 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrokerConsumerGroupDescribe(t *testing.T) {
+	for _, tc := range []struct {
+		name            string
+		kafka           KafkaVersion
+		brokerMax       int16
+		expectedVersion int16
+	}{
+		{"v0", V3_7_0_0, 0, 0},
+		{"v1", V4_0_0_0, 1, 1},
+		{"downgrade", V4_0_0_0, 0, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := NewMockBroker(t, 0)
+			defer mock.Close()
+			group := consumerGroupDescribeTestResponse(1).Groups[0]
+			mock.SetHandlerByMap(map[string]MockResponse{
+				"ApiVersionsRequest": NewMockApiVersionsResponse(t).SetApiKeys([]ApiVersionsResponseKey{
+					{ApiKey: apiKeyConsumerGroupDescribe, MinVersion: 0, MaxVersion: tc.brokerMax},
+				}),
+				"ConsumerGroupDescribeRequest": NewMockConsumerGroupDescribeResponse(t).
+					AddGroupDescription("g", group).
+					AddGroupDescription("moved", ConsumerGroupDescription{ErrorCode: ErrNotCoordinatorForConsumer}),
+			})
+			conf := NewTestConfig()
+			conf.Version = tc.kafka
+			conf.ApiVersionsRequest = true
+			broker := NewBroker(mock.Addr())
+			require.NoError(t, broker.Open(conf))
+			defer safeClose(t, broker)
+
+			req := NewConsumerGroupDescribeRequest(conf.Version)
+			req.GroupIDs = []string{"g", "missing", "moved"}
+			req.IncludeAuthorizedOperations = true
+			res, err := broker.ConsumerGroupDescribe(req)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedVersion, res.Version)
+			require.Len(t, res.Groups, 3)
+			want := consumerGroupDescribeTestResponse(tc.expectedVersion).Groups[0]
+			require.Equal(t, want, res.Groups[0])
+			require.Equal(t, "missing", res.Groups[1].GroupID)
+			require.Equal(t, ErrGroupIDNotFound, res.Groups[1].ErrorCode)
+			require.Equal(t, int32(-2147483648), res.Groups[1].AuthorizedOperations)
+			require.Equal(t, ErrNotCoordinatorForConsumer, res.Groups[2].ErrorCode)
+
+			history := mock.History()
+			sent := history[len(history)-1].Request.(*ConsumerGroupDescribeRequest)
+			require.Equal(t, req, sent)
+
+			req.IncludeAuthorizedOperations = false
+			res, err = broker.ConsumerGroupDescribe(req)
+			require.NoError(t, err)
+			require.Equal(t, int32(-2147483648), res.Groups[0].AuthorizedOperations)
+		})
+	}
+}
+
+func TestBrokerConsumerGroupDescribeFailure(t *testing.T) {
+	// A disconnected broker returns a transport error, not an empty response.
+	broker := NewBroker("localhost:9092")
+	res, err := broker.ConsumerGroupDescribe(&ConsumerGroupDescribeRequest{GroupIDs: []string{"g"}})
+	require.ErrorIs(t, err, ErrNotConnected)
+	require.Nil(t, res)
+}
+
+func ExampleBroker_ConsumerGroupDescribe() {
+	config := NewConfig()
+	config.Version = V4_0_0_0
+	client, err := NewClient([]string{"localhost:9092"}, config)
+	if err != nil {
+		panic(err)
+	}
+	defer func() { _ = client.Close() }()
+
+	coordinator, err := client.Coordinator("my-group")
+	if err != nil {
+		panic(err)
+	}
+	req := NewConsumerGroupDescribeRequest(config.Version)
+	req.GroupIDs = []string{"my-group"}
+	res, err := coordinator.ConsumerGroupDescribe(req)
+	if err != nil {
+		panic(err)
+	}
+	for _, group := range res.Groups {
+		if group.ErrorCode != ErrNoError {
+			fmt.Printf("group %s: %v\n", group.GroupID, group.ErrorCode)
+			continue
+		}
+		fmt.Printf("group %s: %d members\n", group.GroupID, len(group.Members))
+	}
+}

--- a/consumer_group_describe_request.go
+++ b/consumer_group_describe_request.go
@@ -1,0 +1,71 @@
+package sarama
+
+// ConsumerGroupDescribeRequest describes consumer groups using the KIP-848 protocol.
+type ConsumerGroupDescribeRequest struct {
+	Version                     int16
+	GroupIDs                    []string
+	IncludeAuthorizedOperations bool
+}
+
+func NewConsumerGroupDescribeRequest(version KafkaVersion) *ConsumerGroupDescribeRequest {
+	req := &ConsumerGroupDescribeRequest{}
+
+	switch {
+	case version.IsAtLeast(V4_0_0_0):
+		req.Version = 1
+	default:
+		req.Version = 0
+	}
+
+	return req
+}
+
+func (r *ConsumerGroupDescribeRequest) encode(pe packetEncoder) error {
+	if !r.isValidVersion() {
+		return PacketEncodingError{"invalid or unsupported ConsumerGroupDescribeRequest version"}
+	}
+	if err := pe.putStringArray(r.GroupIDs); err != nil {
+		return err
+	}
+	pe.putBool(r.IncludeAuthorizedOperations)
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *ConsumerGroupDescribeRequest) decode(pd packetDecoder, version int16) (err error) {
+	r.Version = version
+	if !r.isValidVersion() {
+		return PacketDecodingError{"invalid or unsupported ConsumerGroupDescribeRequest version"}
+	}
+	if r.GroupIDs, err = pd.getStringArray(); err != nil {
+		return err
+	}
+	if r.IncludeAuthorizedOperations, err = pd.getBool(); err != nil {
+		return err
+	}
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *ConsumerGroupDescribeRequest) key() int16 { return apiKeyConsumerGroupDescribe }
+
+func (r *ConsumerGroupDescribeRequest) version() int16 { return r.Version }
+
+func (r *ConsumerGroupDescribeRequest) setVersion(v int16) { r.Version = v }
+
+func (r *ConsumerGroupDescribeRequest) headerVersion() int16 { return 2 }
+
+func (r *ConsumerGroupDescribeRequest) isValidVersion() bool { return r.Version >= 0 && r.Version <= 1 }
+
+func (r *ConsumerGroupDescribeRequest) isFlexible() bool { return true }
+
+func (r *ConsumerGroupDescribeRequest) isFlexibleVersion(version int16) bool { return version >= 0 }
+
+func (r *ConsumerGroupDescribeRequest) requiredVersion() KafkaVersion {
+	switch r.Version {
+	case 1:
+		return V4_0_0_0
+	default:
+		return V3_7_0_0
+	}
+}

--- a/consumer_group_describe_request_test.go
+++ b/consumer_group_describe_request_test.go
@@ -1,0 +1,78 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var consumerGroupDescribeRequestV0 = []byte{
+	3, // two group IDs
+	2, 'g',
+	2, 'h',
+	1, // include authorized operations
+	0, // tagged fields
+}
+
+func TestConsumerGroupDescribeRequest(t *testing.T) {
+	for _, version := range []int16{0, 1} {
+		t.Run(fmt.Sprint(version), func(t *testing.T) {
+			req := &ConsumerGroupDescribeRequest{
+				Version:                     version,
+				GroupIDs:                    []string{"g", "h"},
+				IncludeAuthorizedOperations: true,
+			}
+			testRequest(t, "groups", req, consumerGroupDescribeRequestV0)
+			testRequest(t, "empty", &ConsumerGroupDescribeRequest{
+				Version: version,
+			}, []byte{1, 0, 0})
+
+			withTags := append([]byte{}, consumerGroupDescribeRequestV0[:len(consumerGroupDescribeRequestV0)-1]...)
+			withTags = append(withTags, 1, 42, 2, 0xab, 0xcd)
+			var decoded ConsumerGroupDescribeRequest
+			require.NoError(t, versionedDecode(withTags, &decoded, version, nil))
+			require.Equal(t, req, &decoded)
+
+			for n := range len(consumerGroupDescribeRequestV0) {
+				require.Error(t, versionedDecode(consumerGroupDescribeRequestV0[:n], &ConsumerGroupDescribeRequest{}, version, nil), "truncated at %d", n)
+			}
+			require.Error(t, versionedDecode([]byte{255, 255, 255, 255, 15}, &ConsumerGroupDescribeRequest{}, version, nil), "oversized group IDs array")
+		})
+	}
+}
+
+func TestNewConsumerGroupDescribeRequest(t *testing.T) {
+	for _, tc := range []struct {
+		kafka    KafkaVersion
+		version  int16
+		required KafkaVersion
+	}{
+		{V3_7_0_0, 0, V3_7_0_0},
+		{V3_8_0_0, 0, V3_7_0_0},
+		{V3_9_0_0, 0, V3_7_0_0},
+		{V4_0_0_0, 1, V4_0_0_0},
+		{MaxVersion, 1, V4_0_0_0},
+	} {
+		req := NewConsumerGroupDescribeRequest(tc.kafka)
+		require.Equal(t, tc.version, req.Version)
+		require.Equal(t, tc.required, req.requiredVersion())
+		require.Equal(t, int16(69), req.key())
+		require.Equal(t, int16(2), req.headerVersion())
+	}
+}
+
+func TestConsumerGroupDescribeInvalidVersion(t *testing.T) {
+	for _, version := range []int16{-1, 2} {
+		req := &ConsumerGroupDescribeRequest{Version: version}
+		_, err := encode(req, nil)
+		require.Error(t, err)
+		require.Error(t, versionedDecode(consumerGroupDescribeRequestV0, req, version, nil))
+		res := &ConsumerGroupDescribeResponse{Version: version}
+		_, err = encode(res, nil)
+		require.Error(t, err)
+		require.Error(t, versionedDecode(consumerGroupDescribeResponseV0, res, version, nil))
+	}
+}

--- a/consumer_group_describe_response.go
+++ b/consumer_group_describe_response.go
@@ -1,0 +1,326 @@
+package sarama
+
+import "time"
+
+// ConsumerGroupDescribeResponse contains descriptions of KIP-848 consumer groups.
+type ConsumerGroupDescribeResponse struct {
+	Version      int16
+	ThrottleTime time.Duration
+	Groups       []ConsumerGroupDescription
+}
+
+// ConsumerGroupDescription contains the state and membership of a consumer group.
+type ConsumerGroupDescription struct {
+	ErrorCode            KError
+	ErrorMessage         *string
+	GroupID              string
+	GroupState           string
+	GroupEpoch           int32
+	AssignmentEpoch      int32
+	AssignorName         string
+	Members              []ConsumerGroupMemberDescription
+	AuthorizedOperations int32
+}
+
+// ConsumerGroupMemberDescription describes a member of a KIP-848 consumer group.
+type ConsumerGroupMemberDescription struct {
+	MemberID             string
+	InstanceID           *string
+	RackID               *string
+	MemberEpoch          int32
+	ClientID             string
+	ClientHost           string
+	SubscribedTopicNames []string
+	SubscribedTopicRegex *string
+	Assignment           ConsumerGroupAssignment
+	TargetAssignment     ConsumerGroupAssignment
+	MemberType           int8
+}
+
+// ConsumerGroupAssignment contains a member's current or target assignment.
+type ConsumerGroupAssignment struct {
+	TopicPartitions []ConsumerGroupTopicPartitions
+}
+
+// ConsumerGroupTopicPartitions contains the assigned partitions of a topic.
+type ConsumerGroupTopicPartitions struct {
+	TopicID    Uuid
+	TopicName  string
+	Partitions []int32
+}
+
+func (t *ConsumerGroupTopicPartitions) encode(pe packetEncoder) error {
+	if err := pe.putUuid(t.TopicID); err != nil {
+		return err
+	}
+	if err := pe.putString(t.TopicName); err != nil {
+		return err
+	}
+	if err := pe.putInt32Array(t.Partitions); err != nil {
+		return err
+	}
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (t *ConsumerGroupTopicPartitions) decode(pd packetDecoder, version int16) (err error) {
+	if t.TopicID, err = pd.getUuid(); err != nil {
+		return err
+	}
+	if t.TopicName, err = pd.getString(); err != nil {
+		return err
+	}
+	if t.Partitions, err = pd.getInt32Array(); err != nil {
+		return err
+	}
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (a *ConsumerGroupAssignment) encode(pe packetEncoder) error {
+	if err := pe.putArrayLength(len(a.TopicPartitions)); err != nil {
+		return err
+	}
+	for i := range a.TopicPartitions {
+		if err := a.TopicPartitions[i].encode(pe); err != nil {
+			return err
+		}
+	}
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (a *ConsumerGroupAssignment) decode(pd packetDecoder, version int16) (err error) {
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+	a.TopicPartitions = make([]ConsumerGroupTopicPartitions, n)
+	for i := range a.TopicPartitions {
+		if err := a.TopicPartitions[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (m *ConsumerGroupMemberDescription) encode(pe packetEncoder, version int16) error {
+	if err := pe.putString(m.MemberID); err != nil {
+		return err
+	}
+	if err := pe.putNullableString(m.InstanceID); err != nil {
+		return err
+	}
+	if err := pe.putNullableString(m.RackID); err != nil {
+		return err
+	}
+	pe.putInt32(m.MemberEpoch)
+	if err := pe.putString(m.ClientID); err != nil {
+		return err
+	}
+	if err := pe.putString(m.ClientHost); err != nil {
+		return err
+	}
+	if err := pe.putStringArray(m.SubscribedTopicNames); err != nil {
+		return err
+	}
+	if err := pe.putNullableString(m.SubscribedTopicRegex); err != nil {
+		return err
+	}
+	if err := m.Assignment.encode(pe); err != nil {
+		return err
+	}
+	if err := m.TargetAssignment.encode(pe); err != nil {
+		return err
+	}
+	if version >= 1 {
+		pe.putInt8(m.MemberType)
+	}
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (m *ConsumerGroupMemberDescription) decode(pd packetDecoder, version int16) (err error) {
+	if m.MemberID, err = pd.getString(); err != nil {
+		return err
+	}
+	if m.InstanceID, err = pd.getNullableString(); err != nil {
+		return err
+	}
+	if m.RackID, err = pd.getNullableString(); err != nil {
+		return err
+	}
+	if m.MemberEpoch, err = pd.getInt32(); err != nil {
+		return err
+	}
+	if m.ClientID, err = pd.getString(); err != nil {
+		return err
+	}
+	if m.ClientHost, err = pd.getString(); err != nil {
+		return err
+	}
+	if m.SubscribedTopicNames, err = pd.getStringArray(); err != nil {
+		return err
+	}
+	if m.SubscribedTopicRegex, err = pd.getNullableString(); err != nil {
+		return err
+	}
+	if err := m.Assignment.decode(pd, version); err != nil {
+		return err
+	}
+	if err := m.TargetAssignment.decode(pd, version); err != nil {
+		return err
+	}
+	m.MemberType = -1
+	if version >= 1 {
+		if m.MemberType, err = pd.getInt8(); err != nil {
+			return err
+		}
+	}
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (g *ConsumerGroupDescription) encode(pe packetEncoder, version int16) error {
+	pe.putKError(g.ErrorCode)
+	if err := pe.putNullableString(g.ErrorMessage); err != nil {
+		return err
+	}
+	if err := pe.putString(g.GroupID); err != nil {
+		return err
+	}
+	if err := pe.putString(g.GroupState); err != nil {
+		return err
+	}
+	pe.putInt32(g.GroupEpoch)
+	pe.putInt32(g.AssignmentEpoch)
+	if err := pe.putString(g.AssignorName); err != nil {
+		return err
+	}
+	if err := pe.putArrayLength(len(g.Members)); err != nil {
+		return err
+	}
+	for i := range g.Members {
+		if err := g.Members[i].encode(pe, version); err != nil {
+			return err
+		}
+	}
+	pe.putInt32(g.AuthorizedOperations)
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (g *ConsumerGroupDescription) decode(pd packetDecoder, version int16) (err error) {
+	if g.ErrorCode, err = pd.getKError(); err != nil {
+		return err
+	}
+	if g.ErrorMessage, err = pd.getNullableString(); err != nil {
+		return err
+	}
+	if g.GroupID, err = pd.getString(); err != nil {
+		return err
+	}
+	if g.GroupState, err = pd.getString(); err != nil {
+		return err
+	}
+	if g.GroupEpoch, err = pd.getInt32(); err != nil {
+		return err
+	}
+	if g.AssignmentEpoch, err = pd.getInt32(); err != nil {
+		return err
+	}
+	if g.AssignorName, err = pd.getString(); err != nil {
+		return err
+	}
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+	g.Members = make([]ConsumerGroupMemberDescription, n)
+	for i := range g.Members {
+		if err := g.Members[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+	if g.AuthorizedOperations, err = pd.getInt32(); err != nil {
+		return err
+	}
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *ConsumerGroupDescribeResponse) encode(pe packetEncoder) error {
+	if !r.isValidVersion() {
+		return PacketEncodingError{"invalid or unsupported ConsumerGroupDescribeResponse version"}
+	}
+	pe.putDurationMs(r.ThrottleTime)
+	if err := pe.putArrayLength(len(r.Groups)); err != nil {
+		return err
+	}
+	for i := range r.Groups {
+		if err := r.Groups[i].encode(pe, r.Version); err != nil {
+			return err
+		}
+	}
+	pe.putEmptyTaggedFieldArray()
+	return nil
+}
+
+func (r *ConsumerGroupDescribeResponse) decode(pd packetDecoder, version int16) (err error) {
+	r.Version = version
+	if !r.isValidVersion() {
+		return PacketDecodingError{"invalid or unsupported ConsumerGroupDescribeResponse version"}
+	}
+	if r.ThrottleTime, err = pd.getDurationMs(); err != nil {
+		return err
+	}
+	n, err := pd.getArrayLength()
+	if err != nil {
+		return err
+	}
+	if n < 0 {
+		return errInvalidArrayLength
+	}
+	r.Groups = make([]ConsumerGroupDescription, n)
+	for i := range r.Groups {
+		if err := r.Groups[i].decode(pd, version); err != nil {
+			return err
+		}
+	}
+	_, err = pd.getEmptyTaggedFieldArray()
+	return err
+}
+
+func (r *ConsumerGroupDescribeResponse) key() int16 { return apiKeyConsumerGroupDescribe }
+
+func (r *ConsumerGroupDescribeResponse) version() int16 { return r.Version }
+
+func (r *ConsumerGroupDescribeResponse) setVersion(v int16) { r.Version = v }
+
+func (r *ConsumerGroupDescribeResponse) headerVersion() int16 { return 1 }
+
+func (r *ConsumerGroupDescribeResponse) isValidVersion() bool {
+	return r.Version >= 0 && r.Version <= 1
+}
+
+func (r *ConsumerGroupDescribeResponse) isFlexible() bool { return true }
+
+func (r *ConsumerGroupDescribeResponse) isFlexibleVersion(version int16) bool { return version >= 0 }
+
+func (r *ConsumerGroupDescribeResponse) requiredVersion() KafkaVersion {
+	switch r.Version {
+	case 1:
+		return V4_0_0_0
+	default:
+		return V3_7_0_0
+	}
+}
+
+func (r *ConsumerGroupDescribeResponse) throttleTime() time.Duration { return r.ThrottleTime }

--- a/consumer_group_describe_response_test.go
+++ b/consumer_group_describe_response_test.go
@@ -1,0 +1,152 @@
+//go:build !functional
+
+package sarama
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These wire fixtures follow Apache Kafka's ConsumerGroupDescribe schema.
+// Tagged fields occur at every struct boundary, including both assignments.
+func consumerGroupDescribeResponseFixture(version int16, tags []byte) []byte {
+	b := []byte{
+		0, 0, 0, 100, // throttle time
+		2,    // one group
+		0, 0, // no error
+		0, // null error message
+		2, 'g',
+		7, 'S', 't', 'a', 'b', 'l', 'e',
+		0, 0, 0, 7, // group epoch
+		0, 0, 0, 6, // assignment epoch
+		8, 'u', 'n', 'i', 'f', 'o', 'r', 'm',
+		2, // one member
+		2, 'm',
+		2, 'i', // instance ID
+		1,          // empty (non-null) rack ID
+		0, 0, 0, 5, // member epoch
+		2, 'c',
+		2, 'h',
+		2, 2, 't', // subscribed topic names
+		0,                                                     // null subscribed regex
+		2,                                                     // current assignment: one topic
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, // UUID
+		2, 't',
+		3, 0, 0, 0, 0, 0, 0, 0, 2, // partitions 0, 2
+	}
+	b = append(b, tags...) // current topic
+	b = append(b, tags...) // current assignment
+	b = append(b,
+		2, // target assignment: one topic
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+		2, 't',
+		2, 0, 0, 0, 2, // partition 2
+	)
+	b = append(b, tags...) // target topic
+	b = append(b, tags...) // target assignment
+	if version >= 1 {
+		b = append(b, 1) // consumer member
+	}
+	b = append(b, tags...)     // member
+	b = append(b, 0, 0, 0, 42) // authorized operations
+	b = append(b, tags...)     // group
+	return append(b, tags...)  // response
+}
+
+var (
+	consumerGroupDescribeResponseV0 = consumerGroupDescribeResponseFixture(0, []byte{0})
+	consumerGroupDescribeResponseV1 = consumerGroupDescribeResponseFixture(1, []byte{0})
+)
+
+func consumerGroupDescribeTestResponse(version int16) *ConsumerGroupDescribeResponse {
+	memberType := int8(-1)
+	if version >= 1 {
+		memberType = 1
+	}
+	topicID := Uuid{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	return &ConsumerGroupDescribeResponse{
+		Version:      version,
+		ThrottleTime: 100 * time.Millisecond,
+		Groups: []ConsumerGroupDescription{{
+			GroupID: "g", GroupState: "Stable", GroupEpoch: 7,
+			AssignmentEpoch: 6, AssignorName: "uniform", AuthorizedOperations: 42,
+			Members: []ConsumerGroupMemberDescription{{
+				MemberID: "m", InstanceID: nullString("i"), RackID: nullString(""),
+				MemberEpoch: 5, ClientID: "c", ClientHost: "h",
+				SubscribedTopicNames: []string{"t"}, MemberType: memberType,
+				Assignment: ConsumerGroupAssignment{TopicPartitions: []ConsumerGroupTopicPartitions{{
+					TopicID: topicID, TopicName: "t", Partitions: []int32{0, 2},
+				}}},
+				TargetAssignment: ConsumerGroupAssignment{TopicPartitions: []ConsumerGroupTopicPartitions{{
+					TopicID: topicID, TopicName: "t", Partitions: []int32{2},
+				}}},
+			}},
+		}},
+	}
+}
+
+func TestConsumerGroupDescribeResponse(t *testing.T) {
+	for _, version := range []int16{0, 1} {
+		t.Run(fmt.Sprint(version), func(t *testing.T) {
+			expected := consumerGroupDescribeTestResponse(version)
+			fixture := consumerGroupDescribeResponseFixture(version, []byte{0})
+			testResponse(t, "member and assignments", expected, fixture)
+			require.Equal(t, 100*time.Millisecond, expected.throttleTime())
+			require.Equal(t, int16(1), expected.headerVersion())
+			require.Equal(t, NewConsumerGroupDescribeRequest(expected.requiredVersion()).Version, version)
+
+			var decoded ConsumerGroupDescribeResponse
+			// Unknown tag 42 with a two-byte payload at every struct boundary.
+			require.NoError(t, versionedDecode(consumerGroupDescribeResponseFixture(version, []byte{1, 42, 2, 0xab, 0xcd}), &decoded, version, nil))
+			require.Equal(t, expected, &decoded)
+
+			for n := range len(fixture) {
+				require.Error(t, versionedDecode(fixture[:n], &ConsumerGroupDescribeResponse{}, version, nil), "truncated at %d", n)
+			}
+			testResponse(t, "empty groups", &ConsumerGroupDescribeResponse{
+				Version: version, Groups: []ConsumerGroupDescription{},
+			}, []byte{0, 0, 0, 0, 1, 0})
+			require.Error(t, versionedDecode([]byte{0, 0, 0, 0, 255, 255, 255, 255, 15}, &ConsumerGroupDescribeResponse{}, version, nil), "oversized groups array")
+		})
+	}
+}
+
+func TestConsumerGroupDescribeResponseError(t *testing.T) {
+	for _, version := range []int16{0, 1} {
+		// A group error is part of a successfully decoded response.
+		testResponse(t, "group not found", &ConsumerGroupDescribeResponse{
+			Version: version,
+			Groups: []ConsumerGroupDescription{{
+				ErrorCode: ErrGroupIDNotFound, ErrorMessage: nullString("missing"),
+				GroupID: "g", Members: []ConsumerGroupMemberDescription{},
+				AuthorizedOperations: -2147483648,
+			}},
+		}, []byte{
+			0, 0, 0, 0, 2, // throttle, one group
+			0, 69, // GROUP_ID_NOT_FOUND
+			8, 'm', 'i', 's', 's', 'i', 'n', 'g',
+			2, 'g', 1, // group ID, empty state
+			0, 0, 0, 0, 0, 0, 0, 0, // epochs
+			1, 1, // empty assignor, empty members
+			128, 0, 0, 0, // authorized operations not requested
+			0, 0,
+		})
+	}
+}
+
+func TestConsumerGroupDescribeResponseEmptyAssignment(t *testing.T) {
+	for _, version := range []int16{0, 1} {
+		res := consumerGroupDescribeTestResponse(version)
+		member := &res.Groups[0].Members[0]
+		member.InstanceID = nil
+		member.RackID = nil
+		member.SubscribedTopicNames = nil
+		member.SubscribedTopicRegex = nullString("t.*")
+		member.Assignment.TopicPartitions = []ConsumerGroupTopicPartitions{}
+		member.TargetAssignment.TopicPartitions[0].Partitions = []int32{}
+		testResponse(t, "empty assignment and regex subscription", res, nil)
+	}
+}

--- a/encoder_decoder_fuzz_test.go
+++ b/encoder_decoder_fuzz_test.go
@@ -68,6 +68,7 @@ func FuzzVersionedDecodeRequest(f *testing.F) {
 		{key: apiKeyDescribeTransactions, version: 0, body: describeTransactionsRequestV0},
 		{key: apiKeyListTransactions, version: 0, body: listTransactionsRequestV0},
 		{key: apiKeyListTransactions, version: 1, body: listTransactionsRequestV1},
+		{key: apiKeyConsumerGroupDescribe, version: 0, body: consumerGroupDescribeRequestV0},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}
@@ -126,6 +127,8 @@ func FuzzVersionedDecodeResponse(f *testing.F) {
 		{key: apiKeyDescribeProducers, version: 0, body: describeProducersResponseV0},
 		{key: apiKeyDescribeTransactions, version: 0, body: describeTransactionsResponseV0},
 		{key: apiKeyListTransactions, version: 0, body: listTransactionsResponseV0},
+		{key: apiKeyConsumerGroupDescribe, version: 0, body: consumerGroupDescribeResponseV0},
+		{key: apiKeyConsumerGroupDescribe, version: 1, body: consumerGroupDescribeResponseV1},
 	} {
 		f.Add(seed.key, seed.version, seed.body)
 	}

--- a/mockresponses.go
+++ b/mockresponses.go
@@ -132,6 +132,45 @@ func (m *MockDescribeGroupsResponse) For(reqBody versionedDecoder) encoderWithHe
 	return response
 }
 
+// MockConsumerGroupDescribeResponse builds responses for KIP-848 group queries.
+type MockConsumerGroupDescribeResponse struct {
+	groups map[string]ConsumerGroupDescription
+	t      TestReporter
+}
+
+func NewMockConsumerGroupDescribeResponse(t TestReporter) *MockConsumerGroupDescribeResponse {
+	return &MockConsumerGroupDescribeResponse{
+		t:      t,
+		groups: make(map[string]ConsumerGroupDescription),
+	}
+}
+
+func (m *MockConsumerGroupDescribeResponse) AddGroupDescription(groupID string, description ConsumerGroupDescription) *MockConsumerGroupDescribeResponse {
+	description.GroupID = groupID
+	m.groups[groupID] = description
+	return m
+}
+
+func (m *MockConsumerGroupDescribeResponse) For(reqBody versionedDecoder) encoderWithHeader {
+	req := reqBody.(*ConsumerGroupDescribeRequest)
+	res := &ConsumerGroupDescribeResponse{Version: req.Version}
+	for _, groupID := range req.GroupIDs {
+		group, ok := m.groups[groupID]
+		if !ok {
+			group = ConsumerGroupDescription{
+				GroupID:              groupID,
+				ErrorCode:            ErrGroupIDNotFound,
+				AuthorizedOperations: -2147483648,
+			}
+		}
+		if !req.IncludeAuthorizedOperations {
+			group.AuthorizedOperations = -2147483648
+		}
+		res.Groups = append(res.Groups, group)
+	}
+	return res
+}
+
 // MockMetadataResponse is a `MetadataResponse` builder.
 type MockMetadataResponse struct {
 	controllerID int32

--- a/request.go
+++ b/request.go
@@ -240,6 +240,8 @@ func allocateBody(key, version int16) protocolBody {
 		return &ListTransactionsRequest{Version: version}
 		// 67: AllocateProducerIdsRequest
 		// 68: ConsumerGroupHeartbeatRequest
+	case apiKeyConsumerGroupDescribe:
+		return &ConsumerGroupDescribeRequest{Version: version}
 	}
 	return nil
 }
@@ -345,6 +347,8 @@ func allocateResponseBody(key, version int16) protocolBody {
 		return &DescribeTransactionsResponse{Version: version}
 	case apiKeyListTransactions:
 		return &ListTransactionsResponse{Version: version}
+	case apiKeyConsumerGroupDescribe:
+		return &ConsumerGroupDescribeResponse{Version: version}
 	}
 	return nil
 }

--- a/request_test.go
+++ b/request_test.go
@@ -83,6 +83,7 @@ var names = map[int16]string{
 	apiKeyListTransactions:             "ListTransactionsRequest",
 	67:                                 "AllocateProducerIdsRequest",
 	68:                                 "ConsumerGroupHeartbeatRequest",
+	apiKeyConsumerGroupDescribe:        "ConsumerGroupDescribeRequest",
 }
 
 // TestAllocateBodyProtocolVersions tests two related version expectations:
@@ -401,8 +402,9 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V3_7_0_0,
 			map[int16]int16{
-				apiKeyDescribeCluster: 1,  // up from 0
-				apiKeyProduce:         10, // up from 9
+				apiKeyDescribeCluster:       1,  // up from 0
+				apiKeyProduce:               10, // up from 9
+				apiKeyConsumerGroupDescribe: 0,  // new in 3.7
 				// TODO: FetchRequest v16 is not supported, but expected for KafkaVersion 3.7.0
 				// apiKeyFetch:           16, // up from 15
 				// TODO: OffsetFetchRequest v9 is not supported, but expected for KafkaVersion 3.7.0
@@ -445,7 +447,8 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 		{
 			V4_0_0_0,
 			map[int16]int16{
-				apiKeyDescribeCluster: 2, // up from 1
+				apiKeyDescribeCluster:       2, // up from 1
+				apiKeyConsumerGroupDescribe: 1, // up from 0
 				// TODO: ProduceRequest v12 is not supported, but expected for KafkaVersion 4.0.0
 				// apiKeyProduce:             12, // up from 11
 				// TODO: ListOffsetsRequest v10 is not supported, but expected for KafkaVersion 4.0.0
@@ -537,6 +540,7 @@ func TestAllocateBodyProtocolVersions(t *testing.T) {
 				apiKeyDescribeProducers:            maxVersion(&DescribeProducersRequest{}),
 				apiKeyDescribeTransactions:         maxVersion(&DescribeTransactionsRequest{}),
 				apiKeyListTransactions:             maxVersion(&ListTransactionsRequest{}),
+				apiKeyConsumerGroupDescribe:        maxVersion(&ConsumerGroupDescribeRequest{}),
 			},
 		},
 	}


### PR DESCRIPTION
Adds support for Kafka's KIP-848 `ConsumerGroupDescribe` API (API key 69).

- Adds v0/v1 request and response codecs
- Adds `Broker.ConsumerGroupDescribe`, version negotiation, mocks, and tests
- Supports Kafka 3.7+ with v1 member types on Kafka 4.0+

Related: [#3747](https://github.com/IBM/sarama/issues/3747)  
References: [KIP-848](https://cwiki.apache.org/confluence/spaces/KAFKA/pages/217387038/KIP-848%2BThe%2BNext%2BGeneration%2Bof%2Bthe%2BConsumer%2BRebalance%2BProtocol), [Kafka protocol specification](https://kafka.apache.org/43/design/protocol/#The_Messages_ConsumerGroupDescribe)

Tested with `go test ./...` and `go vet ./...`.